### PR TITLE
Fixed situation where migrator does not convert JCL log statements and breaks code.

### DIFF
--- a/slf4j-migrator/src/main/java/org/slf4j/migrator/line/JCLRuleSet.java
+++ b/slf4j-migrator/src/main/java/org/slf4j/migrator/line/JCLRuleSet.java
@@ -64,6 +64,13 @@ public class JCLRuleSet implements RuleSet {
         .compile("LogFactory.getLog\\("),"LoggerFactory.getLogger(");
     
 
+    SingleConversionRule cr6 = new SingleConversionRule(Pattern
+            .compile("\\sLogFactory\\b"),"LoggerFactory");
+        
+    SingleConversionRule cr7 = new SingleConversionRule(Pattern
+            .compile("\\s.getLog\\("),".getLogger(");
+        
+
     conversionRuleList = new ArrayList<ConversionRule>();
     conversionRuleList.add(cr0);
     conversionRuleList.add(cr1);
@@ -71,6 +78,8 @@ public class JCLRuleSet implements RuleSet {
     conversionRuleList.add(cr3);
     conversionRuleList.add(cr4);
     conversionRuleList.add(cr5);
+    conversionRuleList.add(cr6);
+    conversionRuleList.add(cr7);
   }
 
 

--- a/slf4j-migrator/src/main/java/org/slf4j/migrator/line/JCLRuleSet.java
+++ b/slf4j-migrator/src/main/java/org/slf4j/migrator/line/JCLRuleSet.java
@@ -66,10 +66,12 @@ public class JCLRuleSet implements RuleSet {
 
     SingleConversionRule cr6 = new SingleConversionRule(Pattern
             .compile("\\sLogFactory\\b"),"LoggerFactory");
+
         
-    SingleConversionRule cr7 = new SingleConversionRule(Pattern
-            .compile("\\s.getLog\\("),".getLogger(");
-        
+    MultiGroupConversionRule mgcr = new MultiGroupConversionRule(Pattern
+            .compile("(\\s.getLog\\()"));
+    mgcr.addReplacement(1,".getLogger\\(");
+    
 
     conversionRuleList = new ArrayList<ConversionRule>();
     conversionRuleList.add(cr0);
@@ -79,7 +81,7 @@ public class JCLRuleSet implements RuleSet {
     conversionRuleList.add(cr4);
     conversionRuleList.add(cr5);
     conversionRuleList.add(cr6);
-    conversionRuleList.add(cr7);
+    conversionRuleList.add(mgcr);
   }
 
 

--- a/slf4j-migrator/src/test/java/org/slf4j/migrator/AternativeApproach.java
+++ b/slf4j-migrator/src/test/java/org/slf4j/migrator/AternativeApproach.java
@@ -56,7 +56,7 @@ public class AternativeApproach extends TestCase {
 
   /**
    * In this test we replace, using the simple Pattern (Log), the full Log
-   * declaration and instanciation. This is not convenient because we will also
+   * declaration and instantiation. This is not convenient because we will also
    * replace all String containing "Log".
    */
   public void test2() {
@@ -83,7 +83,7 @@ public class AternativeApproach extends TestCase {
   }
 
   /**
-   * In this test we use a simple Pattern to replace the log instanciation
+   * In this test we use a simple Pattern to replace the log instantiation
    * without influence on Log declaration.
    * 
    */

--- a/slf4j-migrator/src/test/java/org/slf4j/migrator/line/JCLRuleSetTest.java
+++ b/slf4j-migrator/src/test/java/org/slf4j/migrator/line/JCLRuleSetTest.java
@@ -43,81 +43,81 @@ public class JCLRuleSetTest extends TestCase {
   }
 
   public void testLogFactoryGetLogReplacement() {
-    // Logger declaration and instanciation without modifier
+    // Logger declaration and instantiation without modifier
     assertEquals("  Logger   l = LoggerFactory.getLogger(MyClass.class);",
         jclConverter
             .getOneLineReplacement("  Log   l = LogFactory.getLog(MyClass.class);"));
-    // Logger declaration and instanciation with one modifier
+    // Logger declaration and instantiation with one modifier
     assertEquals(
         "public Logger mylog=LoggerFactory.getLogger(MyClass.class);",
         jclConverter
             .getOneLineReplacement("public Log mylog=LogFactory.getLog(MyClass.class);"));
-    // Logger declaration and instanciation with two modifier
+    // Logger declaration and instantiation with two modifier
     assertEquals(
         "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);",
         jclConverter
             .getOneLineReplacement("public static Log mylog1 = LogFactory.getLog(MyClass.class);"));
-    // Logger declaration and instanciation with two modifier and comment at the
+    // Logger declaration and instantiation with two modifier and comment at the
     // end of line
     assertEquals(
-        "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class); //logger instanciation and declaration",
+        "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class); //logger instantiation and declaration",
         jclConverter
-            .getOneLineReplacement("public static Log mylog1 = LogFactory.getLog(MyClass.class); //logger instanciation and declaration"));
-    // Logger instanciation without declaration and comment at the end of line
+            .getOneLineReplacement("public static Log mylog1 = LogFactory.getLog(MyClass.class); //logger instantiation and declaration"));
+    // Logger instantiation without declaration and comment at the end of line
     assertEquals(
-        " myLog = LoggerFactory.getLogger(MyClass.class);//logger instanciation",
+        " myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         jclConverter
-            .getOneLineReplacement(" myLog = LogFactory.getLog(MyClass.class);//logger instanciation"));
-    // commented Logger declaration and instanciation with two modifier
+            .getOneLineReplacement(" myLog = LogFactory.getLog(MyClass.class);//logger instantiation"));
+    // commented Logger declaration and instantiation with two modifier
     assertEquals(
         "//public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);",
         jclConverter
             .getOneLineReplacement("//public static Log mylog1 = LogFactory.getLog(MyClass.class);"));
-    // commented Logger instanciation without declaration
+    // commented Logger instantiation without declaration
     assertEquals(
-        "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instanciation",
+        "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         jclConverter
-            .getOneLineReplacement("// myLog = LogFactory.getLog(MyClass.class);//logger instanciation"));
+            .getOneLineReplacement("// myLog = LogFactory.getLog(MyClass.class);//logger instantiation"));
   }
 
   public void testLogFactoryGetFactoryReplacement() {
    
-    // Logger declaration and instanciation without modifier
+    // Logger declaration and instantiation without modifier
     assertEquals(
         "Logger l = LoggerFactory.getLogger(MyClass.class);",
         jclConverter
             .getOneLineReplacement("Log l = LogFactory.getFactory().getInstance(MyClass.class);"));
-    // Logger declaration and instanciation with one modifier
+    // Logger declaration and instantiation with one modifier
     assertEquals(
         "public Logger mylog=LoggerFactory.getLogger(MyClass.class);",
         jclConverter
             .getOneLineReplacement("public Log mylog=LogFactory.getFactory().getInstance(MyClass.class);"));
-    // Logger declaration and instanciation with modifiers
+    // Logger declaration and instantiation with modifiers
     assertEquals(
         "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);",
         jclConverter
             .getOneLineReplacement("public static Log mylog1 = LogFactory.getFactory().getInstance(MyClass.class);"));
-    // Logger declaration and instanciation with two modifier and comment at the
+    // Logger declaration and instantiation with two modifier and comment at the
     // end of line
     assertEquals(
-        "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class); //logger instanciation and declaration",
+        "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class); //logger instantiation and declaration",
         jclConverter
-            .getOneLineReplacement("public static Log mylog1 = LogFactory.getFactory().getInstance(MyClass.class); //logger instanciation and declaration"));
-    // Logger instanciation without declaration and comment at the end of line
+            .getOneLineReplacement("public static Log mylog1 = LogFactory.getFactory().getInstance(MyClass.class); //logger instantiation and declaration"));
+    // Logger instantiation without declaration and comment at the end of line
     assertEquals(
-        " myLog = LoggerFactory.getLogger(MyClass.class);//logger instanciation",
+        " myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         jclConverter
-            .getOneLineReplacement(" myLog = LogFactory.getFactory().getInstance(MyClass.class);//logger instanciation"));
-    // commented Logger declaration and instanciation with two modifier
+            .getOneLineReplacement(" myLog = LogFactory.getFactory().getInstance(MyClass.class);//logger instantiation"));
+    // commented Logger declaration and instantiation with two modifier
     assertEquals(
         "//public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);",
         jclConverter
             .getOneLineReplacement("//public static Log mylog1 = LogFactory.getFactory().getInstance(MyClass.class);"));
