### PR TITLE
Fix SL4J-EXT manifest, duplicate bundle name with SL4J-LOG4J

### DIFF
--- a/slf4j-ext/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-ext/src/main/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Implementation-Title: slf4j-ext
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: slf4j.ext
-Bundle-Name: slf4j.ext
+Bundle-Name: slf4j-ext
 Bundle-Vendor: SLF4J.ORG
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Export-Package: org.slf4j.profiler;version=${parsedVersion.osgiVersion}, org.slf4j.cal10n;version=${parsedVersion.osgiVersion}, org.slf4j.ext;version=${parsedVersion.osgiVersion}


### PR DESCRIPTION
This fix is vital for osgi bundle repository. (Deploy SL4J-EXT instead of SL4J-LOG4J)
