### PR TITLE
Added in annotations.xml files for the SLF4J API so that Kotlin users ha...

### DIFF
--- a/slf4j-api/src/main/resources/org/slf4j/annotations.xml
+++ b/slf4j-api/src/main/resources/org/slf4j/annotations.xml
@@ -1,0 +1,86 @@
+<root>
+    <item name='org.slf4j.ILoggerFactory org.slf4j.Logger getLogger(java.lang.String)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.IMarkerFactory org.slf4j.Marker getDetachedMarker(java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.IMarkerFactory org.slf4j.Marker getDetachedMarker(java.lang.String)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.IMarkerFactory org.slf4j.Marker getMarker(java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.IMarkerFactory org.slf4j.Marker getMarker(java.lang.String)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.Logger ROOT_LOGGER_NAME'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.Logger java.lang.String getName()'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.LoggerFactory org.slf4j.Logger getLogger(java.lang.Class)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.LoggerFactory org.slf4j.Logger getLogger(java.lang.Class) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.MDC java.lang.String get(java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.MDC void put(java.lang.String, java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.MDC void remove(java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.Marker ANY_MARKER'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.Marker ANY_NON_NULL_MARKER'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.Marker void add(org.slf4j.Marker) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.Marker boolean contains(java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.Marker boolean contains(org.slf4j.Marker) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.Marker java.lang.String getName()'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+</root>

--- a/slf4j-api/src/main/resources/org/slf4j/helpers/annotations.xml
+++ b/slf4j-api/src/main/resources/org/slf4j/helpers/annotations.xml
@@ -1,0 +1,71 @@
+<root>
+    <item name='org.slf4j.helpers.BasicMDCAdapter void put(java.lang.String, java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.BasicMarker void add(org.slf4j.Marker) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.BasicMarker boolean contains(java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.BasicMarker boolean contains(org.slf4j.Marker) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.BasicMarker java.lang.String getName()'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.BasicMarkerFactory org.slf4j.Marker getDetachedMarker(java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.BasicMarkerFactory org.slf4j.Marker getDetachedMarker(java.lang.String)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.BasicMarkerFactory org.slf4j.Marker getMarker(java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.BasicMarkerFactory org.slf4j.Marker getMarker(java.lang.String)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.MarkerIgnoringBase java.lang.String getName()'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.helpers.MessageFormatter org.slf4j.helpers.FormattingTuple arrayFormat(java.lang.String, java.lang.Object[])'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.MessageFormatter org.slf4j.helpers.FormattingTuple format(java.lang.String, java.lang.Object)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.MessageFormatter org.slf4j.helpers.FormattingTuple format(java.lang.String, java.lang.Object, java.lang.Object)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.NOPLogger NOP_LOGGER'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.NOPLogger java.lang.String getName()'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.NOPLoggerFactory org.slf4j.Logger getLogger(java.lang.String)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.NOPMDCAdapter void put(java.lang.String, java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+    <item name='org.slf4j.helpers.SubstituteLoggerFactory org.slf4j.Logger getLogger(java.lang.String)'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.SubstituteLoggerFactory java.util.List&lt;java.lang.String&gt; getLoggerNames()'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.SubstituteLoggerFactory java.util.List&lt;org.slf4j.helpers.SubstituteLogger&gt; getLoggers()'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+    <item name='org.slf4j.helpers.Util void report(java.lang.String, java.lang.Throwable) 1'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+    </item>
+</root>

--- a/slf4j-api/src/main/resources/org/slf4j/spi/annotations.xml
+++ b/slf4j-api/src/main/resources/org/slf4j/spi/annotations.xml
@@ -1,0 +1,8 @@
+<root>
+    <item name='org.slf4j.spi.MDCAdapter void put(java.lang.String, java.lang.String) 0'>
+        <annotation name='org.jetbrains.annotations.NotNull'/>
+        <annotation name='org.jetbrains.kannotator.runtime.annotations.Propagated'>
+            <val name="value" val="{org.jetbrains.kannotator.controlFlow.builder.analysis.NullabilityKey.class}"/>
+        </annotation>
+    </item>
+</root>


### PR DESCRIPTION
I'm not sure if this is of any interest, but the following patch makes it so that the slf4j-api artifact will contain annotations.xml files that are then picked up by the Kotlin build. This means that anyone using Kotlin and wanting to use SLF4J will have an easier time because the compiler is given information about which methods are null-safe - specifically about the fact that LoggerFactory.getLogger() is null-safe and so the returned Logger instance can be used without needing to use the "?." operator everywhere.

The annotations.xml files were all generated by the KAnnotator tool, but I then added in a single additional entry for the return type from LoggerFactory.getLogger(). 
