### PR TITLE
Logging instrumentation should render non-primitive return values

### DIFF
--- a/slf4j-ext/src/main/java/org/slf4j/instrumentation/JavassistHelper.java
+++ b/slf4j-ext/src/main/java/org/slf4j/instrumentation/JavassistHelper.java
@@ -57,10 +57,10 @@ public class JavassistHelper {
 			return "";
 		} else if (returnType.isPrimitive()) {
 			// let the compiler handle primitive -> string
-			return "returns: \" + $_ + \"";
+			return " returns: \" + $_ + \"";
 		} else {
 			String render = "org.slf4j.instrumentation.ToStringHelper.render";
-			return "returns: \" + " + render + "($_)";
+			return " returns: \" + " + render + "($_) + \"";
 		}
 	}
 

--- a/slf4j-ext/src/main/java/org/slf4j/instrumentation/JavassistHelper.java
+++ b/slf4j-ext/src/main/java/org/slf4j/instrumentation/JavassistHelper.java
@@ -52,11 +52,16 @@ public class JavassistHelper {
 	public static String returnValue(CtBehavior method)
 			throws NotFoundException {
 
-		String returnValue = "";
-		if (methodReturnsValue(method)) {
-			returnValue = " returns: \" + $_ + \".";
+		CtClass returnType = methodReturnType(method);
+		if (!returnType) {
+			return "";
+		} else if (returnType.isPrimitive()) {
+			// let the compiler handle primitive -> string
+			return "returns: \" + $_ + \"";
+		} else {
+			String render = "org.slf4j.instrumentation.ToStringHelper.render";
+			return "returns: \" + " + render + "($_)");
 		}
-		return returnValue;
 	}
 
 	/**
@@ -67,7 +72,7 @@ public class JavassistHelper {
 	 * @return
 	 * @throws NotFoundException
 	 */
-	private static boolean methodReturnsValue(CtBehavior method)
+	private static CtClass methodReturnType(CtBehavior method)
 			throws NotFoundException {
 
 		if (method instanceof CtMethod == false) {
@@ -77,10 +82,11 @@ public class JavassistHelper {
 		CtClass returnType = ((CtMethod) method).getReturnType();
 		String returnTypeName = returnType.getName();
 
-		boolean isVoidMethod = "void".equals(returnTypeName);
-
-		boolean methodReturnsValue = isVoidMethod == false;
-		return methodReturnsValue;
+		if ("void".equals(returnTypeName)) {
+			return null;
+		} else {
+			return returnType;
+		}
 	}
 
 	/**

--- a/slf4j-ext/src/main/java/org/slf4j/instrumentation/JavassistHelper.java
+++ b/slf4j-ext/src/main/java/org/slf4j/instrumentation/JavassistHelper.java
@@ -53,7 +53,7 @@ public class JavassistHelper {
 			throws NotFoundException {
 
 		CtClass returnType = methodReturnType(method);
-		if (returnType != null) {
+		if (returnType == null) {
 			return "";
 		} else if (returnType.isPrimitive()) {
 			// let the compiler handle primitive -> string

--- a/slf4j-ext/src/main/java/org/slf4j/instrumentation/JavassistHelper.java
+++ b/slf4j-ext/src/main/java/org/slf4j/instrumentation/JavassistHelper.java
@@ -53,14 +53,14 @@ public class JavassistHelper {
 			throws NotFoundException {
 
 		CtClass returnType = methodReturnType(method);
-		if (!returnType) {
+		if (returnType != null) {
 			return "";
 		} else if (returnType.isPrimitive()) {
 			// let the compiler handle primitive -> string
 			return "returns: \" + $_ + \"";
 		} else {
 			String render = "org.slf4j.instrumentation.ToStringHelper.render";
-			return "returns: \" + " + render + "($_)");
+			return "returns: \" + " + render + "($_)";
 		}
 	}
 
@@ -76,7 +76,7 @@ public class JavassistHelper {
 			throws NotFoundException {
 
 		if (method instanceof CtMethod == false) {
-			return false;
+			return null;
 		}
 
 		CtClass returnType = ((CtMethod) method).getReturnType();


### PR DESCRIPTION
Instrumented logging with Javassist renders non-primitive method parameters using the _ToStringHelper_.
This patch makes sure that the same also happens to non-primitive return values of method calls.
