### PR TITLE
Fix rendering of arrays in ToStringHelper.renderArray

### DIFF
--- a/slf4j-ext/src/main/java/org/slf4j/instrumentation/ToStringHelper.java
+++ b/slf4j-ext/src/main/java/org/slf4j/instrumentation/ToStringHelper.java
@@ -32,7 +32,7 @@ public class ToStringHelper {
 	/**
 	 * Prefix to use at the start of the representation. Always used.
 	 */
-	private static final char ARRAY_PREFIX = '[';
+	private static final String ARRAY_PREFIX = "[";
 
 	/**
 	 * Suffix to use at the end of the representation. Always used.


### PR DESCRIPTION
StringBuilder or StringBuffer doesn't have constructor for char. See below

Reports any new StringBuffer() and new StringBuilder() calls with an argument with type char. Such an argument is silently casted to an integer used to specify the length of the buffer. Usually this is not what was intended.

Btw, unit test for ToStringHelper was failing before this change.
