### PR TITLE
Asterisk has to be at the end of the loggerName.

### DIFF
--- a/slf4j-android/src/main/java/org/slf4j/impl/AndroidLoggerFactory.java
+++ b/slf4j-android/src/main/java/org/slf4j/impl/AndroidLoggerFactory.java
@@ -119,6 +119,6 @@ class AndroidLoggerFactory implements ILoggerFactory {
         int lastPeriodIndex = loggerName.lastIndexOf('.');
         return lastPeriodIndex != -1 && length - (lastPeriodIndex + 1) <= TAG_MAX_LENGTH
             ? loggerName.substring(lastPeriodIndex + 1)
-            : '*' + loggerName.substring(length - TAG_MAX_LENGTH + 1);
+            : loggerName.substring(length - TAG_MAX_LENGTH + 1) + '*';
     }
 }


### PR DESCRIPTION
Put the asterisk at the end of the loggerName to be align with the documentation http://www.slf4j.org/android/ "Logger name mapping".