-    // commented Logger instanciation without declaration
+    // commented Logger instantiation without declaration
     assertEquals(
-        "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instanciation",
+        "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         jclConverter
-            .getOneLineReplacement("// myLog = LogFactory.getFactory().getInstance(MyClass.class);//logger instanciation"));
+            .getOneLineReplacement("// myLog = LogFactory.getFactory().getInstance(MyClass.class);//logger instantiation"));
   }
 
   public void testLogDeclarationReplacement() {
@@ -144,13 +144,13 @@ public class JCLRuleSetTest extends TestCase {
     assertEquals("protected Logger log =", jclConverter
         .getOneLineReplacement("protected Log log ="));
 
-    // Logger instanciation on the next line
+    // Logger instantiation on the next line
     assertEquals(" LoggerFactory.getLogger(MyComponent.class);", jclConverter
         .getOneLineReplacement(" LogFactory.getLog(MyComponent.class);"));
     // Logger declaration on a line
     assertEquals("protected Logger log ", jclConverter
         .getOneLineReplacement("protected Log log "));
-    // Logger instanciation on the next line
+    // Logger instantiation on the next line
     assertEquals(
         " = LoggerFactory.getLogger(MyComponent.class);",
         jclConverter

--- a/slf4j-migrator/src/test/java/org/slf4j/migrator/line/JCLRuleSetTest.java
+++ b/slf4j-migrator/src/test/java/org/slf4j/migrator/line/JCLRuleSetTest.java
@@ -118,6 +118,15 @@ public class JCLRuleSetTest extends TestCase {
         "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         jclConverter
             .getOneLineReplacement("// myLog = LogFactory.getFactory().getInstance(MyClass.class);//logger instantiation"));
+}
+
+  public void testGetLogWhiteSpaceDeclarationReplacement() {
+	    // Get log with white space
+	    assertEquals(
+	        ".getLogger(",
+	        jclConverter
+	            .getOneLineReplacement(" .getLog("));
+	  
   }
 
   public void testLogDeclarationReplacement() {

--- a/slf4j-migrator/src/test/java/org/slf4j/migrator/line/Log4jRuleSetTest.java
+++ b/slf4j-migrator/src/test/java/org/slf4j/migrator/line/Log4jRuleSetTest.java
@@ -46,79 +46,79 @@ public class Log4jRuleSetTest extends TestCase {
   }
 
   public void testLogManagerGetLoggerReplacement() {
-    // Logger declaration and instanciation without modifier
+    // Logger declaration and instantiation without modifier
     assertEquals(" Logger l = LoggerFactory.getLogger(MyClass.class);",
         log4jConverter
             .getOneLineReplacement(" Logger l = LogManager.getLogger(MyClass.class);"));
-    // Logger declaration and instanciation with one modifier
+    // Logger declaration and instantiation with one modifier
     assertEquals(
         "public Logger mylog=LoggerFactory.getLogger(MyClass.class);",
         log4jConverter
             .getOneLineReplacement("public Logger mylog=LogManager.getLogger(MyClass.class);"));
-    // Logger declaration and instanciation with two modifier
+    // Logger declaration and instantiation with two modifier
     assertEquals(
         "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);",
         log4jConverter
             .getOneLineReplacement("public static Logger mylog1 = LogManager.getLogger(MyClass.class);"));
-    // Logger declaration and instanciation with two modifier and comment at the
+    // Logger declaration and instantiation with two modifier and comment at the
     // end of line
     assertEquals(
-        "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);//logger instanciation and declaration",
+        "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);//logger instantiation and declaration",
         log4jConverter
-            .getOneLineReplacement("public static Logger mylog1 = LogManager.getLogger(MyClass.class);//logger instanciation and declaration"));
-    // Logger instanciation without declaration and comment at the end of line
+            .getOneLineReplacement("public static Logger mylog1 = LogManager.getLogger(MyClass.class);//logger instantiation and declaration"));
+    // Logger instantiation without declaration and comment at the end of line
     assertEquals(
-        " myLog = LoggerFactory.getLogger(MyClass.class);//logger instanciation",
+        " myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         log4jConverter
-            .getOneLineReplacement(" myLog = LogManager.getLogger(MyClass.class);//logger instanciation"));
-    // commented Logger declaration and instanciation with two modifier
+            .getOneLineReplacement(" myLog = LogManager.getLogger(MyClass.class);//logger instantiation"));
+    // commented Logger declaration and instantiation with two modifier
     assertEquals(
         "//public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);",
         log4jConverter
             .getOneLineReplacement("//public static Logger mylog1 = LogManager.getLogger(MyClass.class);"));
-    // commented Logger instanciation without declaration
+    // commented Logger instantiation without declaration
     assertEquals(
-        "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instanciation",
+        "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         log4jConverter
-            .getOneLineReplacement("// myLog = LogManager.getLogger(MyClass.class);//logger instanciation"));
+            .getOneLineReplacement("// myLog = LogManager.getLogger(MyClass.class);//logger instantiation"));
   }
 
   public void testLoggerGetLoggerReplacement() {
-    // Logger declaration and instanciation without modifier
+    // Logger declaration and instantiation without modifier
     assertEquals("Logger l = LoggerFactory.getLogger(MyClass.class);",
         log4jConverter
             .getOneLineReplacement("Logger l = Logger.getLogger(MyClass.class);"));
-    // Logger declaration and instanciation with one modifier
+    // Logger declaration and instantiation with one modifier
     assertEquals(
         "public Logger mylog=LoggerFactory.getLogger(MyClass.class);",
         log4jConverter
             .getOneLineReplacement("public Logger mylog=Logger.getLogger(MyClass.class);"));
-    // Logger declaration and instanciation with modifiers
+    // Logger declaration and instantiation with modifiers
     assertEquals(
         "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);",
         log4jConverter
             .getOneLineReplacement("public static Logger mylog1 = Logger.getLogger(MyClass.class);"));
-    // Logger declaration and instanciation with two modifier and comment at the
+    // Logger declaration and instantiation with two modifier and comment at the
     // end of line
     assertEquals(
-        "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class); // logger instanciation and declaration",
+        "public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class); // logger instantiation and declaration",
         log4jConverter
-            .getOneLineReplacement("public static Logger mylog1 = Logger.getLogger(MyClass.class); // logger instanciation and declaration"));
-    // Logger instanciation without declaration and comment at the end of line
+            .getOneLineReplacement("public static Logger mylog1 = Logger.getLogger(MyClass.class); // logger instantiation and declaration"));
+    // Logger instantiation without declaration and comment at the end of line
     assertEquals(
-        " myLog = LoggerFactory.getLogger(MyClass.class);//logger instanciation",
+        " myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         log4jConverter
-            .getOneLineReplacement(" myLog = Logger.getLogger(MyClass.class);//logger instanciation"));
-    // commented Logger declaration and instanciation with two modifier
+            .getOneLineReplacement(" myLog = Logger.getLogger(MyClass.class);//logger instantiation"));
+    // commented Logger declaration and instantiation with two modifier
     assertEquals(
         "//public static Logger mylog1 = LoggerFactory.getLogger(MyClass.class);",
         log4jConverter
             .getOneLineReplacement("//public static Logger mylog1 = Logger.getLogger(MyClass.class);"));
