### PR TITLE
Add Log4J method to MDC to workaround use in wild

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/MDC.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/MDC.java
@@ -16,6 +16,9 @@
 
 package org.apache.log4j;
 
+import java.util.Hashtable;
+import java.util.Map;
+
 public class MDC {
 
   public static void put(String key, String value) {
@@ -40,5 +43,22 @@ public class MDC {
   
   public static void clear() {
     org.slf4j.MDC.clear();
+  }
+  
+  /** 
+   * This method is not part of the Log4J public API. However it 
+   * has been called by other projects. This method is here temporarily  
+   * until projects who are depending on this method release fixes. 
+   */
+  @Deprecated
+  public static Hashtable getContext() {
+    Map map = org.slf4j.MDC.getCopyOfContextMap();
+
+    if (map != null) {
+      return new Hashtable(map);
+    }
+    else {
+      return new Hashtable();
+    }
   }
 }


### PR DESCRIPTION
Proposing a fix for #84 (http://bugzilla.slf4j.org/show_bug.cgi?id=84) that will allow downstream projects that incorrectly depend on Log4J methods that are not part of the public API to use this bridge. It is marked as deprecated to raise a compiler warning in these projects until they release fixes. For example, see http://jira.pentaho.com/browse/MONDRIAN-1171
