### PR TITLE
Added minimal implementation of log4j's class SimpleLayout.

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/SimpleLayout.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/SimpleLayout.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2001-2004 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.log4j;
+
+/**
+ * This class is a minimal implementation of the original Log4J class.
+ * 
+ * @author Felix Rodemund
+ * */
+public class SimpleLayout extends Layout {
+}


### PR DESCRIPTION
Hi!

I recently faced a ClassNotFoundException as the class SimpleLayout is not provided by the log4j binding (log4j-over-slf4j).

This adds a minimal implementation of the SimpleLayout to the log4j-over-slf4j module.

Regards,
- Felix
