### PR TITLE
Proposed new Util.isInitFailed()

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/Util.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/Util.java
@@ -30,16 +30,24 @@ package org.slf4j.helpers;
  * An internal utility class.
  *
  * @author Ceki G&uuml;lc&uuml;
+ * @author Michael Vorburger - isInitFailed()
  */
 public class Util {
+
+  static private boolean failedInit = false;
     
   static final public void report(String msg, Throwable t) {
-    System.err.println(msg);
-    System.err.println("Reported exception:");
+    report(msg);
+    System.err.println("SLF4J Reported exception:");
     t.printStackTrace();
   }
   
   static final public void report(String msg) {
+    failedInit = true;
     System.err.println("SLF4J: " +msg);
+  }
+
+  static final public boolean isInitFailed() {
+    return failedInit;
   }
 }


### PR DESCRIPTION
Salut Ceki, ça fait un bout, ça va?

I'd like to propose adding an Util.isInitFailed(). This could then be used in an assertFalse("SLF4J Initialization failed", Util.isInitFailed()); kind of check in a @Test, in order to ensure that http://www.slf4j.org/codes.html#multiple_bindings and similar types of errors are caught by an automated test, and then when such problems are fixed other people don't accidentally re-introduce them by adding some new dependency.

The alternative is "watching out" for SLF4J msgs on System.err, which is doable, but in a JUnit TestRule using @Rule or @ClassRule à la something like http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-output-capture-test-utility it's difficult, because this typically happens very early.

PS: The idea for a test like this is for a "product", in this case Mifos the opensource Microfinance platform (which makes a conscious choice of a logger implementation), not for a "framework" library which does not.
