### PR TITLE
use stringbuilder for better multicore performance of formatter 

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
@@ -191,6 +191,7 @@ final public class MessageFormatter {
 
     int i = 0;
     int j;
+    // use string builder for better multicore performance 
     StringBuilder sbuf = new StringBuilder(messagePattern.length() + 50);
 
     int L;


### PR DESCRIPTION
String buffer internally uses locking, which will reduce the performance on machines with multiple cores.
