### PR TITLE
Fix for SLF4JBridgeHandler throws IllegalArgumentException when attempting to parse parameters

### DIFF
--- a/jul-to-slf4j/src/main/java/org/slf4j/bridge/SLF4JBridgeHandler.java
+++ b/jul-to-slf4j/src/main/java/org/slf4j/bridge/SLF4JBridgeHandler.java
@@ -262,7 +262,7 @@ public class SLF4JBridgeHandler extends Handler {
       }
     }
     Object[] params = record.getParameters();
-    if (params != null) {
+    if (params != null && params.length > 0) {
       message = MessageFormat.format(message, params);
     }
     return message;

--- a/jul-to-slf4j/src/test/java/org/slf4j/bridge/SLF4JBridgeHandlerTest.java
+++ b/jul-to-slf4j/src/test/java/org/slf4j/bridge/SLF4JBridgeHandlerTest.java
@@ -168,6 +168,17 @@ public class SLF4JBridgeHandlerTest extends TestCase {
     assertEquals(expectedMsg3, le.getMessage());
   }
 
+  public void testLogWithPlaceholderNoParameters() {
+    SLF4JBridgeHandler.install();
+    String msg = "msg {}";
+    julLogger.logp(Level.INFO, "SLF4JBridgeHandlerTest", "testLogWithPlaceholderNoParameters", msg, new Object[0]);
+
+    assertEquals(1, listAppender.list.size());
+    LoggingEvent le = (LoggingEvent) listAppender.list.get(0);
+    assertEquals(LOGGER_NAME, le.getLoggerName());
+    assertEquals(msg, le.getMessage());
+  }
+
   void assertLevel(int index, org.apache.log4j.Level expectedLevel) {
     LoggingEvent le = (LoggingEvent) listAppender.list.get(index);
     assertEquals(expectedLevel, le.getLevel());


### PR DESCRIPTION
This is a fix for this issue: http://bugzilla.slf4j.org/show_bug.cgi?id=212

Description:

I am trying to bridge a LogRecord with a message that is the result of
HashMap.toString():

{interface
com.google.code.morphia.annotations.Id=@com.google.code.morphia.annotations.Id()}

and get following exception

Caused by: java.lang.IllegalArgumentException: can't parse argument number
interface
com.google.code.morphia.annotations.Id=@com.google.code.morphia.annotations.Id()
    at java.text.MessageFormat.makeFormat(MessageFormat.java:1339)
    at java.text.MessageFormat.applyPattern(MessageFormat.java:458)
    at java.text.MessageFormat.<init>(MessageFormat.java:350)
    at java.text.MessageFormat.format(MessageFormat.java:811)
    at
org.slf4j.bridge.SLF4JBridgeHandler.getMessageI18N(SLF4JBridgeHandler.java:233)

FIX: do not format since there are no parameters!

if (params != null && params.length > 0)
