### PR TITLE
Misc slf4j-simple fixes and enhancements

### DIFF
--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLoggerAccess.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLoggerAccess.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2004-2014 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.slf4j.ILoggerFactory;
+
+/**
+ * @author C&eacute;drik LIME
+ */
+public class SimpleLoggerAccess {
+
+//	final static SimpleLoggerFactory INSTANCE = SimpleLoggerFactory.INSTANCE;
+	final static SimpleLoggerFactory INSTANCE = (SimpleLoggerFactory) StaticLoggerBinder.getSingleton().getLoggerFactory();
+
+	private SimpleLoggerAccess() {
+	}
+
+	/**
+	 * Return an appropriate {@link SimpleLogger} instance by name, or
+	 * {@code null} if none exists.
+	 *
+	 * @see ILoggerFactory#getLogger(String)
+	 */
+	public static SimpleLogger getLogger(String name) {
+		SimpleLogger slogger = INSTANCE.loggerMap.get(name);
+		return slogger;
+	}
+
+	public static Collection<SimpleLogger> getAllLoggers() {
+		return new ArrayList<SimpleLogger>(INSTANCE.loggerMap.values());
+	}
+
+
+	public static void changeLoggerLevel(String loggerName, String newLevel) throws IllegalArgumentException {
+		changeLoggerLevel(getLogger(loggerName), levelNameToInt(newLevel));
+	}
+
+	public static void changeLoggerLevel(SimpleLogger logger, String newLevel) throws IllegalArgumentException {
+		changeLoggerLevel(logger, levelNameToInt(newLevel));
+	}
+
+	public static void changeLoggerLevel(SimpleLogger logger, int newLevel) throws IllegalArgumentException {
+		if (logger == null) {
+			return;
+		}
+		// Sanity check; will throw IllegalArgumentException
+		getLevelName(newLevel);
+		logger.currentLogLevel = newLevel;
+	}
+
+
+	public static int levelNameToInt(String level) throws IllegalArgumentException {
+		int result = SimpleLogger.stringToLevel(level);
+		// SimpleLogger#stringToLevel() defaults to INFO
+		if (result == SimpleLogger.LOG_LEVEL_INFO && ! "info".equalsIgnoreCase(level)) {
+			throw new IllegalArgumentException(level);
+		}
+		return result;
+	}
+
+	public static String getLevelName(SimpleLogger logger) throws IllegalArgumentException {
+		return getLevelName(logger.currentLogLevel);
+	}
+	public static String getLevelName(int level) throws IllegalArgumentException {
+		return SimpleLogger.levelToString(level);
+	}
+}

--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLoggerFactory.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLoggerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2004-2011 QOS.ch
+ * Copyright (c) 2004-2014 QOS.ch
  * All rights reserved.
  *
  * Permission is hereby granted, free  of charge, to any person obtaining
@@ -24,8 +24,6 @@
  */
 package org.slf4j.impl;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -40,10 +38,10 @@ import org.slf4j.ILoggerFactory;
  */
 public class SimpleLoggerFactory implements ILoggerFactory {
 
-  ConcurrentMap<String, Logger> loggerMap;
+  ConcurrentMap<String, SimpleLogger> loggerMap;
 
   public SimpleLoggerFactory() {
-    loggerMap = new ConcurrentHashMap<String, Logger>();
+    loggerMap = new ConcurrentHashMap<String, SimpleLogger>();
   }
 
   /**
@@ -54,7 +52,7 @@ public class SimpleLoggerFactory implements ILoggerFactory {
     if (simpleLogger != null) {
       return simpleLogger;
     } else {
-      Logger newInstance = new SimpleLogger(name);
+      SimpleLogger newInstance = new SimpleLogger(name);
       Logger oldInstance = loggerMap.putIfAbsent(name, newInstance);
       return oldInstance == null ? newInstance : oldInstance;
     }

--- a/slf4j-simple/src/test/resources/simplelogger.properties
+++ b/slf4j-simple/src/test/resources/simplelogger.properties
@@ -1,14 +1,20 @@
 # SLF4J's SimpleLogger configuration file
 # Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
 
+# The output target which can be the path to a file, or the special values "System.out" and "System.err".
+# Defaults to System.err.
+#org.slf4j.simpleLogger.logFile=System.err
+
 # Default logging detail level for all instances of SimpleLogger.
 # Must be one of ("trace", "debug", "info", "warn", or "error").
 # If not specified, defaults to "info".
-#org.slf4j.simpleLogger.defaultLog=info
+#org.slf4j.simpleLogger.defaultLogLevel=info
 
 # Logging detail level for a SimpleLogger instance named "xxxxx".
 # Must be one of ("trace", "debug", "info", "warn", or "error").
-# If not specified, the default logging detail level is used.
+# If unspecified, the level of nearest parent logger will be used,
+# and if none is set, then the value specified by
+# org.slf4j.simpleLogger.defaultLogLevel will be used.
 #org.slf4j.simpleLogger.log.xxxxx=
 
 # Set to true if you want the current date and time to be included in output messages.
@@ -17,9 +23,9 @@
 
 # The date and time format to be used in the output messages.
 # The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
-# If the format is not specified or is invalid, the default format is used.
-# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
-#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+# If the format is not specified or is invalid, the number of milliseconds since start up will be output.
+#org.slf4j.simpleLogger.dateTimeFormat=
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss.SSS Z
 
 # Set to true if you want to output the current thread name.
 # Defaults to true.
@@ -32,3 +38,11 @@
 # Set to true if you want the last component of the name to be included in output messages.
 # Defaults to false.
 #org.slf4j.simpleLogger.showShortLogName=false
+
+# Should the level string be output in brackets?
+# Defaults to false.
+#org.slf4j.simpleLogger.levelInBrackets=false
+
+# The string value output for the warn level.
+# Defaults to WARN.
+#org.slf4j.simpleLogger.warnLevelString=WARN


### PR DESCRIPTION
- Java 5 syntax
- add SimpleLoggerAccess class to enable to change logger levels at runtime
- update documentation (including example simplelogger.properties file)
- restore ability to completely turn off logging for a given logger (level "off")
- force output file (if any) to UTF-8 to avoid platform-dependent surprises while logging to a file
