### PR TITLE
Add Android.mk to slf4j-android

### DIFF
--- a/slf4j-android/Android.mk
+++ b/slf4j-android/Android.mk
@@ -2,7 +2,11 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := slf4j-android
-LOCAL_STATIC_JAVA_LIBRARIES := slf4j-api
-LOCAL_SRC_FILES := $(call all-java-files-under, src/main/java)
+
+api_src := $(call all-java-files-under, ../slf4j-api/src/main/java)
+api_impl := $(call all-java-files-under, ../slf4j-api/src/main/java/org/slf4j/impl)
+api_src_no_impl := $(filter-out $(api_impl), $(api_src))
+
+LOCAL_SRC_FILES := $(api_src_no_impl) $(call all-java-files-under, src/main/java)
 
 include $(BUILD_STATIC_JAVA_LIBRARY)

--- a/slf4j-api/Android.mk
+++ b/slf4j-api/Android.mk
@@ -1,7 +1,0 @@
-LOCAL_PATH := $(call my-dir)
-include $(CLEAR_VARS)
-
-LOCAL_MODULE := slf4j-api
-LOCAL_SRC_FILES := $(call all-java-files-under, src/main/java)
-
-include $(BUILD_STATIC_JAVA_LIBRARY)


### PR DESCRIPTION
This way slf4j-android can be built as part of the Android System and so system applications and libraries can easily use slf4j.
