### PR TITLE
Alternate method for injecting StaticLoggerBinder. This is a major issue and needs a resolution.

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/IStaticLoggerBinder.java
+++ b/slf4j-api/src/main/java/org/slf4j/IStaticLoggerBinder.java
@@ -1,0 +1,23 @@
+package org.slf4j;
+
+/**
+ * Alternate method of specifying a logger binding. Set
+ * the system property "org.slf4j.binder.class" to the FQCN of your
+ * logger binding class
+ */
+public interface IStaticLoggerBinder {
+  /**
+   * Return the logger factory singleton
+   *
+   * @return factory
+   */
+  public ILoggerFactory getLoggerFactory();
+
+  /**
+   * Declare the version of the SLF4J API this implementation is compiled against.
+   * The value of this field is usually modified with each release.
+   *
+   * @return version
+   */
+  public String getRequestedApiVersion();
+}

--- a/slf4j-api/src/test/java/org/slf4j/MyBinding.java
+++ b/slf4j-api/src/test/java/org/slf4j/MyBinding.java
@@ -1,0 +1,213 @@
+package org.slf4j;
+
+public class MyBinding implements IStaticLoggerBinder {
+  static class MyLogger implements Logger {
+    public String getName() {
+      return null;
+    }
+
+    public boolean isTraceEnabled() {
+      return false;
+    }
+
+    public void trace(String msg) {
+    }
+
+    public void trace(String format, Object arg) {
+    }
+
+    public void trace(String format, Object arg1, Object arg2) {
+    }
+
+    public void trace(String format, Object[] argArray) {
+    }
+
+    public void trace(String msg, Throwable t) {
+    }
+
+    public boolean isTraceEnabled(Marker marker) {
+      return false;
+    }
+
+    public void trace(Marker marker, String msg) {
+    }
+
+    public void trace(Marker marker, String format, Object arg) {
+    }
+
+    public void trace(Marker marker, String format, Object arg1, Object arg2) {
+    }
+
+    public void trace(Marker marker, String format, Object[] argArray) {
+    }
+
+    public void trace(Marker marker, String msg, Throwable t) {
+    }
+
+    public boolean isDebugEnabled() {
+      return false;
+    }
+
+    public void debug(String msg) {
+    }
+
+    public void debug(String format, Object arg) {
+    }
+
+    public void debug(String format, Object arg1, Object arg2) {
+    }
+
+    public void debug(String format, Object[] argArray) {
+    }
+
+    public void debug(String msg, Throwable t) {
+    }
+
+    public boolean isDebugEnabled(Marker marker) {
+      return false;
+    }
+
+    public void debug(Marker marker, String msg) {
+    }
+
+    public void debug(Marker marker, String format, Object arg) {
+    }
+
+    public void debug(Marker marker, String format, Object arg1, Object arg2) {
+    }
+
+    public void debug(Marker marker, String format, Object[] argArray) {
+    }
+
+    public void debug(Marker marker, String msg, Throwable t) {
+    }
+
+    public boolean isInfoEnabled() {
+      return false;
+    }
+
+    public void info(String msg) {
+    }
+
+    public void info(String format, Object arg) {
+    }
+
+    public void info(String format, Object arg1, Object arg2) {
+    }
+
+    public void info(String format, Object[] argArray) {
+    }
+
+    public void info(String msg, Throwable t) {
+    }
+
+    public boolean isInfoEnabled(Marker marker) {
+      return false;
+    }
+
+    public void info(Marker marker, String msg) {
+    }
+
+    public void info(Marker marker, String format, Object arg) {
+    }
+
+    public void info(Marker marker, String format, Object arg1, Object arg2) {
+    }
+
+    public void info(Marker marker, String format, Object[] argArray) {
+    }
+
+    public void info(Marker marker, String msg, Throwable t) {
+    }
+
+    public boolean isWarnEnabled() {
+      return false;
+    }
+
+    public void warn(String msg) {
+    }
+
+    public void warn(String format, Object arg) {
+    }
+
+    public void warn(String format, Object[] argArray) {
+    }
+
+    public void warn(String format, Object arg1, Object arg2) {
+    }
+
+    public void warn(String msg, Throwable t) {
+    }
+
+    public boolean isWarnEnabled(Marker marker) {
+      return false;
+    }
+
+    public void warn(Marker marker, String msg) {
+    }
+
+    public void warn(Marker marker, String format, Object arg) {
+    }
+
+    public void warn(Marker marker, String format, Object arg1, Object arg2) {
+    }
+
+    public void warn(Marker marker, String format, Object[] argArray) {
+    }
+
+    public void warn(Marker marker, String msg, Throwable t) {
+    }
+
+    public boolean isErrorEnabled() {
+      return false;
+    }
+
+    public void error(String msg) {
+    }
+
+    public void error(String format, Object arg) {
+    }
+
+    public void error(String format, Object arg1, Object arg2) {
+    }
+
+    public void error(String format, Object[] argArray) {
+    }
+
+    public void error(String msg, Throwable t) {
+    }
+
+    public boolean isErrorEnabled(Marker marker) {
+      return false;
+    }
+
+    public void error(Marker marker, String msg) {
+    }
+
+    public void error(Marker marker, String format, Object arg) {
+    }
+
+    public void error(Marker marker, String format, Object arg1, Object arg2) {
+    }
+
+    public void error(Marker marker, String format, Object[] argArray) {
+    }
+
+    public void error(Marker marker, String msg, Throwable t) {
+    }
+  }
+  
+  private static class MyLoggerFactory implements ILoggerFactory {
+    public Logger getLogger(String name) {
+      return new MyLogger();
+    }
+  }
+
+  public ILoggerFactory getLoggerFactory() {
+    return new MyLoggerFactory();
+  }
+
+  public String getRequestedApiVersion() {
+    return "6.0";
+  }
+}

--- a/slf4j-api/src/test/java/org/slf4j/PropertyBindingTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/PropertyBindingTest.java
@@ -1,0 +1,16 @@
+package org.slf4j;
+
+import junit.framework.TestCase;
+
+public class PropertyBindingTest extends TestCase {
+  public void testPropertyBinding() {
+    LoggerFactory.reset();
+    System.setProperty(LoggerFactory.STATIC_LOGGER_BINDER_CLASS_PROPERTY, "org.slf4j.MyBinding");
+    try {
+      Logger log = LoggerFactory.getLogger("test");
+      assertEquals(log.getClass(), MyBinding.MyLogger.class);
+    } finally {
+      System.clearProperty(LoggerFactory.STATIC_LOGGER_BINDER_CLASS_PROPERTY);
+    }
+  }
+}


### PR DESCRIPTION
The current method for injecting the StaticLoggerBinder is error prone, brittle and difficult to maintain. This change provides an alternate, backward compatible method of injecting the binder. By setting a system property you can specify the binder.
