### PR TITLE
Use ThreadLocal<DateFormat> in SimpleLogger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <module>integration</module>
     <module>slf4j-site</module>
     <module>slf4j-migrator</module>
+    <module>slf4j-perf</module>
   </modules>
 
   <dependencies>
@@ -74,6 +75,13 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jmockit</groupId>
+      <artifactId>jmockit</artifactId>
+      <version>1.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/slf4j-perf/pom.xml
+++ b/slf4j-perf/pom.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>slf4j-parent</artifactId>
+    <groupId>org.slf4j</groupId>
+    <version>1.7.7</version>
+  </parent>
+
+  <artifactId>slf4j-perf</artifactId>
+  <packaging>jar</packaging>
+
+  <name>SLF4J performance and benchmarking module</name>
+
+  <prerequisites>
+    <maven>3.0</maven>
+  </prerequisites>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jmh.version>1.1.1</jmh.version>
+    <javac.target>1.6</javac.target>
+    <uberjar.name>benchmarks</uberjar.name>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <compilerVersion>${javac.target}</compilerVersion>
+          <source>${javac.target}</source>
+          <target>${javac.target}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${uberjar.name}</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                      Shading signed JARs will fail without this.
+                      http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                  -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.5</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.9.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.3</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.2.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.17</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/slf4j-perf/src/main/java/org/slf4j/impl/SimpleLoggerBenchmark.java
+++ b/slf4j-perf/src/main/java/org/slf4j/impl/SimpleLoggerBenchmark.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.slf4j.impl;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.slf4j.Logger;
+
+import java.util.concurrent.BrokenBarrierException;
+
+import static org.slf4j.impl.SimpleLogger.DATE_TIME_FORMAT_KEY;
+import static org.slf4j.impl.SimpleLogger.LOG_FILE_KEY;
+import static org.slf4j.impl.SimpleLogger.SHOW_DATE_TIME_KEY;
+
+public class SimpleLoggerBenchmark {
+
+  @State(Scope.Thread)
+  public static class NormalState {
+    Logger logger;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+      System.setProperty(DATE_TIME_FORMAT_KEY, "");
+      System.setProperty(SHOW_DATE_TIME_KEY, "true");
+      System.setProperty(LOG_FILE_KEY, "/dev/null");
+
+      logger = new SimpleLogger(Long.toString(Thread.currentThread().getId()));
+    }
+
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void oneThread(NormalState e) throws BrokenBarrierException, InterruptedException {
+    e.logger.info("Foobar!");
+  }
+
+  @Benchmark
+  @Threads(2)
+  public void twoThreads(NormalState e) throws BrokenBarrierException, InterruptedException {
+    e.logger.info("Foobar!");
+  }
+
+  @Benchmark
+  @Threads(4)
+  public void fourThreads(NormalState e) throws BrokenBarrierException, InterruptedException {
+    e.logger.info("Foobar!");
+  }
+
+  @Benchmark
+  @Threads(8)
+  public void eightThreads(NormalState e) throws BrokenBarrierException, InterruptedException {
+    e.logger.info("Foobar!");
+  }
+
+  @Benchmark
+  @Threads(16)
+  public void sixteenThreads(NormalState e) throws BrokenBarrierException, InterruptedException {
+    e.logger.info("Foobar!");
+  }
+
+}


### PR DESCRIPTION
In `SimpleLogger` is used static `DateFormatter` guarded by itself. I thought it might be good to replace it with `ThreadLocal<DateFormatter>`. I think it's faster by ~3-5%, but would be good if someone other can verify the results.

```
With LocalThread
Benchmark                                      Mode  Samples       Score      Error  Units
o.s.i.SimpleLoggerBenchmark.eightThreads      thrpt       20  291713.679 ± 2090.442  ops/s
o.s.i.SimpleLoggerBenchmark.fourThreads       thrpt       20  291552.450 ± 1771.590  ops/s
o.s.i.SimpleLoggerBenchmark.oneThread         thrpt       20  548539.921 ± 3197.140  ops/s
o.s.i.SimpleLoggerBenchmark.sixteenThreads    thrpt       20  281860.846 ± 3172.071  ops/s
o.s.i.SimpleLoggerBenchmark.twoThreads        thrpt       20  290422.132 ± 2213.392  ops/s

With synchronized block
Benchmark                                      Mode  Samples       Score       Error  Units
o.s.i.SimpleLoggerBenchmark.eightThreads      thrpt       20  251927.856 ±  4606.081  ops/s
o.s.i.SimpleLoggerBenchmark.fourThreads       thrpt       20  289278.497 ±  1899.424  ops/s
o.s.i.SimpleLoggerBenchmark.oneThread         thrpt       20  550569.540 ±  4470.577  ops/s
o.s.i.SimpleLoggerBenchmark.sixteenThreads    thrpt       20  275318.387 ±  3156.346  ops/s
o.s.i.SimpleLoggerBenchmark.twoThreads        thrpt       20  295816.125 ± 24218.907  ops/s
```

There are new unit tests using jmockit and jmh benchmarks in new module `slf4j-perf`
