### PR TITLE
Remove unnecessary synchronized in JDK14LoggerFactory

### DIFF
--- a/slf4j-jdk14/src/main/java/org/slf4j/impl/JDK14LoggerFactory.java
+++ b/slf4j-jdk14/src/main/java/org/slf4j/impl/JDK14LoggerFactory.java
@@ -50,7 +50,7 @@ public class JDK14LoggerFactory implements ILoggerFactory {
    * 
    * @see org.slf4j.ILoggerFactory#getLogger(java.lang.String)
    */
-  public synchronized Logger getLogger(String name) {
+  public Logger getLogger(String name) {
     // the root logger is called "" in JUL
     if(name.equalsIgnoreCase(Logger.ROOT_LOGGER_NAME)) {
       name = "";


### PR DESCRIPTION
Commit 4dc6af1af741d9419c33187033a210dd623ceff1 changed several logger factories to use ConcurrentHashMap instead of a regular HashMap and synchronized. It appears the synchronized was left on the getLogger method accidentally. This pull request removes it.
