### PR TITLE
Fixed issue with CrystalReports when real log4j is not on classpath

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/PatternLayout.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/PatternLayout.java
@@ -17,11 +17,18 @@
 // Contributors:  Christian Trutz <christian.trutz@belaso.de>
 package org.apache.log4j;
 
+//Contributors:  Octavian Ciubotaru <octavian.ciubotaru@optimo.it>
+
 /**
  * This class is a minimal implementation of the original Log4J class.
  * 
  * @author Christian Trutz <christian.trutz@belaso.de>
  * */
 public class PatternLayout extends Layout {
-
+    
+    public PatternLayout() {
+    }
+    
+    public PatternLayout(String pattern) {
+    }
 }

--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/SimpleLayout.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/SimpleLayout.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2001-2004 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Contributors:  Octavian Ciubotaru <octavian.ciubotaru@optimo.it>
+package org.apache.log4j;
+
+/**
+ * This class is a minimal implementation of the original Log4J class.
+ * 
+ * @author Octavian Ciubotaru <octavian.ciubotaru@optimo.it>
+ * */
+public class SimpleLayout extends Layout {
+
+}


### PR DESCRIPTION
Crystal Reports (version 11.5.8.826) will not run with log4j-over-slf4j because it needs 2 classes on classpath: Layout and SimpleLayout.

First one was already added. Now I also added the second one.

Crystal Reports code is obfuscated I can't understand how Layout or SimpleLayout is used.
I tested and it seems that only the presence of these classes on classpath solves the issue.
