### PR TITLE
A way to get a default logger for the current class.

### DIFF
--- a/slf4j-ext/src/main/java/org/slf4j/ext/XLoggerFactory.java
+++ b/slf4j-ext/src/main/java/org/slf4j/ext/XLoggerFactory.java
@@ -62,4 +62,14 @@ public class XLoggerFactory {
   public static XLogger getXLogger(Class clazz) {
     return getXLogger(clazz.getName());
   }
+
+  /**
+   * Get a new XLogger instance by calling class. The returned XLogger
+   * will be named after the class.
+   * 
+   * @return XLogger instance by name
+   */
+  public static XLogger getXLogger() {
+    return getXLogger(Thread.currentThread().getStackTrace()[2].getClassName());
+  }
 }

--- a/slf4j-ext/src/test/java/org/slf4j/dummyExt/XLoggerTest.java
+++ b/slf4j-ext/src/test/java/org/slf4j/dummyExt/XLoggerTest.java
@@ -154,4 +154,9 @@ public class XLoggerTest extends TestCase {
     }
 
   }
+
+  public void testDefaultClassLogger() {
+    XLogger logger = XLoggerFactory.getXLogger();
+    assertEquals(this.getClass().getName(),logger.getName());
+  }
 }


### PR DESCRIPTION
I had this in a LogUtility class that I've been using for a while and think it would be handy for others.