### PR TITLE
toString now prints BasicMarkers recursively

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/BasicMarker.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/BasicMarker.java
@@ -184,7 +184,8 @@ public class BasicMarker implements Marker {
     sb.append(' ').append(OPEN);
     while (it.hasNext()) {
       reference = (Marker) it.next();
-      sb.append(reference.getName());
+      // recursively process nested Markers
+      sb.append(reference.toString());
       if (it.hasNext()) {
         sb.append(SEP);
       }

--- a/slf4j-api/src/test/java/org/slf4j/BasicMarkerTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/BasicMarkerTest.java
@@ -54,7 +54,7 @@ public class BasicMarkerTest extends TestCase {
   final Marker multiComp;
 
   short diff = Differentiator.getDiffentiator();
-  
+
   public BasicMarkerTest() {
     factory = new BasicMarkerFactory();
 
@@ -143,7 +143,7 @@ public class BasicMarkerTest extends TestCase {
   }
 
   public void testSelfRecursion() {
-    final String diffPrefix = "NEW_"+diff;
+    final String diffPrefix = "NEW_" + diff;
     final String PARENT_NAME = diffPrefix + PARENT_MARKER_STR;
     final String NOT_CONTAINED_NAME = diffPrefix + NOT_CONTAINED_MARKER_STR;
     Marker parent = factory.getMarker(PARENT_NAME);
@@ -156,10 +156,10 @@ public class BasicMarkerTest extends TestCase {
   }
 
   public void testIndirectRecursion() {
-    final String diffPrefix = "NEW_"+diff;
-    final String PARENT_NAME=diffPrefix+PARENT_MARKER_STR;
-    final String CHILD_NAME=diffPrefix+CHILD_MARKER_STR;
-    final String NOT_CONTAINED_NAME=diffPrefix+NOT_CONTAINED_MARKER_STR;
+    final String diffPrefix = "NEW_" + diff;
+    final String PARENT_NAME = diffPrefix + PARENT_MARKER_STR;
+    final String CHILD_NAME = diffPrefix + CHILD_MARKER_STR;
+    final String NOT_CONTAINED_NAME = diffPrefix + NOT_CONTAINED_MARKER_STR;
 
     Marker parent = factory.getMarker(PARENT_NAME);
     Marker child = factory.getMarker(CHILD_NAME);
@@ -176,21 +176,26 @@ public class BasicMarkerTest extends TestCase {
   }
 
   public void testHomonyms() {
-    final String diffPrefix = "homonym"+diff;
-    final String PARENT_NAME=diffPrefix+PARENT_MARKER_STR;
-    final String CHILD_NAME=diffPrefix+CHILD_MARKER_STR;
+    final String diffPrefix = "homonym" + diff;
+    final String PARENT_NAME = diffPrefix + PARENT_MARKER_STR;
+    final String CHILD_NAME = diffPrefix + CHILD_MARKER_STR;
     Marker parent = factory.getMarker(PARENT_NAME);
     Marker child = factory.getMarker(CHILD_NAME);
     parent.add(child);
-   
+
     IMarkerFactory otherFactory = new BasicMarkerFactory();
     Marker otherParent = otherFactory.getMarker(PARENT_NAME);
     Marker otherChild = otherFactory.getMarker(CHILD_NAME);
-    
+
     assertTrue(parent.contains(otherParent));
     assertTrue(parent.contains(otherChild));
-    
+
     assertTrue(parent.remove(otherChild));
   }
-  
+
+  public void testToString() {
+    assertEquals(MULTI_COMP_STR + " [ " + GREEN_STR + ", " + COMP_STR + " [ "
+        + BLUE_STR + " ] ]", multiComp.toString());
+  }
+
 }


### PR DESCRIPTION
In my opinion, BasicMarker#toString() should print all Markers recursively. The original implementation stopped extending the result string at depth 2.
