### PR TITLE
fix for bug 264

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
@@ -180,6 +180,27 @@ final public class MessageFormatter {
       final Object[] argArray) {
 
     Throwable throwableCandidate = getThrowableCandidate(argArray);
+    return arrayFormat(messagePattern, argArray, throwableCandidate);
+  }
+
+  /**
+   * Same principle as the {@link #format(String, Object)} and
+   * {@link #format(String, Object, Object)} methods except that any number of
+   * arguments can be passed in an array.
+   *
+   * @param messagePattern
+   *          The message pattern which will be parsed and formatted
+   * @param argArray
+   *          An array of arguments to be substituted in place of formatting
+   *          anchors
+   * @param t
+   *          {@link Throwable} or {@code null} if not present
+   * @return The formatted message
+   */
+  final public static FormattingTuple arrayFormat(final String messagePattern,
+      final Object[] argArray, final Throwable t) {
+
+    Throwable throwableCandidate = t;
 
     if (messagePattern == null) {
       return new FormattingTuple(null, argArray, throwableCandidate);

--- a/slf4j-jdk14/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java
+++ b/slf4j-jdk14/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java
@@ -648,7 +648,8 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements
     // do not perform this check. See also
     // http://bugzilla.slf4j.org/show_bug.cgi?id=90
     if (logger.isLoggable(julLevel)) {
-      log(callerFQCN, julLevel, message, t);
+      final FormattingTuple ft = MessageFormatter.arrayFormat(message, argArray, t);
+      log(callerFQCN, julLevel, ft.getMessage(), ft.getThrowable());
     }
   }
 }

--- a/slf4j-log4j12/src/main/java/org/slf4j/impl/Log4jLoggerAdapter.java
+++ b/slf4j-log4j12/src/main/java/org/slf4j/impl/Log4jLoggerAdapter.java
@@ -599,7 +599,8 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements
       throw new IllegalStateException("Level number " + level
           + " is not recognized.");
     }
-    logger.log(callerFQCN, log4jLevel, msg, t);
+    final FormattingTuple ft = MessageFormatter.arrayFormat(msg, argArray, t);
+    logger.log(callerFQCN, log4jLevel, ft.getMessage(), ft.getThrowable());
   }
 
 }


### PR DESCRIPTION
Parameters are not used to compose message

Method LocationAwareLogger.log does not use parameters passed to compose message.
As result in logs there are lines containing '{}' instead of passed values.

http://bugzilla.slf4j.org/show_bug.cgi?id=264
