### PR TITLE
PrivilegedAction can executed with generics

### DIFF
--- a/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/SimpleLog.java
+++ b/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/SimpleLog.java
@@ -674,8 +674,8 @@ public class SimpleLog implements Log, Serializable {
   }
 
   private static InputStream getResourceAsStream(final String name) {
-    return (InputStream) AccessController.doPrivileged(new PrivilegedAction() {
-      public Object run() {
+    return AccessController.doPrivileged(new PrivilegedAction<InputStream>() {
+      public InputStream run() {
         ClassLoader threadCL = getContextClassLoader();
 
         if (threadCL != null) {

--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -233,9 +233,9 @@ public class SimpleLogger extends MarkerIgnoringBase {
 
   private static void loadProperties() {
     // Add props from the resource simplelogger.properties
-    InputStream in = (InputStream) AccessController.doPrivileged(
-            new PrivilegedAction() {
-              public Object run() {
+    InputStream in = AccessController.doPrivileged(
+            new PrivilegedAction<InputStream>() {
+              public InputStream run() {
                 ClassLoader threadCL = Thread.currentThread().getContextClassLoader();
                 if (threadCL != null) {
                   return threadCL.getResourceAsStream(CONFIGURATION_FILE);


### PR DESCRIPTION
I did some test with an app that uses commons logging and log4j. I removed log4j and commons-logging jar and put slf4j-api + jcl-over-slf4j and log4j-over-slf4j. All works fine.

Can you suggest another test to see if is really compatible with jcl and log4j? Generics are compiled as Object but is better if we make some tests.

If you appreciate this pull request I think that I can convert all other collections to use generics, if you want. Do you think that we don't have any problems to migrate projects like log4j-over-slf4j to use generics?

Best regards and thank you