-    // commented Logger instanciation without declaration
+    // commented Logger instantiation without declaration
     assertEquals(
-        "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instanciation",
+        "// myLog = LoggerFactory.getLogger(MyClass.class);//logger instantiation",
         log4jConverter
-            .getOneLineReplacement("// myLog = Logger.getLogger(MyClass.class);//logger instanciation"));
+            .getOneLineReplacement("// myLog = Logger.getLogger(MyClass.class);//logger instantiation"));
   }
 
   public void testLogDeclarationReplacement() {
@@ -144,13 +144,13 @@ public class Log4jRuleSetTest extends TestCase {
    assertEquals("protected Logger log =", log4jConverter
    .getOneLineReplacement("protected Logger log ="));
     
-   // Logger instanciation on the next line
+   // Logger instantiation on the next line
    assertEquals(" LoggerFactory.getLogger(MyComponent.class);", log4jConverter
    .getOneLineReplacement(" LogManager.getLogger(MyComponent.class);"));
    // Logger declaration on a line
    assertEquals("protected Logger log ", log4jConverter
    .getOneLineReplacement("protected Logger log "));
-   // Logger instanciation on the next line
+   // Logger instantiation on the next line
    assertEquals(
    " = LoggerFactory.getLogger(MyComponent.class);",
    log4jConverter

--- a/slf4j-migrator/src/test/java/org/slf4j/migrator/line/NoConversionTest.java
+++ b/slf4j-migrator/src/test/java/org/slf4j/migrator/line/NoConversionTest.java
@@ -46,12 +46,12 @@ public class NoConversionTest extends TestCase {
     // no changes on log4j.Logger import
     assertEquals("import org.apache.log4j.Logger;", jclLineConverter
         .getOneLineReplacement("import org.apache.log4j.Logger;"));
-    // no changes on Logger instanciation using LogManager
+    // no changes on Logger instantiation using LogManager
     assertEquals(
         "Logger log = LogManager.getLogger(MyClass.class);",
         jclLineConverter
             .getOneLineReplacement("Logger log = LogManager.getLogger(MyClass.class);"));
-    // no changes on Logger instanciation using Logger.getLogger
+    // no changes on Logger instantiation using Logger.getLogger
     assertEquals(
         "public static Logger mylog1 = Logger.getLogger(MyClass.class);",
         jclLineConverter
@@ -72,12 +72,12 @@ public class NoConversionTest extends TestCase {
     // no changes on Log import
     assertEquals("import org.apache.commons.logging.Log;", log4jConverter
         .getOneLineReplacement("import org.apache.commons.logging.Log;"));
-    // no changes on Log instanciation using Logfactory.getLog
+    // no changes on Log instantiation using Logfactory.getLog
     assertEquals(
         "public static Log mylog1 = LogFactory.getLog(MyClass.class);",
         log4jConverter
             .getOneLineReplacement("public static Log mylog1 = LogFactory.getLog(MyClass.class);"));
-    // no changes on log instanciation using LogFactory.getFactory().getInstance
+    // no changes on log instantiation using LogFactory.getFactory().getInstance
     assertEquals(
         "public Log mylog=LogFactory.getFactory().getInstance(MyClass.class);",
         log4jConverter


### PR DESCRIPTION
There is a bug in the migrator: when the migrator encounters the method line on a new line apart from the class, the convertor changes the declaration but not the method name and thus breaks the code.

Normal convert:

``` java
Log logger = LogFactory.getLog(MyClass.class);
```

To

``` java
Logger logger = LoggerFactory.getLogger(MyClass.class);
```

When method name is on a separate line...

``` java
static Log logger = LogFactory
            .getLog(DoesntWork.class);
```

.. the migrator changes the declaration ... but not the type and method name.

``` java
static Logger logger = LogFactory
    .getLog(DoesntWork.class);
//sb  LoggerFactory
//    .getLogger(DoesntWork.class);
```

---

This looks like an old bug.
See http://mailman.qos.ch/pipermail/slf4j-dev/2011-March/003280.html

---

Also I fixed the spelling of 'instanciation'. :)
