### PR TITLE
Add `@Nonnull` annotation to aid findbugs / Eclipse IDE.

### DIFF
--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -19,7 +19,12 @@
   <url>http://www.slf4j.org</url>
 
   <dependencies>
-
+  	<dependency>
+  		<groupId>com.google.code.findbugs</groupId>
+  		<artifactId>jsr305</artifactId>
+  		<version>2.0.1</version>
+  		<optional>true</optional>
+  	</dependency>
   </dependencies> 
 
   <build>

--- a/slf4j-api/src/main/java/org/slf4j/ILoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/ILoggerFactory.java
@@ -24,6 +24,8 @@
  */
 package org.slf4j;
 
+import javax.annotation.Nonnull;
+
 
 /**
  * <code>ILoggerFactory</code> instances manufacture {@link Logger}
@@ -54,5 +56,6 @@ public interface ILoggerFactory {
    * @param name the name of the Logger to return
    * @return a Logger instance 
    */
-  public Logger getLogger(String name);
+  @Nonnull
+  public Logger getLogger(@Nonnull String name);
 }

--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -26,7 +26,14 @@ package org.slf4j;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
 
 import org.slf4j.helpers.NOPLoggerFactory;
 import org.slf4j.helpers.SubstituteLoggerFactory;
@@ -265,7 +272,8 @@ public final class LoggerFactory {
    * @param name The name of the logger.
    * @return logger
    */
-  public static Logger getLogger(String name) {
+  @Nonnull
+  public static Logger getLogger(@Nonnull String name) {
     ILoggerFactory iLoggerFactory = getILoggerFactory();
     return iLoggerFactory.getLogger(name);
   }
@@ -277,7 +285,8 @@ public final class LoggerFactory {
    * @param clazz the returned logger will be named after clazz
    * @return logger
    */
-  public static Logger getLogger(Class clazz) {
+  @Nonnull
+  public static Logger getLogger(@Nonnull Class clazz) {
     return getLogger(clazz.getName());
   }
 
@@ -289,6 +298,7 @@ public final class LoggerFactory {
    *
    * @return the ILoggerFactory instance in use
    */
+  @Nonnull
   public static ILoggerFactory getILoggerFactory() {
     if (INITIALIZATION_STATE == UNINITIALIZED) {
       INITIALIZATION_STATE = ONGOING_INITIALIZATION;


### PR DESCRIPTION
Adding @Nonnull annotation to aid Findbugs / IDE static analytics users (Eclipse, IDEA, etc.).

The change is very useful to make IDE warnings more accurate, and is harmless, i.e. the Maven dependency to findbugs is optional.

Let me know if there's any objections.
