### PR TITLE
Upgraded from Commons Logging 1.1.1 to 1.1.3.

### DIFF
--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -11,20 +11,12 @@
 
   <artifactId>jcl-over-slf4j</artifactId>
   <packaging>jar</packaging>
-  <name>JCL 1.1.1 implemented over SLF4J</name>
-  <description>JCL 1.1.1 implemented over SLF4J</description>
+  <name>JCL 1.1.3 implemented over SLF4J</name>
+  <description>JCL 1.1.3 implemented over SLF4J</description>
   <url>http://www.slf4j.org</url>
 
 
   <dependencies>
-    <!--
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    -->
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jcl-over-slf4j/src/main/java/org/apache/commons/logging/Log.java
+++ b/jcl-over-slf4j/src/main/java/org/apache/commons/logging/Log.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -17,12 +18,12 @@
 package org.apache.commons.logging;
 
 /**
- * <p>A simple logging interface abstracting logging APIs.  In order to be
+ * A simple logging interface abstracting logging APIs.  In order to be
  * instantiated successfully by {@link LogFactory}, classes that implement
  * this interface must have a constructor that takes a single String
- * parameter representing the "name" of this Log.</p>
- *
- * <p> The six logging levels used by <code>Log</code> are (in order):
+ * parameter representing the "name" of this Log.
+ * <p>
+ * The six logging levels used by <code>Log</code> are (in order):
  * <ol>
  * <li>trace (the least serious)</li>
  * <li>debug</li>
@@ -34,205 +35,186 @@ package org.apache.commons.logging;
  * The mapping of these log levels to the concepts used by the underlying
  * logging system is implementation dependent.
  * The implementation should ensure, though, that this ordering behaves
- * as expected.</p>
- *
- * <p>Performance is often a logging concern.
+ * as expected.
+ * <p>
+ * Performance is often a logging concern.
  * By examining the appropriate property,
  * a component can avoid expensive operations (producing information
- * to be logged).</p>
- *
- * <p> For example,
+ * to be logged).
+ * <p>
+ * For example,
  * <code><pre>
  *    if (log.isDebugEnabled()) {
  *        ... do something expensive ...
  *        log.debug(theResult);
  *    }
  * </pre></code>
- * </p>
- *
- * <p>Configuration of the underlying logging system will generally be done
+ * <p>
+ * Configuration of the underlying logging system will generally be done
  * external to the Logging APIs, through whatever mechanism is supported by
- * that system.</p>
+ * that system.
  *
- * <p style="color: #E40; font-weight: bold;">Please note that this interface is identical to that found in JCL 1.1.1.</p>
- * 
- * @author <a href="mailto:sanders@apache.org">Scott Sanders</a>
- * @author Rod Waldhoff
- * @version $Id: Log.java,v 1.19 2004/06/06 21:16:04 rdonkin Exp $
+ * @version $Id$
  */
 public interface Log {
 
-
     // ----------------------------------------------------- Logging Properties
 
-
     /**
-     * <p> Is debug logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is debug logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than debug. </p>
+     * when the log level is more than debug.
+     *
+     * @return true if debug is enabled in the underlying logger.
      */
     public boolean isDebugEnabled();
 
-
     /**
-     * <p> Is error logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is error logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than error. </p>
+     * when the log level is more than error.
+     *
+     * @return true if error is enabled in the underlying logger.
      */
     public boolean isErrorEnabled();
 
-
     /**
-     * <p> Is fatal logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is fatal logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than fatal. </p>
+     * when the log level is more than fatal.
+     *
+     * @return true if fatal is enabled in the underlying logger.
      */
     public boolean isFatalEnabled();
 
-
     /**
-     * <p> Is info logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is info logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than info. </p>
-     * 
-     * @return true if info enabled, false otherwise
+     * when the log level is more than info.
+     *
+     * @return true if info is enabled in the underlying logger.
      */
     public boolean isInfoEnabled();
 
-
     /**
-     * <p> Is trace logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is trace logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than trace. </p>
-     * 
-     * @return true if trace enabled, false otherwise
+     * when the log level is more than trace.
+     *
+     * @return true if trace is enabled in the underlying logger.
      */
     public boolean isTraceEnabled();
 
-
     /**
-     * <p> Is warn logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is warn logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than warn. </p>
+     * when the log level is more than warn.
+     *
+     * @return true if warn is enabled in the underlying logger.
      */
     public boolean isWarnEnabled();
 
-
     // -------------------------------------------------------- Logging Methods
 
-
     /**
-     * <p> Log a message with trace log level. </p>
+     * Log a message with trace log level.
      *
      * @param message log this message
      */
     public void trace(Object message);
 
-
     /**
-     * <p> Log an error with trace log level. </p>
+     * Log an error with trace log level.
      *
      * @param message log this message
      * @param t log this cause
      */
     public void trace(Object message, Throwable t);
 
-
     /**
-     * <p> Log a message with debug log level. </p>
+     * Log a message with debug log level.
      *
      * @param message log this message
      */
     public void debug(Object message);
 
-
     /**
-     * <p> Log an error with debug log level. </p>
+     * Log an error with debug log level.
      *
      * @param message log this message
      * @param t log this cause
      */
     public void debug(Object message, Throwable t);
 
-
     /**
-     * <p> Log a message with info log level. </p>
+     * Log a message with info log level.
      *
      * @param message log this message
      */
     public void info(Object message);
 
-
     /**
-     * <p> Log an error with info log level. </p>
+     * Log an error with info log level.
      *
      * @param message log this message
      * @param t log this cause
      */
     public void info(Object message, Throwable t);
 
-
     /**
-     * <p> Log a message with warn log level. </p>
+     * Log a message with warn log level.
      *
      * @param message log this message
      */
     public void warn(Object message);
 
-
     /**
-     * <p> Log an error with warn log level. </p>
+     * Log an error with warn log level.
      *
      * @param message log this message
      * @param t log this cause
      */
     public void warn(Object message, Throwable t);
 
-
     /**
-     * <p> Log a message with error log level. </p>
+     * Log a message with error log level.
      *
      * @param message log this message
      */
     public void error(Object message);
 
-
     /**
-     * <p> Log an error with error log level. </p>
+     * Log an error with error log level.
      *
      * @param message log this message
      * @param t log this cause
      */
     public void error(Object message, Throwable t);
 
-
     /**
-     * <p> Log a message with fatal log level. </p>
+     * Log a message with fatal log level.
      *
      * @param message log this message
      */
     public void fatal(Object message);
 
-
     /**
-     * <p> Log an error with fatal log level. </p>
+     * Log an error with fatal log level.
      *
      * @param message log this message
      * @param t log this cause
      */
     public void fatal(Object message, Throwable t);
-
-
 }

--- a/jcl-over-slf4j/src/main/java/org/apache/commons/logging/LogConfigurationException.java
+++ b/jcl-over-slf4j/src/main/java/org/apache/commons/logging/LogConfigurationException.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -17,77 +18,63 @@
 package org.apache.commons.logging;
 
 /**
- * <p>
- * An exception that is thrown only if a suitable <code>LogFactory</code> or
- * <code>Log</code> instance cannot be created by the corresponding factory
- * methods.
- * </p>
- * 
- * <p>
- * In this version of JCL, this exception will never be thrown in practice.
- * However, it is included here to ensure total compile time and run time
- * compatibility with the original JCL 1.0.4.
- * 
- * @author Craig R. McClanahan
+ * An exception that is thrown only if a suitable <code>LogFactory</code>
+ * or <code>Log</code> instance cannot be created by the corresponding
+ * factory methods.
+ *
+ * @version $Id$
  */
-
 public class LogConfigurationException extends RuntimeException {
 
-  private static final long serialVersionUID = 8486587136871052495L;
+    /** Serializable version identifier. */
+    private static final long serialVersionUID = 8486587136871052495L;
 
-  /**
-   * Construct a new exception with <code>null</code> as its detail message.
-   */
-  public LogConfigurationException() {
-    super();
-  }
+    /**
+     * Construct a new exception with <code>null</code> as its detail message.
+     */
+    public LogConfigurationException() {
+        super();
+    }
 
-  /**
-   * Construct a new exception with the specified detail message.
-   * 
-   * @param message
-   *          The detail message
-   */
-  public LogConfigurationException(String message) {
-    super(message);
-  }
+    /**
+     * Construct a new exception with the specified detail message.
+     *
+     * @param message The detail message
+     */
+    public LogConfigurationException(String message) {
+        super(message);
+    }
 
-  /**
-   * Construct a new exception with the specified cause and a derived detail
-   * message.
-   * 
-   * @param cause
-   *          The underlying cause
-   */
-  public LogConfigurationException(Throwable cause) {
+    /**
+     * Construct a new exception with the specified cause and a derived
+     * detail message.
+     *
+     * @param cause The underlying cause
+     */
+    public LogConfigurationException(Throwable cause) {
+        this(cause == null ? null : cause.toString(), cause);
+    }
 
-    this((cause == null) ? null : cause.toString(), cause);
+    /**
+     * Construct a new exception with the specified detail message and cause.
+     *
+     * @param message The detail message
+     * @param cause The underlying cause
+     */
+    public LogConfigurationException(String message, Throwable cause) {
+        super(message + " (Caused by " + cause + ")");
+        this.cause = cause; // Two-argument version requires JDK 1.4 or later
+    }
 
-  }
+    /**
+     * The underlying cause of this exception.
+     */
+    protected Throwable cause = null;
 
-  /**
-   * Construct a new exception with the specified detail message and cause.
-   * 
-   * @param message
-   *          The detail message
-   * @param cause
-   *          The underlying cause
-   */
-  public LogConfigurationException(String message, Throwable cause) {
-    super(message + " (Caused by " + cause + ")");
-    this.cause = cause; // Two-argument version requires JDK 1.4 or later
-  }
-
-  /**
-   * The underlying cause of this exception.
-   */
-  protected Throwable cause = null;
-
-  /**
-   * Return the underlying cause of this exception (if any).
-   */
-  public Throwable getCause() {
-    return (this.cause);
-  }
-
+    /**
+     * Return the underlying cause of this exception (if any).
+     */
+    public Throwable getCause() {
+        return this.cause;
+    }
 }

--- a/jcl-over-slf4j/src/main/java/org/apache/commons/logging/LogFactory.java
+++ b/jcl-over-slf4j/src/main/java/org/apache/commons/logging/LogFactory.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -16,406 +17,1730 @@
 
 package org.apache.commons.logging;
 
+import java.io.BufferedReader;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLConnection;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Enumeration;
 import java.util.Hashtable;
-
-import org.apache.commons.logging.impl.SLF4JLogFactory;
+import java.util.Properties;
 
 /**
+ * Factory for creating {@link Log} instances, with discovery and
+ * configuration features similar to that employed by standard Java APIs
+ * such as JAXP.
  * <p>
- * Factory for creating {@link Log} instances, which always delegates to an
- * instance of {@link SLF4JLogFactory}.
- * 
- * </p>
- * 
- * @author Craig R. McClanahan
- * @author Costin Manolache
- * @author Richard A. Sitze
- * @author Ceki G&uuml;lc&uuml;
+ * <strong>IMPLEMENTATION NOTE</strong> - This implementation is heavily
+ * based on the SAXParserFactory and DocumentBuilderFactory implementations
+ * (corresponding to the JAXP pluggability APIs) found in Apache Xerces.
+ *
+ * @version $Id$
  */
-
 public abstract class LogFactory {
+    // Implementation note re AccessController usage
+    //
+    // It is important to keep code invoked via an AccessController to small
+    // auditable blocks. Such code must carefully evaluate all user input
+    // (parameters, system properties, config file contents, etc). As an
+    // example, a Log implementation should not write to its logfile
+    // with an AccessController anywhere in the call stack, otherwise an
+    // insecure application could configure the log implementation to write
+    // to a protected file using the privileges granted to JCL rather than
+    // to the calling application.
+    //
+    // Under no circumstance should a non-private method return data that is
+    // retrieved via an AccessController. That would allow an insecure app
+    // to invoke that method and obtain data that it is not permitted to have.
+    //
+    // Invoking user-supplied code with an AccessController set is not a major
+    // issue (eg invoking the constructor of the class specified by
+    // HASHTABLE_IMPLEMENTATION_PROPERTY). That class will be in a different
+    // trust domain, and therefore must have permissions to do whatever it
+    // is trying to do regardless of the permissions granted to JCL. There is
+    // a slight issue in that untrusted code may point that environment var
+    // to another trusted library, in which case the code runs if both that
+    // lib and JCL have the necessary permissions even when the untrusted
+    // caller does not. That's a pretty hard route to exploit though.
 
-  static String UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J = "http://www.slf4j.org/codes.html#unsupported_operation_in_jcl_over_slf4j";
+    // ----------------------------------------------------- Manifest Constants
 
-  static LogFactory logFactory = new SLF4JLogFactory();
+    /**
+     * The name (<code>priority</code>) of the key in the config file used to
+     * specify the priority of that particular config file. The associated value
+     * is a floating-point number; higher values take priority over lower values.
+     */
+    public static final String PRIORITY_KEY = "priority";
 
-  /**
-   * The name (<code>priority</code>) of the key in the config file used to
-   * specify the priority of that particular config file. The associated value
-   * is a floating-point number; higher values take priority over lower values.
-   * 
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  public static final String PRIORITY_KEY = "priority";
+    /**
+     * The name (<code>use_tccl</code>) of the key in the config file used
+     * to specify whether logging classes should be loaded via the thread
+     * context class loader (TCCL), or not. By default, the TCCL is used.
+     */
+    public static final String TCCL_KEY = "use_tccl";
 
-  /**
-   * The name (<code>use_tccl</code>) of the key in the config file used to
-   * specify whether logging classes should be loaded via the thread context
-   * class loader (TCCL), or not. By default, the TCCL is used.
-   * 
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  public static final String TCCL_KEY = "use_tccl";
+    /**
+     * The name (<code>org.apache.commons.logging.LogFactory</code>) of the property
+     * used to identify the LogFactory implementation
+     * class name. This can be used as a system property, or as an entry in a
+     * configuration properties file.
+     */
+    public static final String FACTORY_PROPERTY = "org.apache.commons.logging.LogFactory";
 
-  /**
-   * The name of the property used to identify the LogFactory implementation
-   * class name.
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  public static final String FACTORY_PROPERTY = "org.apache.commons.logging.LogFactory";
+    /**
+     * The fully qualified class name of the fallback <code>LogFactory</code>
+     * implementation class to use, if no other can be found.
+     */
+    public static final String FACTORY_DEFAULT = "org.apache.commons.logging.impl.LogFactoryImpl";
 
-  /**
-   * The fully qualified class name of the fallback <code>LogFactory</code>
-   * implementation class to use, if no other can be found.
-   * 
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  public static final String FACTORY_DEFAULT = "org.apache.commons.logging.impl.SLF4JLogFactory";
+    /**
+     * The name (<code>commons-logging.properties</code>) of the properties file to search for.
+     */
+    public static final String FACTORY_PROPERTIES = "commons-logging.properties";
 
-  /**
-   * The name of the properties file to search for.
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  public static final String FACTORY_PROPERTIES = "commons-logging.properties";
+    /**
+     * JDK1.3+ <a href="http://java.sun.com/j2se/1.3/docs/guide/jar/jar.html#Service%20Provider">
+     * 'Service Provider' specification</a>.
+     */
+    protected static final String SERVICE_ID =
+        "META-INF/services/org.apache.commons.logging.LogFactory";
 
-  
-  /**
-   * JDK1.3+ <a href="http://java.sun.com/j2se/1.3/docs/guide/jar/jar.html#Service%20Provider">
-   * 'Service Provider' specification</a>.
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  protected static final String SERVICE_ID =
-      "META-INF/services/org.apache.commons.logging.LogFactory";
-  
-  /**
-   * The name (<code>org.apache.commons.logging.diagnostics.dest</code>) of
-   * the property used to enable internal commons-logging diagnostic output, in
-   * order to get information on what logging implementations are being
-   * discovered, what classloaders they are loaded through, etc.
-   * 
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  public static final String DIAGNOSTICS_DEST_PROPERTY = "org.apache.commons.logging.diagnostics.dest";
+    /**
+     * The name (<code>org.apache.commons.logging.diagnostics.dest</code>)
+     * of the property used to enable internal commons-logging
+     * diagnostic output, in order to get information on what logging
+     * implementations are being discovered, what classloaders they
+     * are loaded through, etc.
+     * <p>
+     * If a system property of this name is set then the value is
+     * assumed to be the name of a file. The special strings
+     * STDOUT or STDERR (case-sensitive) indicate output to
+     * System.out and System.err respectively.
+     * <p>
+     * Diagnostic logging should be used only to debug problematic
+     * configurations and should not be set in normal production use.
+     */
+    public static final String DIAGNOSTICS_DEST_PROPERTY =
+        "org.apache.commons.logging.diagnostics.dest";
 
-  /**
-   * <p>
-   * Setting this system property value allows the <code>Hashtable</code> used
-   * to store classloaders to be substituted by an alternative implementation.
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  public static final String HASHTABLE_IMPLEMENTATION_PROPERTY = "org.apache.commons.logging.LogFactory.HashtableImpl";
-  
-  /**
-   * The previously constructed <code>LogFactory</code> instances, keyed by
-   * the <code>ClassLoader</code> with which it was created.
-   * 
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  protected static Hashtable factories = null;
-  
-  /**
-   * <p>
-   * This property is not used but preserved here for compatibility.
-   */
-  protected static LogFactory nullClassLoaderFactory = null;
+    /**
+     * When null (the usual case), no diagnostic output will be
+     * generated by LogFactory or LogFactoryImpl. When non-null,
+     * interesting events will be written to the specified object.
+     */
+    private static PrintStream diagnosticsStream = null;
 
-  /**
-   * Protected constructor that is not available for public use.
-   */
-  protected LogFactory() {
-  }
+    /**
+     * A string that gets prefixed to every message output by the
+     * logDiagnostic method, so that users can clearly see which
+     * LogFactory class is generating the output.
+     */
+    private static final String diagnosticPrefix;
 
-  // --------------------------------------------------------- Public Methods
+    /**
+     * Setting this system property
+     * (<code>org.apache.commons.logging.LogFactory.HashtableImpl</code>)
+     * value allows the <code>Hashtable</code> used to store
+     * classloaders to be substituted by an alternative implementation.
+     * <p>
+     * <strong>Note:</strong> <code>LogFactory</code> will print:
+     * <code><pre>
+     * [ERROR] LogFactory: Load of custom hashtable failed</em>
+     * </pre></code>
+     * to system error and then continue using a standard Hashtable.
+     * <p>
+     * <strong>Usage:</strong> Set this property when Java is invoked
+     * and <code>LogFactory</code> will attempt to load a new instance
+     * of the given implementation class.
+     * For example, running the following ant scriplet:
+     * <code><pre>
+     *  &lt;java classname="${test.runner}" fork="yes" failonerror="${test.failonerror}"&gt;
+     *     ...
+     *     &lt;sysproperty
+     *        key="org.apache.commons.logging.LogFactory.HashtableImpl"
+     *        value="org.apache.commons.logging.AltHashtable"/&gt;
+     *  &lt;/java&gt;
+     * </pre></code>
+     * will mean that <code>LogFactory</code> will load an instance of
+     * <code>org.apache.commons.logging.AltHashtable</code>.
+     * <p>
+     * A typical use case is to allow a custom
+     * Hashtable implementation using weak references to be substituted.
+     * This will allow classloaders to be garbage collected without
+     * the need to release them (on 1.3+ JVMs only, of course ;).
+     */
+    public static final String HASHTABLE_IMPLEMENTATION_PROPERTY =
+        "org.apache.commons.logging.LogFactory.HashtableImpl";
 
-  /**
-   * Return the configuration attribute with the specified name (if any), or
-   * <code>null</code> if there is no such attribute.
-   * 
-   * @param name Name of the attribute to return
-   * @return configuration attribute
-   */
-  public abstract Object getAttribute(String name);
+    /** Name used to load the weak hashtable implementation by names. */
+    private static final String WEAK_HASHTABLE_CLASSNAME =
+        "org.apache.commons.logging.impl.WeakHashtable";
 
-  /**
-   * Return an array containing the names of all currently defined configuration
-   * attributes. If there are no such attributes, a zero length array is
-   * returned.
-   * 
-   * @return names of all currently defined configuration attributes
-   */
-  public abstract String[] getAttributeNames();
+    /**
+     * A reference to the classloader that loaded this class. This is the
+     * same as LogFactory.class.getClassLoader(). However computing this
+     * value isn't quite as simple as that, as we potentially need to use
+     * AccessControllers etc. It's more efficient to compute it once and
+     * cache it here.
+     */
+    private static final ClassLoader thisClassLoader;
 
-  /**
-   * Convenience method to derive a name from the specified class and call
-   * <code>getInstance(String)</code> with it.
-   * 
-   * @param clazz
-   *                Class for which a suitable Log name will be derived
-   * 
-   * @exception LogConfigurationException
-   *                    if a suitable <code>Log</code> instance cannot be
-   *                    returned
-   */
-  public abstract Log getInstance(Class clazz) throws LogConfigurationException;
+    // ----------------------------------------------------------- Constructors
 
-  /**
-   * <p>
-   * Construct (if necessary) and return a <code>Log</code> instance, using
-   * the factory's current set of configuration attributes.
-   * </p>
-   * 
-   * <p>
-   * <strong>NOTE </strong>- Depending upon the implementation of the
-   * <code>LogFactory</code> you are using, the <code>Log</code> instance
-   * you are returned may or may not be local to the current application, and
-   * may or may not be returned again on a subsequent call with the same name
-   * argument.
-   * </p>
-   * 
-   * @param name
-   *                Logical name of the <code>Log</code> instance to be
-   *                returned (the meaning of this name is only known to the
-   *                underlying logging implementation that is being wrapped)
-   * 
-   * @exception LogConfigurationException
-   *                    if a suitable <code>Log</code> instance cannot be
-   *                    returned
-   */
-  public abstract Log getInstance(String name) throws LogConfigurationException;
-
-  /**
-   * Release any internal references to previously created {@link Log}instances
-   * returned by this factory. This is useful in environments like servlet
-   * containers, which implement application reloading by throwing away a
-   * ClassLoader. Dangling references to objects in that class loader would
-   * prevent garbage collection.
-   */
-  public abstract void release();
-
-  /**
-   * Remove any configuration attribute associated with the specified name. If
-   * there is no such attribute, no action is taken.
-   * 
-   * @param name
-   *                Name of the attribute to remove
-   */
-  public abstract void removeAttribute(String name);
-
-  /**
-   * Set the configuration attribute with the specified name. Calling this with
-   * a <code>null</code> value is equivalent to calling
-   * <code>removeAttribute(name)</code>.
-   * 
-   * @param name
-   *                Name of the attribute to set
-   * @param value
-   *                Value of the attribute to set, or <code>null</code> to
-   *                remove any setting for this attribute
-   */
-  public abstract void setAttribute(String name, Object value);
-
-  // --------------------------------------------------------- Static Methods
-
-  /**
-   * <p>
-   * Construct (if necessary) and return a <code>LogFactory</code> instance,
-   * using the following ordered lookup procedure to determine the name of the
-   * implementation class to be loaded.
-   * </p>
-   * <ul>
-   * <li>The <code>org.apache.commons.logging.LogFactory</code> system
-   * property.</li>
-   * <li>The JDK 1.3 Service Discovery mechanism</li>
-   * <li>Use the properties file <code>commons-logging.properties</code>
-   * file, if found in the class path of this class. The configuration file is
-   * in standard <code>java.util.Properties</code> format and contains the
-   * fully qualified name of the implementation class with the key being the
-   * system property defined above.</li>
-   * <li>Fall back to a default implementation class (
-   * <code>org.apache.commons.logging.impl.SLF4FLogFactory</code>).</li>
-   * </ul>
-   * 
-   * <p>
-   * <em>NOTE</em>- If the properties file method of identifying the
-   * <code>LogFactory</code> implementation class is utilized, all of the
-   * properties defined in this file will be set as configuration attributes on
-   * the corresponding <code>LogFactory</code> instance.
-   * </p>
-   * 
-   * @exception LogConfigurationException
-   *                    if the implementation class is not available or cannot
-   *                    be instantiated.
-   */
-  public static LogFactory getFactory() throws LogConfigurationException {
-    return logFactory;
-  }
-
-  /**
-   * Convenience method to return a named logger, without the application having
-   * to care about factories.
-   * 
-   * @param clazz
-   *                Class from which a log name will be derived
-   * 
-   * @exception LogConfigurationException
-   *                    if a suitable <code>Log</code> instance cannot be
-   *                    returned
-   */
-  public static Log getLog(Class clazz) throws LogConfigurationException {
-    return (getFactory().getInstance(clazz));
-  }
-
-  /**
-   * Convenience method to return a named logger, without the application having
-   * to care about factories.
-   * 
-   * @param name
-   *                Logical name of the <code>Log</code> instance to be
-   *                returned (the meaning of this name is only known to the
-   *                underlying logging implementation that is being wrapped)
-   * 
-   * @exception LogConfigurationException
-   *                    if a suitable <code>Log</code> instance cannot be
-   *                    returned
-   */
-  public static Log getLog(String name) throws LogConfigurationException {
-    return (getFactory().getInstance(name));
-  }
-
-  /**
-   * Release any internal references to previously created {@link LogFactory}
-   * instances that have been associated with the specified class loader (if
-   * any), after calling the instance method <code>release()</code> on each of
-   * them.
-   * 
-   * @param classLoader
-   *                ClassLoader for which to release the LogFactory
-   */
-  public static void release(ClassLoader classLoader) {
-    // since SLF4J based JCL does not make use of classloaders, there is nothing
-    // to do here
-  }
-
-  /**
-   * Release any internal references to previously created {@link LogFactory}
-   * instances, after calling the instance method <code>release()</code> on
-   * each of them. This is useful in environments like servlet containers, which
-   * implement application reloading by throwing away a ClassLoader. Dangling
-   * references to objects in that class loader would prevent garbage
-   * collection.
-   */
-  public static void releaseAll() {
-    // since SLF4J based JCL does not make use of classloaders, there is nothing
-    // to do here
-  }
-
-  /**
-   * Returns a string that uniquely identifies the specified object, including
-   * its class.
-   * <p>
-   * The returned string is of form "classname@hashcode", ie is the same as the
-   * return value of the Object.toString() method, but works even when the
-   * specified object's class has overidden the toString method.
-   * 
-   * @param o
-   *                may be null.
-   * @return a string of form classname@hashcode, or "null" if param o is null.
-   * @since 1.1
-   */
-  public static String objectId(Object o) {
-    if (o == null) {
-      return "null";
-    } else {
-      return o.getClass().getName() + "@" + System.identityHashCode(o);
+    /**
+     * Protected constructor that is not available for public use.
+     */
+    protected LogFactory() {
     }
-  }
 
-  // protected methods which were added in JCL 1.1. These are not used
-  // by SLF4JLogFactory
+    // --------------------------------------------------------- Public Methods
 
-  /**
-   * This method exists to ensure signature compatibility.
-   */
-  protected static Object createFactory(String factoryClass, ClassLoader classLoader) {
-    throw new UnsupportedOperationException(
-        "Operation [factoryClass] is not supported in jcl-over-slf4j. See also "
-            + UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J);
-  }
+    /**
+     * Return the configuration attribute with the specified name (if any),
+     * or <code>null</code> if there is no such attribute.
+     *
+     * @param name Name of the attribute to return
+     */
+    public abstract Object getAttribute(String name);
 
-  /**
-   * This method exists to ensure signature compatibility.
-   */
-  protected static ClassLoader directGetContextClassLoader() {
-    throw new UnsupportedOperationException(
-        "Operation [directGetContextClassLoader] is not supported in jcl-over-slf4j. See also "
-            + UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J);
-  }
+    /**
+     * Return an array containing the names of all currently defined
+     * configuration attributes.  If there are no such attributes, a zero
+     * length array is returned.
+     */
+    public abstract String[] getAttributeNames();
 
-  /**
-   * This method exists to ensure signature compatibility.
-   */
-  protected static ClassLoader getContextClassLoader()
-      throws LogConfigurationException {
-    throw new UnsupportedOperationException(
-        "Operation [getContextClassLoader] is not supported in jcl-over-slf4j. See also "
-            + UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J);
-  }
-  
-  /**
-   * This method exists to ensure signature compatibility.
-   */
-  protected static ClassLoader getClassLoader(Class clazz) {
-    throw new UnsupportedOperationException(
-        "Operation [getClassLoader] is not supported in jcl-over-slf4j. See also "
-            + UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J);
-  }
+    /**
+     * Convenience method to derive a name from the specified class and
+     * call <code>getInstance(String)</code> with it.
+     *
+     * @param clazz Class for which a suitable Log name will be derived
+     * @throws LogConfigurationException if a suitable <code>Log</code>
+     *  instance cannot be returned
+     */
+    public abstract Log getInstance(Class clazz)
+        throws LogConfigurationException;
 
-  /**
-   * This method exists to ensure signature compatibility.
-   */
-  protected static boolean isDiagnosticsEnabled() {
-    throw new UnsupportedOperationException(
-        "Operation [isDiagnosticsEnabled] is not supported in jcl-over-slf4j. See also "
-            + UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J);
-  }
-  
-  /**
-   * This method exists to ensure signature compatibility.
-   */
-  protected static void logRawDiagnostic(String msg) {
-    throw new UnsupportedOperationException(
-        "Operation [logRawDiagnostic] is not supported in jcl-over-slf4j. See also "
-            + UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J);
-  }
-  
-  /**
-   * This method exists to ensure signature compatibility.
-   */
-  protected static LogFactory newFactory(final String factoryClass,
-      final ClassLoader classLoader, final ClassLoader contextClassLoader) {
-    throw new UnsupportedOperationException(
-        "Operation [logRawDiagnostic] is not supported in jcl-over-slf4j. See also "
-            + UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J);
-  }
- 
-  /**
-   * This method exists to ensure signature compatibility.
-   */
-  protected static LogFactory newFactory(final String factoryClass,
-                                         final ClassLoader classLoader) {
-    throw new UnsupportedOperationException(
-        "Operation [newFactory] is not supported in jcl-over-slf4j. See also "
-            + UNSUPPORTED_OPERATION_IN_JCL_OVER_SLF4J);
-  }
+    /**
+     * Construct (if necessary) and return a <code>Log</code> instance,
+     * using the factory's current set of configuration attributes.
+     * <p>
+     * <strong>NOTE</strong> - Depending upon the implementation of
+     * the <code>LogFactory</code> you are using, the <code>Log</code>
+     * instance you are returned may or may not be local to the current
+     * application, and may or may not be returned again on a subsequent
+     * call with the same name argument.
+     *
+     * @param name Logical name of the <code>Log</code> instance to be
+     *  returned (the meaning of this name is only known to the underlying
+     *  logging implementation that is being wrapped)
+     * @throws LogConfigurationException if a suitable <code>Log</code>
+     *  instance cannot be returned
+     */
+    public abstract Log getInstance(String name)
+        throws LogConfigurationException;
 
+    /**
+     * Release any internal references to previously created {@link Log}
+     * instances returned by this factory.  This is useful in environments
+     * like servlet containers, which implement application reloading by
+     * throwing away a ClassLoader.  Dangling references to objects in that
+     * class loader would prevent garbage collection.
+     */
+    public abstract void release();
 
+    /**
+     * Remove any configuration attribute associated with the specified name.
+     * If there is no such attribute, no action is taken.
+     *
+     * @param name Name of the attribute to remove
+     */
+    public abstract void removeAttribute(String name);
+
+    /**
+     * Set the configuration attribute with the specified name.  Calling
+     * this with a <code>null</code> value is equivalent to calling
+     * <code>removeAttribute(name)</code>.
+     *
+     * @param name Name of the attribute to set
+     * @param value Value of the attribute to set, or <code>null</code>
+     *  to remove any setting for this attribute
+     */
+    public abstract void setAttribute(String name, Object value);
+
+    // ------------------------------------------------------- Static Variables
+
+    /**
+     * The previously constructed <code>LogFactory</code> instances, keyed by
+     * the <code>ClassLoader</code> with which it was created.
+     */
+    protected static Hashtable factories = null;
+
+    /**
+     * Previously constructed <code>LogFactory</code> instance as in the
+     * <code>factories</code> map, but for the case where
+     * <code>getClassLoader</code> returns <code>null</code>.
+     * This can happen when:
+     * <ul>
+     * <li>using JDK1.1 and the calling code is loaded via the system
+     *  classloader (very common)</li>
+     * <li>using JDK1.2+ and the calling code is loaded via the boot
+     *  classloader (only likely for embedded systems work).</li>
+     * </ul>
+     * Note that <code>factories</code> is a <i>Hashtable</i> (not a HashMap),
+     * and hashtables don't allow null as a key.
+     * @deprecated since 1.1.2
+     */
+    protected static volatile LogFactory nullClassLoaderFactory = null;
+
+    /**
+     * Create the hashtable which will be used to store a map of
+     * (context-classloader -> logfactory-object). Version 1.2+ of Java
+     * supports "weak references", allowing a custom Hashtable class
+     * to be used which uses only weak references to its keys. Using weak
+     * references can fix memory leaks on webapp unload in some cases (though
+     * not all). Version 1.1 of Java does not support weak references, so we
+     * must dynamically determine which we are using. And just for fun, this
+     * code also supports the ability for a system property to specify an
+     * arbitrary Hashtable implementation name.
+     * <p>
+     * Note that the correct way to ensure no memory leaks occur is to ensure
+     * that LogFactory.release(contextClassLoader) is called whenever a
+     * webapp is undeployed.
+     */
+    private static final Hashtable createFactoryStore() {
+        Hashtable result = null;
+        String storeImplementationClass;
+        try {
+            storeImplementationClass = getSystemProperty(HASHTABLE_IMPLEMENTATION_PROPERTY, null);
+        } catch (SecurityException ex) {
+            // Permissions don't allow this to be accessed. Default to the "modern"
+            // weak hashtable implementation if it is available.
+            storeImplementationClass = null;
+        }
+
+        if (storeImplementationClass == null) {
+            storeImplementationClass = WEAK_HASHTABLE_CLASSNAME;
+        }
+        try {
+            Class implementationClass = Class.forName(storeImplementationClass);
+            result = (Hashtable) implementationClass.newInstance();
+        } catch (Throwable t) {
+            handleThrowable(t); // may re-throw t
+
+            // ignore
+            if (!WEAK_HASHTABLE_CLASSNAME.equals(storeImplementationClass)) {
+                // if the user's trying to set up a custom implementation, give a clue
+                if (isDiagnosticsEnabled()) {
+                    // use internal logging to issue the warning
+                    logDiagnostic("[ERROR] LogFactory: Load of custom hashtable failed");
+                } else {
+                    // we *really* want this output, even if diagnostics weren't
+                    // explicitly enabled by the user.
+                    System.err.println("[ERROR] LogFactory: Load of custom hashtable failed");
+                }
+            }
+        }
+        if (result == null) {
+            result = new Hashtable();
+        }
+        return result;
+    }
+
+    // --------------------------------------------------------- Static Methods
+
+    /** Utility method to safely trim a string. */
+    private static String trim(String src) {
+        if (src == null) {
+            return null;
+        }
+        return src.trim();
+    }
+
+    /**
+     * Checks whether the supplied Throwable is one that needs to be
+     * re-thrown and ignores all others.
+     *
+     * The following errors are re-thrown:
+     * <ul>
+     *   <li>ThreadDeath</li>
+     *   <li>VirtualMachineError</li>
+     * </ul>
+     *
+     * @param t the Throwable to check
+     */
+    protected static void handleThrowable(Throwable t) {
+        if (t instanceof ThreadDeath) {
+            throw (ThreadDeath) t;
+        }
+        if (t instanceof VirtualMachineError) {
+            throw (VirtualMachineError) t;
+        }
+        // All other instances of Throwable will be silently ignored
+    }
+
+    /**
+     * Construct (if necessary) and return a <code>LogFactory</code>
+     * instance, using the following ordered lookup procedure to determine
+     * the name of the implementation class to be loaded.
+     * <p>
+     * <ul>
+     * <li>The <code>org.apache.commons.logging.LogFactory</code> system
+     *     property.</li>
+     * <li>The JDK 1.3 Service Discovery mechanism</li>
+     * <li>Use the properties file <code>commons-logging.properties</code>
+     *     file, if found in the class path of this class.  The configuration
+     *     file is in standard <code>java.util.Properties</code> format and
+     *     contains the fully qualified name of the implementation class
+     *     with the key being the system property defined above.</li>
+     * <li>Fall back to a default implementation class
+     *     (<code>org.apache.commons.logging.impl.LogFactoryImpl</code>).</li>
+     * </ul>
+     * <p>
+     * <em>NOTE</em> - If the properties file method of identifying the
+     * <code>LogFactory</code> implementation class is utilized, all of the
+     * properties defined in this file will be set as configuration attributes
+     * on the corresponding <code>LogFactory</code> instance.
+     * <p>
+     * <em>NOTE</em> - In a multi-threaded environment it is possible
+     * that two different instances will be returned for the same
+     * classloader environment.
+     *
+     * @throws LogConfigurationException if the implementation class is not
+     *  available or cannot be instantiated.
+     */
+    public static LogFactory getFactory() throws LogConfigurationException {
+        // Identify the class loader we will be using
+        ClassLoader contextClassLoader = getContextClassLoaderInternal();
+
+        if (contextClassLoader == null) {
+            // This is an odd enough situation to report about. This
+            // output will be a nuisance on JDK1.1, as the system
+            // classloader is null in that environment.
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("Context classloader is null.");
+            }
+        }
+
+        // Return any previously registered factory for this class loader
+        LogFactory factory = getCachedFactory(contextClassLoader);
+        if (factory != null) {
+            return factory;
+        }
+
+        if (isDiagnosticsEnabled()) {
+            logDiagnostic(
+                    "[LOOKUP] LogFactory implementation requested for the first time for context classloader " +
+                    objectId(contextClassLoader));
+            logHierarchy("[LOOKUP] ", contextClassLoader);
+        }
+
+        // Load properties file.
+        //
+        // If the properties file exists, then its contents are used as
+        // "attributes" on the LogFactory implementation class. One particular
+        // property may also control which LogFactory concrete subclass is
+        // used, but only if other discovery mechanisms fail..
+        //
+        // As the properties file (if it exists) will be used one way or
+        // another in the end we may as well look for it first.
+
+        Properties props = getConfigurationFile(contextClassLoader, FACTORY_PROPERTIES);
+
+        // Determine whether we will be using the thread context class loader to
+        // load logging classes or not by checking the loaded properties file (if any).
+        ClassLoader baseClassLoader = contextClassLoader;
+        if (props != null) {
+            String useTCCLStr = props.getProperty(TCCL_KEY);
+            if (useTCCLStr != null) {
+                // The Boolean.valueOf(useTCCLStr).booleanValue() formulation
+                // is required for Java 1.2 compatibility.
+                if (Boolean.valueOf(useTCCLStr).booleanValue() == false) {
+                    // Don't use current context classloader when locating any
+                    // LogFactory or Log classes, just use the class that loaded
+                    // this abstract class. When this class is deployed in a shared
+                    // classpath of a container, it means webapps cannot deploy their
+                    // own logging implementations. It also means that it is up to the
+                    // implementation whether to load library-specific config files
+                    // from the TCCL or not.
+                    baseClassLoader = thisClassLoader;
+                }
+            }
+        }
+
+        // Determine which concrete LogFactory subclass to use.
+        // First, try a global system property
+        if (isDiagnosticsEnabled()) {
+            logDiagnostic("[LOOKUP] Looking for system property [" + FACTORY_PROPERTY +
+                          "] to define the LogFactory subclass to use...");
+        }
+
+        try {
+            String factoryClass = getSystemProperty(FACTORY_PROPERTY, null);
+            if (factoryClass != null) {
+                if (isDiagnosticsEnabled()) {
+                    logDiagnostic("[LOOKUP] Creating an instance of LogFactory class '" + factoryClass +
+                                  "' as specified by system property " + FACTORY_PROPERTY);
+                }
+                factory = newFactory(factoryClass, baseClassLoader, contextClassLoader);
+            } else {
+                if (isDiagnosticsEnabled()) {
+                    logDiagnostic("[LOOKUP] No system property [" + FACTORY_PROPERTY + "] defined.");
+                }
+            }
+        } catch (SecurityException e) {
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("[LOOKUP] A security exception occurred while trying to create an" +
+                              " instance of the custom factory class" + ": [" + trim(e.getMessage()) +
+                              "]. Trying alternative implementations...");
+            }
+            // ignore
+        } catch (RuntimeException e) {
+            // This is not consistent with the behaviour when a bad LogFactory class is
+            // specified in a services file.
+            //
+            // One possible exception that can occur here is a ClassCastException when
+            // the specified class wasn't castable to this LogFactory type.
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("[LOOKUP] An exception occurred while trying to create an" +
+                              " instance of the custom factory class" + ": [" +
+                              trim(e.getMessage()) +
+                              "] as specified by a system property.");
+            }
+            throw e;
+        }
+
+        // Second, try to find a service by using the JDK1.3 class
+        // discovery mechanism, which involves putting a file with the name
+        // of an interface class in the META-INF/services directory, where the
+        // contents of the file is a single line specifying a concrete class
+        // that implements the desired interface.
+
+        if (factory == null) {
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("[LOOKUP] Looking for a resource file of name [" + SERVICE_ID +
+                              "] to define the LogFactory subclass to use...");
+            }
+            try {
+                final InputStream is = getResourceAsStream(contextClassLoader, SERVICE_ID);
+
+                if( is != null ) {
+                    // This code is needed by EBCDIC and other strange systems.
+                    // It's a fix for bugs reported in xerces
+                    BufferedReader rd;
+                    try {
+                        rd = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+                    } catch (java.io.UnsupportedEncodingException e) {
+                        rd = new BufferedReader(new InputStreamReader(is));
+                    }
+
+                    String factoryClassName = rd.readLine();
+                    rd.close();
+
+                    if (factoryClassName != null && ! "".equals(factoryClassName)) {
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic("[LOOKUP]  Creating an instance of LogFactory class " +
+                                          factoryClassName +
+                                          " as specified by file '" + SERVICE_ID +
+                                          "' which was present in the path of the context classloader.");
+                        }
+                        factory = newFactory(factoryClassName, baseClassLoader, contextClassLoader );
+                    }
+                } else {
+                    // is == null
+                    if (isDiagnosticsEnabled()) {
+                        logDiagnostic("[LOOKUP] No resource file with name '" + SERVICE_ID + "' found.");
+                    }
+                }
+            } catch (Exception ex) {
+                // note: if the specified LogFactory class wasn't compatible with LogFactory
+                // for some reason, a ClassCastException will be caught here, and attempts will
+                // continue to find a compatible class.
+                if (isDiagnosticsEnabled()) {
+                    logDiagnostic(
+                        "[LOOKUP] A security exception occurred while trying to create an" +
+                        " instance of the custom factory class" +
+                        ": [" + trim(ex.getMessage()) +
+                        "]. Trying alternative implementations...");
+                }
+                // ignore
+            }
+        }
+
+        // Third try looking into the properties file read earlier (if found)
+
+        if (factory == null) {
+            if (props != null) {
+                if (isDiagnosticsEnabled()) {
+                    logDiagnostic(
+                        "[LOOKUP] Looking in properties file for entry with key '" + FACTORY_PROPERTY +
+                        "' to define the LogFactory subclass to use...");
+                }
+                String factoryClass = props.getProperty(FACTORY_PROPERTY);
+                if (factoryClass != null) {
+                    if (isDiagnosticsEnabled()) {
+                        logDiagnostic(
+                            "[LOOKUP] Properties file specifies LogFactory subclass '" + factoryClass + "'");
+                    }
+                    factory = newFactory(factoryClass, baseClassLoader, contextClassLoader);
+
+                    // TODO: think about whether we need to handle exceptions from newFactory
+                } else {
+                    if (isDiagnosticsEnabled()) {
+                        logDiagnostic("[LOOKUP] Properties file has no entry specifying LogFactory subclass.");
+                    }
+                }
+            } else {
+                if (isDiagnosticsEnabled()) {
+                    logDiagnostic("[LOOKUP] No properties file available to determine" + " LogFactory subclass from..");
+                }
+            }
+        }
+
+        // Fourth, try the fallback implementation class
+
+        if (factory == null) {
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic(
+                    "[LOOKUP] Loading the default LogFactory implementation '" + FACTORY_DEFAULT +
+                    "' via the same classloader that loaded this LogFactory" +
+                    " class (ie not looking in the context classloader).");
+            }
+
+            // Note: unlike the above code which can try to load custom LogFactory
+            // implementations via the TCCL, we don't try to load the default LogFactory
+            // implementation via the context classloader because:
+            // * that can cause problems (see comments in newFactory method)
+            // * no-one should be customising the code of the default class
+            // Yes, we do give up the ability for the child to ship a newer
+            // version of the LogFactoryImpl class and have it used dynamically
+            // by an old LogFactory class in the parent, but that isn't
+            // necessarily a good idea anyway.
+            factory = newFactory(FACTORY_DEFAULT, thisClassLoader, contextClassLoader);
+        }
+
+        if (factory != null) {
+            /**
+             * Always cache using context class loader.
+             */
+            cacheFactory(contextClassLoader, factory);
+
+            if (props != null) {
+                Enumeration names = props.propertyNames();
+                while (names.hasMoreElements()) {
+                    String name = (String) names.nextElement();
+                    String value = props.getProperty(name);
+                    factory.setAttribute(name, value);
+                }
+            }
+        }
+
+        return factory;
+    }
+
+    /**
+     * Convenience method to return a named logger, without the application
+     * having to care about factories.
+     *
+     * @param clazz Class from which a log name will be derived
+     * @throws LogConfigurationException if a suitable <code>Log</code>
+     *  instance cannot be returned
+     */
+    public static Log getLog(Class clazz) throws LogConfigurationException {
+        return getFactory().getInstance(clazz);
+    }
+
+    /**
+     * Convenience method to return a named logger, without the application
+     * having to care about factories.
+     *
+     * @param name Logical name of the <code>Log</code> instance to be
+     *  returned (the meaning of this name is only known to the underlying
+     *  logging implementation that is being wrapped)
+     * @throws LogConfigurationException if a suitable <code>Log</code>
+     *  instance cannot be returned
+     */
+    public static Log getLog(String name) throws LogConfigurationException {
+        return getFactory().getInstance(name);
+    }
+
+    /**
+     * Release any internal references to previously created {@link LogFactory}
+     * instances that have been associated with the specified class loader
+     * (if any), after calling the instance method <code>release()</code> on
+     * each of them.
+     *
+     * @param classLoader ClassLoader for which to release the LogFactory
+     */
+    public static void release(ClassLoader classLoader) {
+        if (isDiagnosticsEnabled()) {
+            logDiagnostic("Releasing factory for classloader " + objectId(classLoader));
+        }
+        // factories is not final and could be replaced in this block.
+        final Hashtable factories = LogFactory.factories;
+        synchronized (factories) {
+            if (classLoader == null) {
+                if (nullClassLoaderFactory != null) {
+                    nullClassLoaderFactory.release();
+                    nullClassLoaderFactory = null;
+                }
+            } else {
+                final LogFactory factory = (LogFactory) factories.get(classLoader);
+                if (factory != null) {
+                    factory.release();
+                    factories.remove(classLoader);
+                }
+            }
+        }
+    }
+
+    /**
+     * Release any internal references to previously created {@link LogFactory}
+     * instances, after calling the instance method <code>release()</code> on
+     * each of them.  This is useful in environments like servlet containers,
+     * which implement application reloading by throwing away a ClassLoader.
+     * Dangling references to objects in that class loader would prevent
+     * garbage collection.
+     */
+    public static void releaseAll() {
+        if (isDiagnosticsEnabled()) {
+            logDiagnostic("Releasing factory for all classloaders.");
+        }
+        // factories is not final and could be replaced in this block.
+        final Hashtable factories = LogFactory.factories;
+        synchronized (factories) {
+            final Enumeration elements = factories.elements();
+            while (elements.hasMoreElements()) {
+                LogFactory element = (LogFactory) elements.nextElement();
+                element.release();
+            }
+            factories.clear();
+
+            if (nullClassLoaderFactory != null) {
+                nullClassLoaderFactory.release();
+                nullClassLoaderFactory = null;
+            }
+        }
+    }
+
+    // ------------------------------------------------------ Protected Methods
+
+    /**
+     * Safely get access to the classloader for the specified class.
+     * <p>
+     * Theoretically, calling getClassLoader can throw a security exception,
+     * and so should be done under an AccessController in order to provide
+     * maximum flexibility. However in practice people don't appear to use
+     * security policies that forbid getClassLoader calls. So for the moment
+     * all code is written to call this method rather than Class.getClassLoader,
+     * so that we could put AccessController stuff in this method without any
+     * disruption later if we need to.
+     * <p>
+     * Even when using an AccessController, however, this method can still
+     * throw SecurityException. Commons-logging basically relies on the
+     * ability to access classloaders, ie a policy that forbids all
+     * classloader access will also prevent commons-logging from working:
+     * currently this method will throw an exception preventing the entire app
+     * from starting up. Maybe it would be good to detect this situation and
+     * just disable all commons-logging? Not high priority though - as stated
+     * above, security policies that prevent classloader access aren't common.
+     * <p>
+     * Note that returning an object fetched via an AccessController would
+     * technically be a security flaw anyway; untrusted code that has access
+     * to a trusted JCL library could use it to fetch the classloader for
+     * a class even when forbidden to do so directly.
+     *
+     * @since 1.1
+     */
+    protected static ClassLoader getClassLoader(Class clazz) {
+        try {
+            return clazz.getClassLoader();
+        } catch (SecurityException ex) {
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("Unable to get classloader for class '" + clazz +
+                              "' due to security restrictions - " + ex.getMessage());
+            }
+            throw ex;
+        }
+    }
+
+    /**
+     * Returns the current context classloader.
+     * <p>
+     * In versions prior to 1.1, this method did not use an AccessController.
+     * In version 1.1, an AccessController wrapper was incorrectly added to
+     * this method, causing a minor security flaw.
+     * <p>
+     * In version 1.1.1 this change was reverted; this method no longer uses
+     * an AccessController. User code wishing to obtain the context classloader
+     * must invoke this method via AccessController.doPrivileged if it needs
+     * support for that.
+     *
+     * @return the context classloader associated with the current thread,
+     *  or null if security doesn't allow it.
+     * @throws LogConfigurationException if there was some weird error while
+     *  attempting to get the context classloader.
+     * @throws SecurityException if the current java security policy doesn't
+     *  allow this class to access the context classloader.
+     */
+    protected static ClassLoader getContextClassLoader() throws LogConfigurationException {
+        return directGetContextClassLoader();
+    }
+
+    /**
+     * Calls LogFactory.directGetContextClassLoader under the control of an
+     * AccessController class. This means that java code running under a
+     * security manager that forbids access to ClassLoaders will still work
+     * if this class is given appropriate privileges, even when the caller
+     * doesn't have such privileges. Without using an AccessController, the
+     * the entire call stack must have the privilege before the call is
+     * allowed.
+     *
+     * @return the context classloader associated with the current thread,
+     *  or null if security doesn't allow it.
+     * @throws LogConfigurationException if there was some weird error while
+     *  attempting to get the context classloader.
+     * @throws SecurityException if the current java security policy doesn't
+     *  allow this class to access the context classloader.
+     */
+    private static ClassLoader getContextClassLoaderInternal() throws LogConfigurationException {
+        return (ClassLoader)AccessController.doPrivileged(
+            new PrivilegedAction() {
+                public Object run() {
+                    return directGetContextClassLoader();
+                }
+            });
+    }
+
+    /**
+     * Return the thread context class loader if available; otherwise return null.
+     * <p>
+     * Most/all code should call getContextClassLoaderInternal rather than
+     * calling this method directly.
+     * <p>
+     * The thread context class loader is available for JDK 1.2
+     * or later, if certain security conditions are met.
+     * <p>
+     * Note that no internal logging is done within this method because
+     * this method is called every time LogFactory.getLogger() is called,
+     * and we don't want too much output generated here.
+     *
+     * @throws LogConfigurationException if a suitable class loader
+     *  cannot be identified.
+     * @throws SecurityException if the java security policy forbids
+     *  access to the context classloader from one of the classes in the
+     *  current call stack.
+     * @since 1.1
+     */
+    protected static ClassLoader directGetContextClassLoader() throws LogConfigurationException {
+        ClassLoader classLoader = null;
+
+        try {
+            // Are we running on a JDK 1.2 or later system?
+            final Method method = Thread.class.getMethod("getContextClassLoader", (Class[]) null);
+
+            // Get the thread context class loader (if there is one)
+            try {
+                classLoader = (ClassLoader)method.invoke(Thread.currentThread(), (Object[]) null);
+            } catch (IllegalAccessException e) {
+                throw new LogConfigurationException
+                    ("Unexpected IllegalAccessException", e);
+            } catch (InvocationTargetException e) {
+                /**
+                 * InvocationTargetException is thrown by 'invoke' when
+                 * the method being invoked (getContextClassLoader) throws
+                 * an exception.
+                 *
+                 * getContextClassLoader() throws SecurityException when
+                 * the context class loader isn't an ancestor of the
+                 * calling class's class loader, or if security
+                 * permissions are restricted.
+                 *
+                 * In the first case (not related), we want to ignore and
+                 * keep going.  We cannot help but also ignore the second
+                 * with the logic below, but other calls elsewhere (to
+                 * obtain a class loader) will trigger this exception where
+                 * we can make a distinction.
+                 */
+                if (e.getTargetException() instanceof SecurityException) {
+                    // ignore
+                } else {
+                    // Capture 'e.getTargetException()' exception for details
+                    // alternate: log 'e.getTargetException()', and pass back 'e'.
+                    throw new LogConfigurationException("Unexpected InvocationTargetException", e.getTargetException());
+                }
+            }
+        } catch (NoSuchMethodException e) {
+            // Assume we are running on JDK 1.1
+            classLoader = getClassLoader(LogFactory.class);
+
+            // We deliberately don't log a message here to outputStream;
+            // this message would be output for every call to LogFactory.getLog()
+            // when running on JDK1.1
+            //
+            // if (outputStream != null) {
+            //    outputStream.println(
+            //        "Method Thread.getContextClassLoader does not exist;"
+            //         + " assuming this is JDK 1.1, and that the context"
+            //         + " classloader is the same as the class that loaded"
+            //         + " the concrete LogFactory class.");
+            // }
+        }
+
+        // Return the selected class loader
+        return classLoader;
+    }
+
+    /**
+     * Check cached factories (keyed by contextClassLoader)
+     *
+     * @param contextClassLoader is the context classloader associated
+     * with the current thread. This allows separate LogFactory objects
+     * per component within a container, provided each component has
+     * a distinct context classloader set. This parameter may be null
+     * in JDK1.1, and in embedded systems where jcl-using code is
+     * placed in the bootclasspath.
+     *
+     * @return the factory associated with the specified classloader if
+     *  one has previously been created, or null if this is the first time
+     *  we have seen this particular classloader.
+     */
+    private static LogFactory getCachedFactory(ClassLoader contextClassLoader) {
+        if (contextClassLoader == null) {
+            // We have to handle this specially, as factories is a Hashtable
+            // and those don't accept null as a key value.
+            //
+            // nb: nullClassLoaderFactory might be null. That's ok.
+            return nullClassLoaderFactory;
+        } else {
+            return (LogFactory) factories.get(contextClassLoader);
+        }
+    }
+
+    /**
+     * Remember this factory, so later calls to LogFactory.getCachedFactory
+     * can return the previously created object (together with all its
+     * cached Log objects).
+     *
+     * @param classLoader should be the current context classloader. Note that
+     *  this can be null under some circumstances; this is ok.
+     * @param factory should be the factory to cache. This should never be null.
+     */
+    private static void cacheFactory(ClassLoader classLoader, LogFactory factory) {
+        // Ideally we would assert(factory != null) here. However reporting
+        // errors from within a logging implementation is a little tricky!
+
+        if (factory != null) {
+            if (classLoader == null) {
+                nullClassLoaderFactory = factory;
+            } else {
+                factories.put(classLoader, factory);
+            }
+        }
+    }
+
+    /**
+     * Return a new instance of the specified <code>LogFactory</code>
+     * implementation class, loaded by the specified class loader.
+     * If that fails, try the class loader used to load this
+     * (abstract) LogFactory.
+     * <p>
+     * <h2>ClassLoader conflicts</h2>
+     * Note that there can be problems if the specified ClassLoader is not the
+     * same as the classloader that loaded this class, ie when loading a
+     * concrete LogFactory subclass via a context classloader.
+     * <p>
+     * The problem is the same one that can occur when loading a concrete Log
+     * subclass via a context classloader.
+     * <p>
+     * The problem occurs when code running in the context classloader calls
+     * class X which was loaded via a parent classloader, and class X then calls
+     * LogFactory.getFactory (either directly or via LogFactory.getLog). Because
+     * class X was loaded via the parent, it binds to LogFactory loaded via
+     * the parent. When the code in this method finds some LogFactoryYYYY
+     * class in the child (context) classloader, and there also happens to be a
+     * LogFactory class defined in the child classloader, then LogFactoryYYYY
+     * will be bound to LogFactory@childloader. It cannot be cast to
+     * LogFactory@parentloader, ie this method cannot return the object as
+     * the desired type. Note that it doesn't matter if the LogFactory class
+     * in the child classloader is identical to the LogFactory class in the
+     * parent classloader, they are not compatible.
+     * <p>
+     * The solution taken here is to simply print out an error message when
+     * this occurs then throw an exception. The deployer of the application
+     * must ensure they remove all occurrences of the LogFactory class from
+     * the child classloader in order to resolve the issue. Note that they
+     * do not have to move the custom LogFactory subclass; that is ok as
+     * long as the only LogFactory class it can find to bind to is in the
+     * parent classloader.
+     *
+     * @param factoryClass Fully qualified name of the <code>LogFactory</code>
+     *  implementation class
+     * @param classLoader ClassLoader from which to load this class
+     * @param contextClassLoader is the context that this new factory will
+     *  manage logging for.
+     * @throws LogConfigurationException if a suitable instance
+     *  cannot be created
+     * @since 1.1
+     */
+    protected static LogFactory newFactory(final String factoryClass,
+                                           final ClassLoader classLoader,
+                                           final ClassLoader contextClassLoader)
+        throws LogConfigurationException {
+        // Note that any unchecked exceptions thrown by the createFactory
+        // method will propagate out of this method; in particular a
+        // ClassCastException can be thrown.
+        Object result = AccessController.doPrivileged(
+            new PrivilegedAction() {
+                public Object run() {
+                    return createFactory(factoryClass, classLoader);
+                }
+            });
+
+        if (result instanceof LogConfigurationException) {
+            LogConfigurationException ex = (LogConfigurationException) result;
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("An error occurred while loading the factory class:" + ex.getMessage());
+            }
+            throw ex;
+        }
+        if (isDiagnosticsEnabled()) {
+            logDiagnostic("Created object " + objectId(result) + " to manage classloader " +
+                          objectId(contextClassLoader));
+        }
+        return (LogFactory)result;
+    }
+
+    /**
+     * Method provided for backwards compatibility; see newFactory version that
+     * takes 3 parameters.
+     * <p>
+     * This method would only ever be called in some rather odd situation.
+     * Note that this method is static, so overriding in a subclass doesn't
+     * have any effect unless this method is called from a method in that
+     * subclass. However this method only makes sense to use from the
+     * getFactory method, and as that is almost always invoked via
+     * LogFactory.getFactory, any custom definition in a subclass would be
+     * pointless. Only a class with a custom getFactory method, then invoked
+     * directly via CustomFactoryImpl.getFactory or similar would ever call
+     * this. Anyway, it's here just in case, though the "managed class loader"
+     * value output to the diagnostics will not report the correct value.
+     */
+    protected static LogFactory newFactory(final String factoryClass,
+                                           final ClassLoader classLoader) {
+        return newFactory(factoryClass, classLoader, null);
+    }
+
+    /**
+     * Implements the operations described in the javadoc for newFactory.
+     *
+     * @param factoryClass
+     * @param classLoader used to load the specified factory class. This is
+     *  expected to be either the TCCL or the classloader which loaded this
+     *  class. Note that the classloader which loaded this class might be
+     *  "null" (ie the bootloader) for embedded systems.
+     * @return either a LogFactory object or a LogConfigurationException object.
+     * @since 1.1
+     */
+    protected static Object createFactory(String factoryClass, ClassLoader classLoader) {
+        // This will be used to diagnose bad configurations
+        // and allow a useful message to be sent to the user
+        Class logFactoryClass = null;
+        try {
+            if (classLoader != null) {
+                try {
+                    // First the given class loader param (thread class loader)
+
+                    // Warning: must typecast here & allow exception
+                    // to be generated/caught & recast properly.
+                    logFactoryClass = classLoader.loadClass(factoryClass);
+                    if (LogFactory.class.isAssignableFrom(logFactoryClass)) {
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic("Loaded class " + logFactoryClass.getName() +
+                                          " from classloader " + objectId(classLoader));
+                        }
+                    } else {
+                        //
+                        // This indicates a problem with the ClassLoader tree.
+                        // An incompatible ClassLoader was used to load the
+                        // implementation.
+                        // As the same classes
+                        // must be available in multiple class loaders,
+                        // it is very likely that multiple JCL jars are present.
+                        // The most likely fix for this
+                        // problem is to remove the extra JCL jars from the
+                        // ClassLoader hierarchy.
+                        //
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic("Factory class " + logFactoryClass.getName() +
+                                          " loaded from classloader " + objectId(logFactoryClass.getClassLoader()) +
+                                          " does not extend '" + LogFactory.class.getName() +
+                                          "' as loaded by this classloader.");
+                            logHierarchy("[BAD CL TREE] ", classLoader);
+                        }
+                    }
+
+                    return (LogFactory) logFactoryClass.newInstance();
+
+                } catch (ClassNotFoundException ex) {
+                    if (classLoader == thisClassLoader) {
+                        // Nothing more to try, onwards.
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic("Unable to locate any class called '" + factoryClass +
+                                          "' via classloader " + objectId(classLoader));
+                        }
+                        throw ex;
+                    }
+                    // ignore exception, continue
+                } catch (NoClassDefFoundError e) {
+                    if (classLoader == thisClassLoader) {
+                        // Nothing more to try, onwards.
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic("Class '" + factoryClass + "' cannot be loaded" +
+                                          " via classloader " + objectId(classLoader) +
+                                          " - it depends on some other class that cannot be found.");
+                        }
+                        throw e;
+                    }
+                    // ignore exception, continue
+                } catch (ClassCastException e) {
+                    if (classLoader == thisClassLoader) {
+                        // There's no point in falling through to the code below that
+                        // tries again with thisClassLoader, because we've just tried
+                        // loading with that loader (not the TCCL). Just throw an
+                        // appropriate exception here.
+
+                        final boolean implementsLogFactory = implementsLogFactory(logFactoryClass);
+
+                        //
+                        // Construct a good message: users may not actual expect that a custom implementation
+                        // has been specified. Several well known containers use this mechanism to adapt JCL
+                        // to their native logging system.
+                        //
+                        final StringBuffer msg = new StringBuffer();
+                        msg.append("The application has specified that a custom LogFactory implementation ");
+                        msg.append("should be used but Class '");
+                        msg.append(factoryClass);
+                        msg.append("' cannot be converted to '");
+                        msg.append(LogFactory.class.getName());
+                        msg.append("'. ");
+                        if (implementsLogFactory) {
+                            msg.append("The conflict is caused by the presence of multiple LogFactory classes ");
+                            msg.append("in incompatible classloaders. ");
+                            msg.append("Background can be found in http://commons.apache.org/logging/tech.html. ");
+                            msg.append("If you have not explicitly specified a custom LogFactory then it is likely ");
+                            msg.append("that the container has set one without your knowledge. ");
+                            msg.append("In this case, consider using the commons-logging-adapters.jar file or ");
+                            msg.append("specifying the standard LogFactory from the command line. ");
+                        } else {
+                            msg.append("Please check the custom implementation. ");
+                        }
+                        msg.append("Help can be found @http://commons.apache.org/logging/troubleshooting.html.");
+
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic(msg.toString());
+                        }
+
+                        throw new ClassCastException(msg.toString());
+                    }
+
+                    // Ignore exception, continue. Presumably the classloader was the
+                    // TCCL; the code below will try to load the class via thisClassLoader.
+                    // This will handle the case where the original calling class is in
+                    // a shared classpath but the TCCL has a copy of LogFactory and the
+                    // specified LogFactory implementation; we will fall back to using the
+                    // LogFactory implementation from the same classloader as this class.
+                    //
+                    // Issue: this doesn't handle the reverse case, where this LogFactory
+                    // is in the webapp, and the specified LogFactory implementation is
+                    // in a shared classpath. In that case:
+                    // (a) the class really does implement LogFactory (bad log msg above)
+                    // (b) the fallback code will result in exactly the same problem.
+                }
+            }
+
+            /* At this point, either classLoader == null, OR
+             * classLoader was unable to load factoryClass.
+             *
+             * In either case, we call Class.forName, which is equivalent
+             * to LogFactory.class.getClassLoader().load(name), ie we ignore
+             * the classloader parameter the caller passed, and fall back
+             * to trying the classloader associated with this class. See the
+             * javadoc for the newFactory method for more info on the
+             * consequences of this.
+             *
+             * Notes:
+             * * LogFactory.class.getClassLoader() may return 'null'
+             *   if LogFactory is loaded by the bootstrap classloader.
+             */
+            // Warning: must typecast here & allow exception
+            // to be generated/caught & recast properly.
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("Unable to load factory class via classloader " + objectId(classLoader) +
+                              " - trying the classloader associated with this LogFactory.");
+            }
+            logFactoryClass = Class.forName(factoryClass);
+            return (LogFactory) logFactoryClass.newInstance();
+        } catch (Exception e) {
+            // Check to see if we've got a bad configuration
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("Unable to create LogFactory instance.");
+            }
+            if (logFactoryClass != null && !LogFactory.class.isAssignableFrom(logFactoryClass)) {
+                return new LogConfigurationException(
+                    "The chosen LogFactory implementation does not extend LogFactory." +
+                    " Please check your configuration.", e);
+            }
+            return new LogConfigurationException(e);
+        }
+    }
+
+    /**
+     * Determines whether the given class actually implements <code>LogFactory</code>.
+     * Diagnostic information is also logged.
+     * <p>
+     * <strong>Usage:</strong> to diagnose whether a classloader conflict is the cause
+     * of incompatibility. The test used is whether the class is assignable from
+     * the <code>LogFactory</code> class loaded by the class's classloader.
+     * @param logFactoryClass <code>Class</code> which may implement <code>LogFactory</code>
+     * @return true if the <code>logFactoryClass</code> does extend
+     * <code>LogFactory</code> when that class is loaded via the same
+     * classloader that loaded the <code>logFactoryClass</code>.
+     */
+    private static boolean implementsLogFactory(Class logFactoryClass) {
+        boolean implementsLogFactory = false;
+        if (logFactoryClass != null) {
+            try {
+                ClassLoader logFactoryClassLoader = logFactoryClass.getClassLoader();
+                if (logFactoryClassLoader == null) {
+                    logDiagnostic("[CUSTOM LOG FACTORY] was loaded by the boot classloader");
+                } else {
+                    logHierarchy("[CUSTOM LOG FACTORY] ", logFactoryClassLoader);
+                    Class factoryFromCustomLoader
+                        = Class.forName("org.apache.commons.logging.LogFactory", false, logFactoryClassLoader);
+                    implementsLogFactory = factoryFromCustomLoader.isAssignableFrom(logFactoryClass);
+                    if (implementsLogFactory) {
+                        logDiagnostic("[CUSTOM LOG FACTORY] " + logFactoryClass.getName() +
+                                      " implements LogFactory but was loaded by an incompatible classloader.");
+                    } else {
+                        logDiagnostic("[CUSTOM LOG FACTORY] " + logFactoryClass.getName() +
+                                      " does not implement LogFactory.");
+                    }
+                }
+            } catch (SecurityException e) {
+                //
+                // The application is running within a hostile security environment.
+                // This will make it very hard to diagnose issues with JCL.
+                // Consider running less securely whilst debugging this issue.
+                //
+                logDiagnostic("[CUSTOM LOG FACTORY] SecurityException thrown whilst trying to determine whether " +
+                              "the compatibility was caused by a classloader conflict: " + e.getMessage());
+            } catch (LinkageError e) {
+                //
+                // This should be an unusual circumstance.
+                // LinkageError's usually indicate that a dependent class has incompatibly changed.
+                // Another possibility may be an exception thrown by an initializer.
+                // Time for a clean rebuild?
+                //
+                logDiagnostic("[CUSTOM LOG FACTORY] LinkageError thrown whilst trying to determine whether " +
+                              "the compatibility was caused by a classloader conflict: " + e.getMessage());
+            } catch (ClassNotFoundException e) {
+                //
+                // LogFactory cannot be loaded by the classloader which loaded the custom factory implementation.
+                // The custom implementation is not viable until this is corrected.
+                // Ensure that the JCL jar and the custom class are available from the same classloader.
+                // Running with diagnostics on should give information about the classloaders used
+                // to load the custom factory.
+                //
+                logDiagnostic("[CUSTOM LOG FACTORY] LogFactory class cannot be loaded by classloader which loaded " +
+                              "the custom LogFactory implementation. Is the custom factory in the right classloader?");
+            }
+        }
+        return implementsLogFactory;
+    }
+
+    /**
+     * Applets may run in an environment where accessing resources of a loader is
+     * a secure operation, but where the commons-logging library has explicitly
+     * been granted permission for that operation. In this case, we need to
+     * run the operation using an AccessController.
+     */
+    private static InputStream getResourceAsStream(final ClassLoader loader, final String name) {
+        return (InputStream)AccessController.doPrivileged(
+            new PrivilegedAction() {
+                public Object run() {
+                    if (loader != null) {
+                        return loader.getResourceAsStream(name);
+                    } else {
+                        return ClassLoader.getSystemResourceAsStream(name);
+                    }
+                }
+            });
+    }
+
+    /**
+     * Given a filename, return an enumeration of URLs pointing to
+     * all the occurrences of that filename in the classpath.
+     * <p>
+     * This is just like ClassLoader.getResources except that the
+     * operation is done under an AccessController so that this method will
+     * succeed when this jarfile is privileged but the caller is not.
+     * This method must therefore remain private to avoid security issues.
+     * <p>
+     * If no instances are found, an Enumeration is returned whose
+     * hasMoreElements method returns false (ie an "empty" enumeration).
+     * If resources could not be listed for some reason, null is returned.
+     */
+    private static Enumeration getResources(final ClassLoader loader, final String name) {
+        PrivilegedAction action =
+            new PrivilegedAction() {
+                public Object run() {
+                    try {
+                        if (loader != null) {
+                            return loader.getResources(name);
+                        } else {
+                            return ClassLoader.getSystemResources(name);
+                        }
+                    } catch (IOException e) {
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic("Exception while trying to find configuration file " +
+                                          name + ":" + e.getMessage());
+                        }
+                        return null;
+                    } catch (NoSuchMethodError e) {
+                        // we must be running on a 1.1 JVM which doesn't support
+                        // ClassLoader.getSystemResources; just return null in
+                        // this case.
+                        return null;
+                    }
+                }
+            };
+        Object result = AccessController.doPrivileged(action);
+        return (Enumeration) result;
+    }
+
+    /**
+     * Given a URL that refers to a .properties file, load that file.
+     * This is done under an AccessController so that this method will
+     * succeed when this jarfile is privileged but the caller is not.
+     * This method must therefore remain private to avoid security issues.
+     * <p>
+     * {@code Null} is returned if the URL cannot be opened.
+     */
+    private static Properties getProperties(final URL url) {
+        PrivilegedAction action =
+            new PrivilegedAction() {
+                public Object run() {
+                    InputStream stream = null;
+                    try {
+                        // We must ensure that useCaches is set to false, as the
+                        // default behaviour of java is to cache file handles, and
+                        // this "locks" files, preventing hot-redeploy on windows.
+                        URLConnection connection = url.openConnection();
+                        connection.setUseCaches(false);
+                        stream = connection.getInputStream();
+                        if (stream != null) {
+                            Properties props = new Properties();
+                            props.load(stream);
+                            stream.close();
+                            stream = null;
+                            return props;
+                        }
+                    } catch (IOException e) {
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic("Unable to read URL " + url);
+                        }
+                    } finally {
+                        if (stream != null) {
+                            try {
+                                stream.close();
+                            } catch (IOException e) {
+                                // ignore exception; this should not happen
+                                if (isDiagnosticsEnabled()) {
+                                    logDiagnostic("Unable to close stream for URL " + url);
+                                }
+                            }
+                        }
+                    }
+
+                    return null;
+                }
+            };
+        return (Properties) AccessController.doPrivileged(action);
+    }
+
+    /**
+     * Locate a user-provided configuration file.
+     * <p>
+     * The classpath of the specified classLoader (usually the context classloader)
+     * is searched for properties files of the specified name. If none is found,
+     * null is returned. If more than one is found, then the file with the greatest
+     * value for its PRIORITY property is returned. If multiple files have the
+     * same PRIORITY value then the first in the classpath is returned.
+     * <p>
+     * This differs from the 1.0.x releases; those always use the first one found.
+     * However as the priority is a new field, this change is backwards compatible.
+     * <p>
+     * The purpose of the priority field is to allow a webserver administrator to
+     * override logging settings in all webapps by placing a commons-logging.properties
+     * file in a shared classpath location with a priority > 0; this overrides any
+     * commons-logging.properties files without priorities which are in the
+     * webapps. Webapps can also use explicit priorities to override a configuration
+     * file in the shared classpath if needed.
+     */
+    private static final Properties getConfigurationFile(ClassLoader classLoader, String fileName) {
+        Properties props = null;
+        double priority = 0.0;
+        URL propsUrl = null;
+        try {
+            Enumeration urls = getResources(classLoader, fileName);
+
+            if (urls == null) {
+                return null;
+            }
+
+            while (urls.hasMoreElements()) {
+                URL url = (URL) urls.nextElement();
+
+                Properties newProps = getProperties(url);
+                if (newProps != null) {
+                    if (props == null) {
+                        propsUrl = url;
+                        props = newProps;
+                        String priorityStr = props.getProperty(PRIORITY_KEY);
+                        priority = 0.0;
+                        if (priorityStr != null) {
+                            priority = Double.parseDouble(priorityStr);
+                        }
+
+                        if (isDiagnosticsEnabled()) {
+                            logDiagnostic("[LOOKUP] Properties file found at '" + url + "'" +
+                                          " with priority " + priority);
+                        }
+                    } else {
+                        String newPriorityStr = newProps.getProperty(PRIORITY_KEY);
+                        double newPriority = 0.0;
+                        if (newPriorityStr != null) {
+                            newPriority = Double.parseDouble(newPriorityStr);
+                        }
+
+                        if (newPriority > priority) {
+                            if (isDiagnosticsEnabled()) {
+                                logDiagnostic("[LOOKUP] Properties file at '" + url + "'" +
+                                              " with priority " + newPriority +
+                                              " overrides file at '" + propsUrl + "'" +
+                                              " with priority " + priority);
+                            }
+
+                            propsUrl = url;
+                            props = newProps;
+                            priority = newPriority;
+                        } else {
+                            if (isDiagnosticsEnabled()) {
+                                logDiagnostic("[LOOKUP] Properties file at '" + url + "'" +
+                                              " with priority " + newPriority +
+                                              " does not override file at '" + propsUrl + "'" +
+                                              " with priority " + priority);
+                            }
+                        }
+                    }
+
+                }
+            }
+        } catch (SecurityException e) {
+            if (isDiagnosticsEnabled()) {
+                logDiagnostic("SecurityException thrown while trying to find/read config files.");
+            }
+        }
+
+        if (isDiagnosticsEnabled()) {
+            if (props == null) {
+                logDiagnostic("[LOOKUP] No properties file of name '" + fileName + "' found.");
+            } else {
+                logDiagnostic("[LOOKUP] Properties file of name '" + fileName + "' found at '" + propsUrl + '"');
+            }
+        }
+
+        return props;
+    }
+
+    /**
+     * Read the specified system property, using an AccessController so that
+     * the property can be read if JCL has been granted the appropriate
+     * security rights even if the calling code has not.
+     * <p>
+     * Take care not to expose the value returned by this method to the
+     * calling application in any way; otherwise the calling app can use that
+     * info to access data that should not be available to it.
+     */
+    private static String getSystemProperty(final String key, final String def)
+        throws SecurityException {
+        return (String) AccessController.doPrivileged(
+                new PrivilegedAction() {
+                    public Object run() {
+                        return System.getProperty(key, def);
+                    }
+                });
+    }
+
+    /**
+     * Determines whether the user wants internal diagnostic output. If so,
+     * returns an appropriate writer object. Users can enable diagnostic
+     * output by setting the system property named {@link #DIAGNOSTICS_DEST_PROPERTY} to
+     * a filename, or the special values STDOUT or STDERR.
+     */
+    private static PrintStream initDiagnostics() {
+        String dest;
+        try {
+            dest = getSystemProperty(DIAGNOSTICS_DEST_PROPERTY, null);
+            if (dest == null) {
+                return null;
+            }
+        } catch (SecurityException ex) {
+            // We must be running in some very secure environment.
+            // We just have to assume output is not wanted..
+            return null;
+        }
+
+        if (dest.equals("STDOUT")) {
+            return System.out;
+        } else if (dest.equals("STDERR")) {
+            return System.err;
+        } else {
+            try {
+                // open the file in append mode
+                FileOutputStream fos = new FileOutputStream(dest, true);
+                return new PrintStream(fos);
+            } catch (IOException ex) {
+                // We should report this to the user - but how?
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Indicates true if the user has enabled internal logging.
+     * <p>
+     * By the way, sorry for the incorrect grammar, but calling this method
+     * areDiagnosticsEnabled just isn't java beans style.
+     *
+     * @return true if calls to logDiagnostic will have any effect.
+     * @since 1.1
+     */
+    protected static boolean isDiagnosticsEnabled() {
+        return diagnosticsStream != null;
+    }
+
+    /**
+     * Write the specified message to the internal logging destination.
+     * <p>
+     * Note that this method is private; concrete subclasses of this class
+     * should not call it because the diagnosticPrefix string this
+     * method puts in front of all its messages is LogFactory@....,
+     * while subclasses should put SomeSubClass@...
+     * <p>
+     * Subclasses should instead compute their own prefix, then call
+     * logRawDiagnostic. Note that calling isDiagnosticsEnabled is
+     * fine for subclasses.
+     * <p>
+     * Note that it is safe to call this method before initDiagnostics
+     * is called; any output will just be ignored (as isDiagnosticsEnabled
+     * will return false).
+     *
+     * @param msg is the diagnostic message to be output.
+     */
+    private static final void logDiagnostic(String msg) {
+        if (diagnosticsStream != null) {
+            diagnosticsStream.print(diagnosticPrefix);
+            diagnosticsStream.println(msg);
+            diagnosticsStream.flush();
+        }
+    }
+
+    /**
+     * Write the specified message to the internal logging destination.
+     *
+     * @param msg is the diagnostic message to be output.
+     * @since 1.1
+     */
+    protected static final void logRawDiagnostic(String msg) {
+        if (diagnosticsStream != null) {
+            diagnosticsStream.println(msg);
+            diagnosticsStream.flush();
+        }
+    }
+
+    /**
+     * Generate useful diagnostics regarding the classloader tree for
+     * the specified class.
+     * <p>
+     * As an example, if the specified class was loaded via a webapp's
+     * classloader, then you may get the following output:
+     * <pre>
+     * Class com.acme.Foo was loaded via classloader 11111
+     * ClassLoader tree: 11111 -> 22222 (SYSTEM) -> 33333 -> BOOT
+     * </pre>
+     * <p>
+     * This method returns immediately if isDiagnosticsEnabled()
+     * returns false.
+     *
+     * @param clazz is the class whose classloader + tree are to be
+     * output.
+     */
+    private static void logClassLoaderEnvironment(Class clazz) {
+        if (!isDiagnosticsEnabled()) {
+            return;
+        }
+
+        try {
+            // Deliberately use System.getProperty here instead of getSystemProperty; if
+            // the overall security policy for the calling application forbids access to
+            // these variables then we do not want to output them to the diagnostic stream.
+            logDiagnostic("[ENV] Extension directories (java.ext.dir): " + System.getProperty("java.ext.dir"));
+            logDiagnostic("[ENV] Application classpath (java.class.path): " + System.getProperty("java.class.path"));
+        } catch (SecurityException ex) {
+            logDiagnostic("[ENV] Security setting prevent interrogation of system classpaths.");
+        }
+
+        String className = clazz.getName();
+        ClassLoader classLoader;
+
+        try {
+            classLoader = getClassLoader(clazz);
+        } catch (SecurityException ex) {
+            // not much useful diagnostics we can print here!
+            logDiagnostic("[ENV] Security forbids determining the classloader for " + className);
+            return;
+        }
+
+        logDiagnostic("[ENV] Class " + className + " was loaded via classloader " + objectId(classLoader));
+        logHierarchy("[ENV] Ancestry of classloader which loaded " + className + " is ", classLoader);
+    }
+
+    /**
+     * Logs diagnostic messages about the given classloader
+     * and it's hierarchy. The prefix is prepended to the message
+     * and is intended to make it easier to understand the logs.
+     * @param prefix
+     * @param classLoader
+     */
+    private static void logHierarchy(String prefix, ClassLoader classLoader) {
+        if (!isDiagnosticsEnabled()) {
+            return;
+        }
+        ClassLoader systemClassLoader;
+        if (classLoader != null) {
+            final String classLoaderString = classLoader.toString();
+            logDiagnostic(prefix + objectId(classLoader) + " == '" + classLoaderString + "'");
+        }
+
+        try {
+            systemClassLoader = ClassLoader.getSystemClassLoader();
+        } catch (SecurityException ex) {
+            logDiagnostic(prefix + "Security forbids determining the system classloader.");
+            return;
+        }
+        if (classLoader != null) {
+            final StringBuffer buf = new StringBuffer(prefix + "ClassLoader tree:");
+            for(;;) {
+                buf.append(objectId(classLoader));
+                if (classLoader == systemClassLoader) {
+                    buf.append(" (SYSTEM) ");
+                }
+
+                try {
+                    classLoader = classLoader.getParent();
+                } catch (SecurityException ex) {
+                    buf.append(" --> SECRET");
+                    break;
+                }
+
+                buf.append(" --> ");
+                if (classLoader == null) {
+                    buf.append("BOOT");
+                    break;
+                }
+            }
+            logDiagnostic(buf.toString());
+        }
+    }
+
+    /**
+     * Returns a string that uniquely identifies the specified object, including
+     * its class.
+     * <p>
+     * The returned string is of form "classname@hashcode", ie is the same as
+     * the return value of the Object.toString() method, but works even when
+     * the specified object's class has overidden the toString method.
+     *
+     * @param o may be null.
+     * @return a string of form classname@hashcode, or "null" if param o is null.
+     * @since 1.1
+     */
+    public static String objectId(Object o) {
+        if (o == null) {
+            return "null";
+        } else {
+            return o.getClass().getName() + "@" + System.identityHashCode(o);
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Static initialiser block to perform initialisation at class load time.
+    //
+    // We can't do this in the class constructor, as there are many
+    // static methods on this class that can be called before any
+    // LogFactory instances are created, and they depend upon this
+    // stuff having been set up.
+    //
+    // Note that this block must come after any variable declarations used
+    // by any methods called from this block, as we want any static initialiser
+    // associated with the variable to run first. If static initialisers for
+    // variables run after this code, then (a) their value might be needed
+    // by methods called from here, and (b) they might *override* any value
+    // computed here!
+    //
+    // So the wisest thing to do is just to place this code at the very end
+    // of the class file.
+    // ----------------------------------------------------------------------
+
+    static {
+        // note: it's safe to call methods before initDiagnostics (though
+        // diagnostic output gets discarded).
+        thisClassLoader = getClassLoader(LogFactory.class);
+        // In order to avoid confusion where multiple instances of JCL are
+        // being used via different classloaders within the same app, we
+        // ensure each logged message has a prefix of form
+        // [LogFactory from classloader OID]
+        //
+        // Note that this prefix should be kept consistent with that
+        // in LogFactoryImpl. However here we don't need to output info
+        // about the actual *instance* of LogFactory, as all methods that
+        // output diagnostics from this class are static.
+        String classLoaderName;
+        try {
+            ClassLoader classLoader = thisClassLoader;
+            if (thisClassLoader == null) {
+                classLoaderName = "BOOTLOADER";
+            } else {
+                classLoaderName = objectId(classLoader);
+            }
+        } catch (SecurityException e) {
+            classLoaderName = "UNKNOWN";
+        }
+        diagnosticPrefix = "[LogFactory from " + classLoaderName + "] ";
+        diagnosticsStream = initDiagnostics();
+        logClassLoaderEnvironment(LogFactory.class);
+        factories = createFactoryStore();
+        if (isDiagnosticsEnabled()) {
+            logDiagnostic("BOOTSTRAP COMPLETED");
+        }
+    }
 }

--- a/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/NoOpLog.java
+++ b/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/NoOpLog.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -20,126 +21,84 @@ import java.io.Serializable;
 import org.apache.commons.logging.Log;
 
 /**
- * <p>
- * Trivial implementation of Log that throws away all messages. No configurable
- * system properties are supported.
- * </p>
- * 
- * @author <a href="mailto:sanders@apache.org">Scott Sanders</a>
- * @author Rod Waldhoff
- * @version $Id: NoOpLog.java,v 1.8 2004/06/06 21:13:12 rdonkin Exp $
+ * Trivial implementation of Log that throws away all messages.  No
+ * configurable system properties are supported.
+ *
+ * @version $Id$
  */
 public class NoOpLog implements Log, Serializable {
-  private static final long serialVersionUID = 561423906191706148L;
 
-  /** Convenience constructor */
-  public NoOpLog() {
-  }
+    /** Serializable version identifier. */
+    private static final long serialVersionUID = 561423906191706148L;
 
-  /** Base constructor */
-  public NoOpLog(String name) {
-  }
+    /** Convenience constructor */
+    public NoOpLog() { }
+    /** Base constructor */
+    public NoOpLog(String name) { }
+    /** Do nothing */
+    public void trace(Object message) { }
+    /** Do nothing */
+    public void trace(Object message, Throwable t) { }
+    /** Do nothing */
+    public void debug(Object message) { }
+    /** Do nothing */
+    public void debug(Object message, Throwable t) { }
+    /** Do nothing */
+    public void info(Object message) { }
+    /** Do nothing */
+    public void info(Object message, Throwable t) { }
+    /** Do nothing */
+    public void warn(Object message) { }
+    /** Do nothing */
+    public void warn(Object message, Throwable t) { }
+    /** Do nothing */
+    public void error(Object message) { }
+    /** Do nothing */
+    public void error(Object message, Throwable t) { }
+    /** Do nothing */
+    public void fatal(Object message) { }
+    /** Do nothing */
+    public void fatal(Object message, Throwable t) { }
 
-  /** Do nothing */
-  public void trace(Object message) {
-  }
+    /**
+     * Debug is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isDebugEnabled() { return false; }
 
-  /** Do nothing */
-  public void trace(Object message, Throwable t) {
-  }
+    /**
+     * Error is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isErrorEnabled() { return false; }
 
-  /** Do nothing */
-  public void debug(Object message) {
-  }
+    /**
+     * Fatal is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isFatalEnabled() { return false; }
 
-  /** Do nothing */
-  public void debug(Object message, Throwable t) {
-  }
+    /**
+     * Info is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isInfoEnabled() { return false; }
 
-  /** Do nothing */
-  public void info(Object message) {
-  }
+    /**
+     * Trace is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isTraceEnabled() { return false; }
 
-  /** Do nothing */
-  public void info(Object message, Throwable t) {
-  }
-
-  /** Do nothing */
-  public void warn(Object message) {
-  }
-
-  /** Do nothing */
-  public void warn(Object message, Throwable t) {
-  }
-
-  /** Do nothing */
-  public void error(Object message) {
-  }
-
-  /** Do nothing */
-  public void error(Object message, Throwable t) {
-  }
-
-  /** Do nothing */
-  public void fatal(Object message) {
-  }
-
-  /** Do nothing */
-  public void fatal(Object message, Throwable t) {
-  }
-
-  /**
-   * Debug is never enabled.
-   * 
-   * @return false
-   */
-  public final boolean isDebugEnabled() {
-    return false;
-  }
-
-  /**
-   * Error is never enabled.
-   * 
-   * @return false
-   */
-  public final boolean isErrorEnabled() {
-    return false;
-  }
-
-  /**
-   * Fatal is never enabled.
-   * 
-   * @return false
-   */
-  public final boolean isFatalEnabled() {
-    return false;
-  }
-
-  /**
-   * Info is never enabled.
-   * 
-   * @return false
-   */
-  public final boolean isInfoEnabled() {
-    return false;
-  }
-
-  /**
-   * Trace is never enabled.
-   * 
-   * @return false
-   */
-  public final boolean isTraceEnabled() {
-    return false;
-  }
-
-  /**
-   * Warn is never enabled.
-   * 
-   * @return false
-   */
-  public final boolean isWarnEnabled() {
-    return false;
-  }
-
+    /**
+     * Warn is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isWarnEnabled() { return false; }
 }

--- a/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/SimpleLog.java
+++ b/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/SimpleLog.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -31,659 +32,618 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogConfigurationException;
 
 /**
- * <p>
- * Simple implementation of Log that sends all enabled log messages, for all
- * defined loggers, to System.err. The following system properties are supported
- * to configure the behavior of this logger:
- * </p>
+ * Simple implementation of Log that sends all enabled log messages,
+ * for all defined loggers, to System.err.  The following system properties
+ * are supported to configure the behavior of this logger:
  * <ul>
- * <li><code>org.apache.commons.logging.simplelog.defaultlog</code> - Default
- * logging detail level for all instances of SimpleLog. Must be one of ("trace",
- * "debug", "info", "warn", "error", or "fatal"). If not specified, defaults to
- * "info".</li>
- * <li><code>org.apache.commons.logging.simplelog.log.xxxxx</code> - Logging
- * detail level for a SimpleLog instance named "xxxxx". Must be one of ("trace",
- * "debug", "info", "warn", "error", or "fatal"). If not specified, the default
- * logging detail level is used.</li>
- * <li><code>org.apache.commons.logging.simplelog.showlogname</code> - Set to
- * <code>true</code> if you want the Log instance name to be included in output
- * messages. Defaults to <code>false</code>.</li>
- * <li><code>org.apache.commons.logging.simplelog.showShortLogname</code> - Set
- * to <code>true</code> if you want the last component of the name to be
- * included in output messages. Defaults to <code>true</code>.</li>
- * <li><code>org.apache.commons.logging.simplelog.showdatetime</code> - Set to
- * <code>true</code> if you want the current date and time to be included in
- * output messages. Default is <code>false</code>.</li>
- * <li><code>org.apache.commons.logging.simplelog.dateTimeFormat</code> - The
- * date and time format to be used in the output messages. The pattern
- * describing the date and time format is the same that is used in
- * <code>java.text.SimpleDateFormat</code>. If the format is not specified or is
- * invalid, the default format is used. The default format is
- * <code>yyyy/MM/dd HH:mm:ss:SSS zzz</code>.</li>
+ * <li><code>org.apache.commons.logging.simplelog.defaultlog</code> -
+ *     Default logging detail level for all instances of SimpleLog.
+ *     Must be one of ("trace", "debug", "info", "warn", "error", or "fatal").
+ *     If not specified, defaults to "info". </li>
+ * <li><code>org.apache.commons.logging.simplelog.log.xxxxx</code> -
+ *     Logging detail level for a SimpleLog instance named "xxxxx".
+ *     Must be one of ("trace", "debug", "info", "warn", "error", or "fatal").
+ *     If not specified, the default logging detail level is used.</li>
+ * <li><code>org.apache.commons.logging.simplelog.showlogname</code> -
+ *     Set to <code>true</code> if you want the Log instance name to be
+ *     included in output messages. Defaults to <code>false</code>.</li>
+ * <li><code>org.apache.commons.logging.simplelog.showShortLogname</code> -
+ *     Set to <code>true</code> if you want the last component of the name to be
+ *     included in output messages. Defaults to <code>true</code>.</li>
+ * <li><code>org.apache.commons.logging.simplelog.showdatetime</code> -
+ *     Set to <code>true</code> if you want the current date and time
+ *     to be included in output messages. Default is <code>false</code>.</li>
+ * <li><code>org.apache.commons.logging.simplelog.dateTimeFormat</code> -
+ *     The date and time format to be used in the output messages.
+ *     The pattern describing the date and time format is the same that is
+ *     used in <code>java.text.SimpleDateFormat</code>. If the format is not
+ *     specified or is invalid, the default format is used.
+ *     The default format is <code>yyyy/MM/dd HH:mm:ss:SSS zzz</code>.</li>
  * </ul>
- * 
  * <p>
- * In addition to looking for system properties with the names specified above,
- * this implementation also checks for a class loader resource named
+ * In addition to looking for system properties with the names specified
+ * above, this implementation also checks for a class loader resource named
  * <code>"simplelog.properties"</code>, and includes any matching definitions
  * from this resource (if it exists).
- * </p>
- * 
- * @author <a href="mailto:sanders@apache.org">Scott Sanders</a>
- * @author Rod Waldhoff
- * @author Robert Burrell Donkin
- * 
- * @version $Id: SimpleLog.java,v 1.21 2004/06/06 20:47:56 rdonkin Exp $
+ *
+ * @version $Id$
  */
 public class SimpleLog implements Log, Serializable {
 
-  private static final long serialVersionUID = 136942970684951178L;
-
-  // ------------------------------------------------------- Class Attributes
-
-  /** All system properties used by <code>SimpleLog</code> start with this */
-  static protected final String systemPrefix = "org.apache.commons.logging.simplelog.";
-
-  /** Properties loaded from simplelog.properties */
-  static protected final Properties simpleLogProps = new Properties();
-
-  /** The default format to use when formating dates */
-  static protected final String DEFAULT_DATE_TIME_FORMAT = "yyyy/MM/dd HH:mm:ss:SSS zzz";
-
-  /** Include the instance name in the log message? */
-  static protected boolean showLogName = false;
-  /**
-   * Include the short name ( last component ) of the logger in the log message.
-   * Defaults to true - otherwise we'll be lost in a flood of messages without
-   * knowing who sends them.
-   */
-  static protected boolean showShortName = true;
-  /** Include the current time in the log message */
-  static protected boolean showDateTime = false;
-  /** The date and time format to use in the log message */
-  static protected String dateTimeFormat = DEFAULT_DATE_TIME_FORMAT;
-  /** Used to format times */
-  static protected DateFormat dateFormatter = null;
-
-  // ---------------------------------------------------- Log Level Constants
-
-  /** "Trace" level logging. */
-  public static final int LOG_LEVEL_TRACE = 1;
-  /** "Debug" level logging. */
-  public static final int LOG_LEVEL_DEBUG = 2;
-  /** "Info" level logging. */
-  public static final int LOG_LEVEL_INFO = 3;
-  /** "Warn" level logging. */
-  public static final int LOG_LEVEL_WARN = 4;
-  /** "Error" level logging. */
-  public static final int LOG_LEVEL_ERROR = 5;
-  /** "Fatal" level logging. */
-  public static final int LOG_LEVEL_FATAL = 6;
-
-  /** Enable all logging levels */
-  public static final int LOG_LEVEL_ALL = (LOG_LEVEL_TRACE - 1);
-
-  /** Enable no logging levels */
-  public static final int LOG_LEVEL_OFF = (LOG_LEVEL_FATAL + 1);
-
-  // ------------------------------------------------------------ Initializer
-
-  private static String getStringProperty(String name) {
-    String prop = null;
-    try {
-      prop = System.getProperty(name);
-    } catch (SecurityException e) {
-      ; // Ignore
-    }
-    return (prop == null) ? simpleLogProps.getProperty(name) : prop;
-  }
-
-  private static String getStringProperty(String name, String dephault) {
-    String prop = getStringProperty(name);
-    return (prop == null) ? dephault : prop;
-  }
-
-  private static boolean getBooleanProperty(String name, boolean dephault) {
-    String prop = getStringProperty(name);
-    return (prop == null) ? dephault : "true".equalsIgnoreCase(prop);
-  }
-
-  // Initialize class attributes.
-  // Load properties file, if found.
-  // Override with system properties.
-  static {
-    // Add props from the resource simplelog.properties
-    InputStream in = getResourceAsStream("simplelog.properties");
-    if (null != in) {
-      try {
-        simpleLogProps.load(in);
-        in.close();
-      } catch (java.io.IOException e) {
-        // ignored
-      }
-    }
-
-    showLogName = getBooleanProperty(systemPrefix + "showlogname", showLogName);
-    showShortName = getBooleanProperty(systemPrefix + "showShortLogname",
-        showShortName);
-    showDateTime = getBooleanProperty(systemPrefix + "showdatetime",
-        showDateTime);
-
-    if (showDateTime) {
-      dateTimeFormat = getStringProperty(systemPrefix + "dateTimeFormat",
-          dateTimeFormat);
-      try {
-        dateFormatter = new SimpleDateFormat(dateTimeFormat);
-      } catch (IllegalArgumentException e) {
-        // If the format pattern is invalid - use the default format
-        dateTimeFormat = DEFAULT_DATE_TIME_FORMAT;
-        dateFormatter = new SimpleDateFormat(dateTimeFormat);
-      }
-    }
-  }
-
-  // ------------------------------------------------------------- Attributes
-
-  /** The name of this simple log instance */
-  protected String logName = null;
-  /** The current log level */
-  protected int currentLogLevel;
-  /** The short name of this simple log instance */
-  private String shortLogName = null;
-
-  // ------------------------------------------------------------ Constructor
-
-  /**
-   * Construct a simple log with given name.
-   * 
-   * @param name
-   *          log name
-   */
-  public SimpleLog(String name) {
-
-    logName = name;
-
-    // Set initial log level
-    // Used to be: set default log level to ERROR
-    // IMHO it should be lower, but at least info ( costin ).
-    setLevel(SimpleLog.LOG_LEVEL_INFO);
-
-    // Set log level from properties
-    String lvl = getStringProperty(systemPrefix + "log." + logName);
-    int i = String.valueOf(name).lastIndexOf(".");
-    while (null == lvl && i > -1) {
-      name = name.substring(0, i);
-      lvl = getStringProperty(systemPrefix + "log." + name);
-      i = String.valueOf(name).lastIndexOf(".");
-    }
-
-    if (null == lvl) {
-      lvl = getStringProperty(systemPrefix + "defaultlog");
-    }
-
-    if ("all".equalsIgnoreCase(lvl)) {
-      setLevel(SimpleLog.LOG_LEVEL_ALL);
-    } else if ("trace".equalsIgnoreCase(lvl)) {
-      setLevel(SimpleLog.LOG_LEVEL_TRACE);
-    } else if ("debug".equalsIgnoreCase(lvl)) {
-      setLevel(SimpleLog.LOG_LEVEL_DEBUG);
-    } else if ("info".equalsIgnoreCase(lvl)) {
-      setLevel(SimpleLog.LOG_LEVEL_INFO);
-    } else if ("warn".equalsIgnoreCase(lvl)) {
-      setLevel(SimpleLog.LOG_LEVEL_WARN);
-    } else if ("error".equalsIgnoreCase(lvl)) {
-      setLevel(SimpleLog.LOG_LEVEL_ERROR);
-    } else if ("fatal".equalsIgnoreCase(lvl)) {
-      setLevel(SimpleLog.LOG_LEVEL_FATAL);
-    } else if ("off".equalsIgnoreCase(lvl)) {
-      setLevel(SimpleLog.LOG_LEVEL_OFF);
-    }
-
-  }
-
-  // -------------------------------------------------------- Properties
-
-  /**
-   * <p>
-   * Set logging level.
-   * </p>
-   * 
-   * @param currentLogLevel
-   *          new logging level
-   */
-  public void setLevel(int currentLogLevel) {
-
-    this.currentLogLevel = currentLogLevel;
-
-  }
-
-  /**
-   * <p>
-   * Get logging level.
-   * </p>
-   */
-  public int getLevel() {
-
-    return currentLogLevel;
-  }
-
-  // -------------------------------------------------------- Logging Methods
-
-  /**
-   * <p>
-   * Do the actual logging. This method assembles the message and then calls
-   * <code>write()</code> to cause it to be written.
-   * </p>
-   * 
-   * @param type
-   *          One of the LOG_LEVEL_XXX constants defining the log level
-   * @param message
-   *          The message itself (typically a String)
-   * @param t
-   *          The exception whose stack trace should be logged
-   */
-  protected void log(int type, Object message, Throwable t) {
-    // Use a string buffer for better performance
-    StringBuffer buf = new StringBuffer();
-
-    // Append date-time if so configured
-    if (showDateTime) {
-      buf.append(dateFormatter.format(new Date()));
-      buf.append(" ");
-    }
-
-    // Append a readable representation of the log level
-    switch (type) {
-    case SimpleLog.LOG_LEVEL_TRACE:
-      buf.append("[TRACE] ");
-      break;
-    case SimpleLog.LOG_LEVEL_DEBUG:
-      buf.append("[DEBUG] ");
-      break;
-    case SimpleLog.LOG_LEVEL_INFO:
-      buf.append("[INFO] ");
-      break;
-    case SimpleLog.LOG_LEVEL_WARN:
-      buf.append("[WARN] ");
-      break;
-    case SimpleLog.LOG_LEVEL_ERROR:
-      buf.append("[ERROR] ");
-      break;
-    case SimpleLog.LOG_LEVEL_FATAL:
-      buf.append("[FATAL] ");
-      break;
-    }
-
-    // Append the name of the log instance if so configured
-    if (showShortName) {
-      if (shortLogName == null) {
-        // Cut all but the last component of the name for both styles
-        shortLogName = logName.substring(logName.lastIndexOf(".") + 1);
-        shortLogName = shortLogName
-            .substring(shortLogName.lastIndexOf("/") + 1);
-      }
-      buf.append(String.valueOf(shortLogName)).append(" - ");
-    } else if (showLogName) {
-      buf.append(String.valueOf(logName)).append(" - ");
-    }
-
-    // Append the message
-    buf.append(String.valueOf(message));
-
-    // Append stack trace if not null
-    if (t != null) {
-      buf.append(" <");
-      buf.append(t.toString());
-      buf.append(">");
-
-      java.io.StringWriter sw = new java.io.StringWriter(1024);
-      java.io.PrintWriter pw = new java.io.PrintWriter(sw);
-      t.printStackTrace(pw);
-      pw.close();
-      buf.append(sw.toString());
-    }
-
-    // Print to the appropriate destination
-    write(buf);
-
-  }
-
-  /**
-   * <p>
-   * Write the content of the message accumulated in the specified
-   * <code>StringBuffer</code> to the appropriate output destination. The
-   * default implementation writes to <code>System.err</code>.
-   * </p>
-   * 
-   * @param buffer
-   *          A <code>StringBuffer</code> containing the accumulated text to be
-   *          logged
-   */
-  protected void write(StringBuffer buffer) {
-
-    System.err.println(buffer.toString());
-
-  }
-
-  /**
-   * Is the given log level currently enabled?
-   * 
-   * @param logLevel
-   *          is this level enabled?
-   */
-  protected boolean isLevelEnabled(int logLevel) {
-    // log level are numerically ordered so can use simple numeric
-    // comparison
-    return (logLevel >= currentLogLevel);
-  }
-
-  // -------------------------------------------------------- Log Implementation
-
-  /**
-   * <p>
-   * Log a message with debug log level.
-   * </p>
-   */
-  public final void debug(Object message) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_DEBUG)) {
-      log(SimpleLog.LOG_LEVEL_DEBUG, message, null);
-    }
-  }
-
-  /**
-   * <p>
-   * Log an error with debug log level.
-   * </p>
-   */
-  public final void debug(Object message, Throwable t) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_DEBUG)) {
-      log(SimpleLog.LOG_LEVEL_DEBUG, message, t);
-    }
-  }
-
-  /**
-   * <p>
-   * Log a message with trace log level.
-   * </p>
-   */
-  public final void trace(Object message) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_TRACE)) {
-      log(SimpleLog.LOG_LEVEL_TRACE, message, null);
-    }
-  }
-
-  /**
-   * <p>
-   * Log an error with trace log level.
-   * </p>
-   */
-  public final void trace(Object message, Throwable t) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_TRACE)) {
-      log(SimpleLog.LOG_LEVEL_TRACE, message, t);
-    }
-  }
-
-  /**
-   * <p>
-   * Log a message with info log level.
-   * </p>
-   */
-  public final void info(Object message) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_INFO)) {
-      log(SimpleLog.LOG_LEVEL_INFO, message, null);
-    }
-  }
-
-  /**
-   * <p>
-   * Log an error with info log level.
-   * </p>
-   */
-  public final void info(Object message, Throwable t) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_INFO)) {
-      log(SimpleLog.LOG_LEVEL_INFO, message, t);
-    }
-  }
-
-  /**
-   * <p>
-   * Log a message with warn log level.
-   * </p>
-   */
-  public final void warn(Object message) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_WARN)) {
-      log(SimpleLog.LOG_LEVEL_WARN, message, null);
-    }
-  }
-
-  /**
-   * <p>
-   * Log an error with warn log level.
-   * </p>
-   */
-  public final void warn(Object message, Throwable t) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_WARN)) {
-      log(SimpleLog.LOG_LEVEL_WARN, message, t);
-    }
-  }
-
-  /**
-   * <p>
-   * Log a message with error log level.
-   * </p>
-   */
-  public final void error(Object message) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_ERROR)) {
-      log(SimpleLog.LOG_LEVEL_ERROR, message, null);
-    }
-  }
-
-  /**
-   * <p>
-   * Log an error with error log level.
-   * </p>
-   */
-  public final void error(Object message, Throwable t) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_ERROR)) {
-      log(SimpleLog.LOG_LEVEL_ERROR, message, t);
-    }
-  }
-
-  /**
-   * <p>
-   * Log a message with fatal log level.
-   * </p>
-   */
-  public final void fatal(Object message) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_FATAL)) {
-      log(SimpleLog.LOG_LEVEL_FATAL, message, null);
-    }
-  }
-
-  /**
-   * <p>
-   * Log an error with fatal log level.
-   * </p>
-   */
-  public final void fatal(Object message, Throwable t) {
-
-    if (isLevelEnabled(SimpleLog.LOG_LEVEL_FATAL)) {
-      log(SimpleLog.LOG_LEVEL_FATAL, message, t);
-    }
-  }
-
-  /**
-   * <p>
-   * Are debug messages currently enabled?
-   * </p>
-   * 
-   * <p>
-   * This allows expensive operations such as <code>String</code> concatenation
-   * to be avoided when the message will be ignored by the logger.
-   * </p>
-   */
-  public final boolean isDebugEnabled() {
-
-    return isLevelEnabled(SimpleLog.LOG_LEVEL_DEBUG);
-  }
-
-  /**
-   * <p>
-   * Are error messages currently enabled?
-   * </p>
-   * 
-   * <p>
-   * This allows expensive operations such as <code>String</code> concatenation
-   * to be avoided when the message will be ignored by the logger.
-   * </p>
-   */
-  public final boolean isErrorEnabled() {
-
-    return isLevelEnabled(SimpleLog.LOG_LEVEL_ERROR);
-  }
-
-  /**
-   * <p>
-   * Are fatal messages currently enabled?
-   * </p>
-   * 
-   * <p>
-   * This allows expensive operations such as <code>String</code> concatenation
-   * to be avoided when the message will be ignored by the logger.
-   * </p>
-   */
-  public final boolean isFatalEnabled() {
-
-    return isLevelEnabled(SimpleLog.LOG_LEVEL_FATAL);
-  }
-
-  /**
-   * <p>
-   * Are info messages currently enabled?
-   * </p>
-   * 
-   * <p>
-   * This allows expensive operations such as <code>String</code> concatenation
-   * to be avoided when the message will be ignored by the logger.
-   * </p>
-   */
-  public final boolean isInfoEnabled() {
-
-    return isLevelEnabled(SimpleLog.LOG_LEVEL_INFO);
-  }
-
-  /**
-   * <p>
-   * Are trace messages currently enabled?
-   * </p>
-   * 
-   * <p>
-   * This allows expensive operations such as <code>String</code> concatenation
-   * to be avoided when the message will be ignored by the logger.
-   * </p>
-   */
-  public final boolean isTraceEnabled() {
-
-    return isLevelEnabled(SimpleLog.LOG_LEVEL_TRACE);
-  }
-
-  /**
-   * <p>
-   * Are warn messages currently enabled?
-   * </p>
-   * 
-   * <p>
-   * This allows expensive operations such as <code>String</code> concatenation
-   * to be avoided when the message will be ignored by the logger.
-   * </p>
-   */
-  public final boolean isWarnEnabled() {
-
-    return isLevelEnabled(SimpleLog.LOG_LEVEL_WARN);
-  }
-
-  /**
-   * Return the thread context class loader if available. Otherwise return null.
-   * 
-   * The thread context class loader is available for JDK 1.2 or later, if
-   * certain security conditions are met.
-   * 
-   * @exception LogConfigurationException
-   *              if a suitable class loader cannot be identified.
-   */
-  private static ClassLoader getContextClassLoader() {
-    ClassLoader classLoader = null;
-
-    if (classLoader == null) {
-      try {
-        // Are we running on a JDK 1.2 or later system?
-        Method method = Thread.class.getMethod("getContextClassLoader", null);
-
-        // Get the thread context class loader (if there is one)
+    /** Serializable version identifier. */
+    private static final long serialVersionUID = 136942970684951178L;
+
+    // ------------------------------------------------------- Class Attributes
+
+    /** All system properties used by <code>SimpleLog</code> start with this */
+    static protected final String systemPrefix = "org.apache.commons.logging.simplelog.";
+
+    /** Properties loaded from simplelog.properties */
+    static protected final Properties simpleLogProps = new Properties();
+
+    /** The default format to use when formating dates */
+    static protected final String DEFAULT_DATE_TIME_FORMAT = "yyyy/MM/dd HH:mm:ss:SSS zzz";
+
+    /** Include the instance name in the log message? */
+    static volatile protected boolean showLogName = false;
+
+    /** Include the short name ( last component ) of the logger in the log
+     *  message. Defaults to true - otherwise we'll be lost in a flood of
+     *  messages without knowing who sends them.
+     */
+    static volatile protected boolean showShortName = true;
+
+    /** Include the current time in the log message */
+    static volatile protected boolean showDateTime = false;
+
+    /** The date and time format to use in the log message */
+    static volatile protected String dateTimeFormat = DEFAULT_DATE_TIME_FORMAT;
+
+    /**
+     * Used to format times.
+     * <p>
+     * Any code that accesses this object should first obtain a lock on it,
+     * ie use synchronized(dateFormatter); this requirement was introduced
+     * in 1.1.1 to fix an existing thread safety bug (SimpleDateFormat.format
+     * is not thread-safe).
+     */
+    static protected DateFormat dateFormatter = null;
+
+    // ---------------------------------------------------- Log Level Constants
+
+    /** "Trace" level logging. */
+    public static final int LOG_LEVEL_TRACE  = 1;
+    /** "Debug" level logging. */
+    public static final int LOG_LEVEL_DEBUG  = 2;
+    /** "Info" level logging. */
+    public static final int LOG_LEVEL_INFO   = 3;
+    /** "Warn" level logging. */
+    public static final int LOG_LEVEL_WARN   = 4;
+    /** "Error" level logging. */
+    public static final int LOG_LEVEL_ERROR  = 5;
+    /** "Fatal" level logging. */
+    public static final int LOG_LEVEL_FATAL  = 6;
+
+    /** Enable all logging levels */
+    public static final int LOG_LEVEL_ALL    = LOG_LEVEL_TRACE - 1;
+
+    /** Enable no logging levels */
+    public static final int LOG_LEVEL_OFF    = LOG_LEVEL_FATAL + 1;
+
+    // ------------------------------------------------------------ Initializer
+
+    private static String getStringProperty(String name) {
+        String prop = null;
         try {
-          classLoader = (ClassLoader) method.invoke(Thread.currentThread(),
-              null);
-        } catch (IllegalAccessException e) {
-          ; // ignore
-        } catch (InvocationTargetException e) {
-          /**
-           * InvocationTargetException is thrown by 'invoke' when the method
-           * being invoked (getContextClassLoader) throws an exception.
-           * 
-           * getContextClassLoader() throws SecurityException when the context
-           * class loader isn't an ancestor of the calling class's class loader,
-           * or if security permissions are restricted.
-           * 
-           * In the first case (not related), we want to ignore and keep going.
-           * We cannot help but also ignore the second with the logic below, but
-           * other calls elsewhere (to obtain a class loader) will trigger this
-           * exception where we can make a distinction.
-           */
-          if (e.getTargetException() instanceof SecurityException) {
-            ; // ignore
-          } else {
-            // Capture 'e.getTargetException()' exception for details
-            // alternate: log 'e.getTargetException()', and pass back 'e'.
-            throw new LogConfigurationException(
-                "Unexpected InvocationTargetException", e.getTargetException());
-          }
+            prop = System.getProperty(name);
+        } catch (SecurityException e) {
+            // Ignore
         }
-      } catch (NoSuchMethodException e) {
-        // Assume we are running on JDK 1.1
-        ; // ignore
-      }
+        return prop == null ? simpleLogProps.getProperty(name) : prop;
     }
 
-    if (classLoader == null) {
-      classLoader = SimpleLog.class.getClassLoader();
+    private static String getStringProperty(String name, String dephault) {
+        String prop = getStringProperty(name);
+        return prop == null ? dephault : prop;
     }
 
-    // Return the selected class loader
-    return classLoader;
-  }
+    private static boolean getBooleanProperty(String name, boolean dephault) {
+        String prop = getStringProperty(name);
+        return prop == null ? dephault : "true".equalsIgnoreCase(prop);
+    }
 
-  private static InputStream getResourceAsStream(final String name) {
-    return AccessController.doPrivileged(new PrivilegedAction<InputStream>() {
-      public InputStream run() {
-        ClassLoader threadCL = getContextClassLoader();
-
-        if (threadCL != null) {
-          return threadCL.getResourceAsStream(name);
-        } else {
-          return ClassLoader.getSystemResourceAsStream(name);
+    // Initialize class attributes.
+    // Load properties file, if found.
+    // Override with system properties.
+    static {
+        // Add props from the resource simplelog.properties
+        InputStream in = getResourceAsStream("simplelog.properties");
+        if(null != in) {
+            try {
+                simpleLogProps.load(in);
+                in.close();
+            } catch(java.io.IOException e) {
+                // ignored
+            }
         }
-      }
-    });
-  }
+
+        showLogName = getBooleanProperty(systemPrefix + "showlogname", showLogName);
+        showShortName = getBooleanProperty(systemPrefix + "showShortLogname", showShortName);
+        showDateTime = getBooleanProperty(systemPrefix + "showdatetime", showDateTime);
+
+        if(showDateTime) {
+            dateTimeFormat = getStringProperty(systemPrefix + "dateTimeFormat",
+                                               dateTimeFormat);
+            try {
+                dateFormatter = new SimpleDateFormat(dateTimeFormat);
+            } catch(IllegalArgumentException e) {
+                // If the format pattern is invalid - use the default format
+                dateTimeFormat = DEFAULT_DATE_TIME_FORMAT;
+                dateFormatter = new SimpleDateFormat(dateTimeFormat);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------- Attributes
+
+    /** The name of this simple log instance */
+    protected volatile String logName = null;
+    /** The current log level */
+    protected volatile int currentLogLevel;
+    /** The short name of this simple log instance */
+    private volatile String shortLogName = null;
+
+    // ------------------------------------------------------------ Constructor
+
+    /**
+     * Construct a simple log with given name.
+     *
+     * @param name log name
+     */
+    public SimpleLog(String name) {
+        logName = name;
+
+        // Set initial log level
+        // Used to be: set default log level to ERROR
+        // IMHO it should be lower, but at least info ( costin ).
+        setLevel(SimpleLog.LOG_LEVEL_INFO);
+
+        // Set log level from properties
+        String lvl = getStringProperty(systemPrefix + "log." + logName);
+        int i = String.valueOf(name).lastIndexOf(".");
+        while(null == lvl && i > -1) {
+            name = name.substring(0,i);
+            lvl = getStringProperty(systemPrefix + "log." + name);
+            i = String.valueOf(name).lastIndexOf(".");
+        }
+
+        if(null == lvl) {
+            lvl =  getStringProperty(systemPrefix + "defaultlog");
+        }
+
+        if("all".equalsIgnoreCase(lvl)) {
+            setLevel(SimpleLog.LOG_LEVEL_ALL);
+        } else if("trace".equalsIgnoreCase(lvl)) {
+            setLevel(SimpleLog.LOG_LEVEL_TRACE);
+        } else if("debug".equalsIgnoreCase(lvl)) {
+            setLevel(SimpleLog.LOG_LEVEL_DEBUG);
+        } else if("info".equalsIgnoreCase(lvl)) {
+            setLevel(SimpleLog.LOG_LEVEL_INFO);
+        } else if("warn".equalsIgnoreCase(lvl)) {
+            setLevel(SimpleLog.LOG_LEVEL_WARN);
+        } else if("error".equalsIgnoreCase(lvl)) {
+            setLevel(SimpleLog.LOG_LEVEL_ERROR);
+        } else if("fatal".equalsIgnoreCase(lvl)) {
+            setLevel(SimpleLog.LOG_LEVEL_FATAL);
+        } else if("off".equalsIgnoreCase(lvl)) {
+            setLevel(SimpleLog.LOG_LEVEL_OFF);
+        }
+    }
+
+    // -------------------------------------------------------- Properties
+
+    /**
+     * Set logging level.
+     *
+     * @param currentLogLevel new logging level
+     */
+    public void setLevel(int currentLogLevel) {
+        this.currentLogLevel = currentLogLevel;
+    }
+
+    /**
+     * Get logging level.
+     */
+    public int getLevel() {
+        return currentLogLevel;
+    }
+
+    // -------------------------------------------------------- Logging Methods
+
+    /**
+     * Do the actual logging.
+     * <p>
+     * This method assembles the message and then calls <code>write()</code>
+     * to cause it to be written.
+     *
+     * @param type One of the LOG_LEVEL_XXX constants defining the log level
+     * @param message The message itself (typically a String)
+     * @param t The exception whose stack trace should be logged
+     */
+    protected void log(int type, Object message, Throwable t) {
+        // Use a string buffer for better performance
+        final StringBuffer buf = new StringBuffer();
+
+        // Append date-time if so configured
+        if(showDateTime) {
+            final Date now = new Date();
+            String dateText;
+            synchronized(dateFormatter) {
+                dateText = dateFormatter.format(now);
+            }
+            buf.append(dateText);
+            buf.append(" ");
+        }
+
+        // Append a readable representation of the log level
+        switch(type) {
+            case SimpleLog.LOG_LEVEL_TRACE: buf.append("[TRACE] "); break;
+            case SimpleLog.LOG_LEVEL_DEBUG: buf.append("[DEBUG] "); break;
+            case SimpleLog.LOG_LEVEL_INFO:  buf.append("[INFO] ");  break;
+            case SimpleLog.LOG_LEVEL_WARN:  buf.append("[WARN] ");  break;
+            case SimpleLog.LOG_LEVEL_ERROR: buf.append("[ERROR] "); break;
+            case SimpleLog.LOG_LEVEL_FATAL: buf.append("[FATAL] "); break;
+        }
+
+        // Append the name of the log instance if so configured
+        if(showShortName) {
+            if(shortLogName == null) {
+                // Cut all but the last component of the name for both styles
+                final String slName = logName.substring(logName.lastIndexOf(".") + 1);
+                shortLogName = slName.substring(slName.lastIndexOf("/") + 1);
+            }
+            buf.append(String.valueOf(shortLogName)).append(" - ");
+        } else if(showLogName) {
+            buf.append(String.valueOf(logName)).append(" - ");
+        }
+
+        // Append the message
+        buf.append(String.valueOf(message));
+
+        // Append stack trace if not null
+        if(t != null) {
+            buf.append(" <");
+            buf.append(t.toString());
+            buf.append(">");
+
+            final java.io.StringWriter sw = new java.io.StringWriter(1024);
+            final java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+            t.printStackTrace(pw);
+            pw.close();
+            buf.append(sw.toString());
+        }
+
+        // Print to the appropriate destination
+        write(buf);
+    }
+
+    /**
+     * Write the content of the message accumulated in the specified
+     * <code>StringBuffer</code> to the appropriate output destination.  The
+     * default implementation writes to <code>System.err</code>.
+     *
+     * @param buffer A <code>StringBuffer</code> containing the accumulated
+     *  text to be logged
+     */
+    protected void write(StringBuffer buffer) {
+        System.err.println(buffer.toString());
+    }
+
+    /**
+     * Is the given log level currently enabled?
+     *
+     * @param logLevel is this level enabled?
+     */
+    protected boolean isLevelEnabled(int logLevel) {
+        // log level are numerically ordered so can use simple numeric
+        // comparison
+        return logLevel >= currentLogLevel;
+    }
+
+    // -------------------------------------------------------- Log Implementation
+
+    /**
+     * Logs a message with
+     * <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_DEBUG</code>.
+     *
+     * @param message to log
+     * @see org.apache.commons.logging.Log#debug(Object)
+     */
+    public final void debug(Object message) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_DEBUG)) {
+            log(SimpleLog.LOG_LEVEL_DEBUG, message, null);
+        }
+    }
+
+    /**
+     * Logs a message with
+     * <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_DEBUG</code>.
+     *
+     * @param message to log
+     * @param t log this cause
+     * @see org.apache.commons.logging.Log#debug(Object, Throwable)
+     */
+    public final void debug(Object message, Throwable t) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_DEBUG)) {
+            log(SimpleLog.LOG_LEVEL_DEBUG, message, t);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_TRACE</code>.
+     *
+     * @param message to log
+     * @see org.apache.commons.logging.Log#trace(Object)
+     */
+    public final void trace(Object message) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_TRACE)) {
+            log(SimpleLog.LOG_LEVEL_TRACE, message, null);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_TRACE</code>.
+     *
+     * @param message to log
+     * @param t log this cause
+     * @see org.apache.commons.logging.Log#trace(Object, Throwable)
+     */
+    public final void trace(Object message, Throwable t) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_TRACE)) {
+            log(SimpleLog.LOG_LEVEL_TRACE, message, t);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_INFO</code>.
+     *
+     * @param message to log
+     * @see org.apache.commons.logging.Log#info(Object)
+     */
+    public final void info(Object message) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_INFO)) {
+            log(SimpleLog.LOG_LEVEL_INFO,message,null);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_INFO</code>.
+     *
+     * @param message to log
+     * @param t log this cause
+     * @see org.apache.commons.logging.Log#info(Object, Throwable)
+     */
+    public final void info(Object message, Throwable t) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_INFO)) {
+            log(SimpleLog.LOG_LEVEL_INFO, message, t);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_WARN</code>.
+     *
+     * @param message to log
+     * @see org.apache.commons.logging.Log#warn(Object)
+     */
+    public final void warn(Object message) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_WARN)) {
+            log(SimpleLog.LOG_LEVEL_WARN, message, null);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_WARN</code>.
+     *
+     * @param message to log
+     * @param t log this cause
+     * @see org.apache.commons.logging.Log#warn(Object, Throwable)
+     */
+    public final void warn(Object message, Throwable t) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_WARN)) {
+            log(SimpleLog.LOG_LEVEL_WARN, message, t);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_ERROR</code>.
+     *
+     * @param message to log
+     * @see org.apache.commons.logging.Log#error(Object)
+     */
+    public final void error(Object message) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_ERROR)) {
+            log(SimpleLog.LOG_LEVEL_ERROR, message, null);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_ERROR</code>.
+     *
+     * @param message to log
+     * @param t log this cause
+     * @see org.apache.commons.logging.Log#error(Object, Throwable)
+     */
+    public final void error(Object message, Throwable t) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_ERROR)) {
+            log(SimpleLog.LOG_LEVEL_ERROR, message, t);
+        }
+    }
+
+    /**
+     * Log a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_FATAL</code>.
+     *
+     * @param message to log
+     * @see org.apache.commons.logging.Log#fatal(Object)
+     */
+    public final void fatal(Object message) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_FATAL)) {
+            log(SimpleLog.LOG_LEVEL_FATAL, message, null);
+        }
+    }
+
+    /**
+     * Logs a message with <code>org.apache.commons.logging.impl.SimpleLog.LOG_LEVEL_FATAL</code>.
+     *
+     * @param message to log
+     * @param t log this cause
+     * @see org.apache.commons.logging.Log#fatal(Object, Throwable)
+     */
+    public final void fatal(Object message, Throwable t) {
+        if (isLevelEnabled(SimpleLog.LOG_LEVEL_FATAL)) {
+            log(SimpleLog.LOG_LEVEL_FATAL, message, t);
+        }
+    }
+
+    /**
+     * Are debug messages currently enabled?
+     * <p>
+     * This allows expensive operations such as <code>String</code>
+     * concatenation to be avoided when the message will be ignored by the
+     * logger.
+     */
+    public final boolean isDebugEnabled() {
+        return isLevelEnabled(SimpleLog.LOG_LEVEL_DEBUG);
+    }
+
+    /**
+     * Are error messages currently enabled?
+     * <p>
+     * This allows expensive operations such as <code>String</code>
+     * concatenation to be avoided when the message will be ignored by the
+     * logger.
+     */
+    public final boolean isErrorEnabled() {
+        return isLevelEnabled(SimpleLog.LOG_LEVEL_ERROR);
+    }
+
+    /**
+     * Are fatal messages currently enabled?
+     * <p>
+     * This allows expensive operations such as <code>String</code>
+     * concatenation to be avoided when the message will be ignored by the
+     * logger.
+     */
+    public final boolean isFatalEnabled() {
+        return isLevelEnabled(SimpleLog.LOG_LEVEL_FATAL);
+    }
+
+    /**
+     * Are info messages currently enabled?
+     * <p>
+     * This allows expensive operations such as <code>String</code>
+     * concatenation to be avoided when the message will be ignored by the
+     * logger.
+     */
+    public final boolean isInfoEnabled() {
+        return isLevelEnabled(SimpleLog.LOG_LEVEL_INFO);
+    }
+
+    /**
+     * Are trace messages currently enabled?
+     * <p>
+     * This allows expensive operations such as <code>String</code>
+     * concatenation to be avoided when the message will be ignored by the
+     * logger.
+     */
+    public final boolean isTraceEnabled() {
+        return isLevelEnabled(SimpleLog.LOG_LEVEL_TRACE);
+    }
+
+    /**
+     * Are warn messages currently enabled?
+     * <p>
+     * This allows expensive operations such as <code>String</code>
+     * concatenation to be avoided when the message will be ignored by the
+     * logger.
+     */
+    public final boolean isWarnEnabled() {
+        return isLevelEnabled(SimpleLog.LOG_LEVEL_WARN);
+    }
+
+    /**
+     * Return the thread context class loader if available.
+     * Otherwise return null.
+     *
+     * The thread context class loader is available for JDK 1.2
+     * or later, if certain security conditions are met.
+     *
+     * @exception LogConfigurationException if a suitable class loader
+     * cannot be identified.
+     */
+    private static ClassLoader getContextClassLoader() {
+        ClassLoader classLoader = null;
+
+        try {
+            // Are we running on a JDK 1.2 or later system?
+            final Method method = Thread.class.getMethod("getContextClassLoader", (Class[]) null);
+
+            // Get the thread context class loader (if there is one)
+            try {
+                classLoader = (ClassLoader)method.invoke(Thread.currentThread(), (Class[]) null);
+            } catch (IllegalAccessException e) {
+                // ignore
+            } catch (InvocationTargetException e) {
+                /**
+                 * InvocationTargetException is thrown by 'invoke' when
+                 * the method being invoked (getContextClassLoader) throws
+                 * an exception.
+                 *
+                 * getContextClassLoader() throws SecurityException when
+                 * the context class loader isn't an ancestor of the
+                 * calling class's class loader, or if security
+                 * permissions are restricted.
+                 *
+                 * In the first case (not related), we want to ignore and
+                 * keep going.  We cannot help but also ignore the second
+                 * with the logic below, but other calls elsewhere (to
+                 * obtain a class loader) will trigger this exception where
+                 * we can make a distinction.
+                 */
+                if (e.getTargetException() instanceof SecurityException) {
+                    // ignore
+                } else {
+                    // Capture 'e.getTargetException()' exception for details
+                    // alternate: log 'e.getTargetException()', and pass back 'e'.
+                    throw new LogConfigurationException
+                        ("Unexpected InvocationTargetException", e.getTargetException());
+                }
+            }
+        } catch (NoSuchMethodException e) {
+            // Assume we are running on JDK 1.1
+            // ignore
+        }
+
+        if (classLoader == null) {
+            classLoader = SimpleLog.class.getClassLoader();
+        }
+
+        // Return the selected class loader
+        return classLoader;
+    }
+
+    private static InputStream getResourceAsStream(final String name) {
+        return (InputStream)AccessController.doPrivileged(
+            new PrivilegedAction() {
+                public Object run() {
+                    ClassLoader threadCL = getContextClassLoader();
+
+                    if (threadCL != null) {
+                        return threadCL.getResourceAsStream(name);
+                    } else {
+                        return ClassLoader.getSystemResourceAsStream(name);
+                    }
+                }
+            });
+    }
 }
+

--- a/jcl-over-slf4j/src/main/java/org/apache/commons/logging/package.html
+++ b/jcl-over-slf4j/src/main/java/org/apache/commons/logging/package.html
@@ -1,10 +1,11 @@
 <!--
 
- Copyright 2001-2004 The Apache Software Foundation.
- 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
  
       http://www.apache.org/licenses/LICENSE-2.0
  
@@ -17,29 +18,38 @@
 -->
 
 <body>
-<p>Jakarta Commons Logging implemented over SLF4J.</p>
+<p>Simple wrapper API around multiple logging APIs.</p>
 
 
 <h3>Overview</h3>
 
-<p>This package contains the same public user interface as <a
-href="http://jakarta.apache.org/commons/logging/">Jakarta Commons
-Logging (JCL)</a>. It is intended as a 100% compatible drop-in
-replacement for the original JCL version 1.0.4.
-</p>
+<p>This package provides an API for logging in server-based applications that
+    can be used around a variety of different logging implementations, including
+    prebuilt support for the following:</p>
+<ul>
+    <li><a href="http://logging.apache.org/log4j/">Log4J</a> (version 1.2 or later)
+        from Apache's Logging project.  Each named <a href="Log.html">Log</a>
+        instance is connected to a corresponding Log4J Logger.</li>
+    <li><a href="http://java.sun.com/j2se/1.4/docs/guide/util/logging/index.html">
+        JDK Logging API</a>, included in JDK 1.4 or later systems.  Each named
+        <a href="Log.html">Log</a> instance is connected to a corresponding
+        <code>java.util.logging.Logger</code> instance.</li>
+    <li><a href="http://avalon.apache.org/logkit/">LogKit</a> from Apache's
+        Avalon project.  Each named <a href="Log.html">Log</a> instance is
+        connected to a corresponding LogKit <code>Logger</code>.</li>
+    <li><a href="impl/NoOpLog.html">NoOpLog</a> implementation that simply swallows
+        all log output, for all named <a href="Log.html">Log</a> instances.</li>
+    <li><a href="impl/SimpleLog.html">SimpleLog</a> implementation that writes all
+        log output, for all named <a href="Log.html">Log</a> instances, to
+        System.err.</li>
+</ul>
 
-<p>As the original JCL version 1.0.4, the present version supports
-various logging APIs. It differs from the original in implementation
-but not the public API. This implementation uses SLF4J under the
-covers. As as such, all the logging systems that SLF4J supports,
-e.g. NOP, Simple, JDK14, nlog4j are supported by this version of JCL.
-</p>
 
 <h3>Quick Start Guide</h3>
 
 <p>For those impatient to just get on with it, the following example
-illustrates the typical declaration and use of a logger that is named (by
-convention) after the calling class:
+    illustrates the typical declaration and use of a logger that is named (by
+    convention) after the calling class:
 
 <pre>
     import org.apache.commons.logging.Log;
@@ -47,7 +57,7 @@ convention) after the calling class:
 
     public class Foo {
 
-        static Log log = LogFactory.getLog(Foo.class);
+        private Log log = LogFactory.getLog(Foo.class);
 
         public void foo() {
             ...
@@ -63,63 +73,139 @@ convention) after the calling class:
         }
 </pre>
 
+<p>Unless you configure things differently, all log output will be written
+    to System.err.  Therefore, you really will want to review the remainder of
+    this page in order to understand how to configure logging for your
+    application.</p>
+
+
 <h3>Configuring the Commons Logging Package</h3>
 
-<p>In this version of JCL, the selection of the logging system to use
-is chosen by the underlying SLF4J API. Consequently, all JCL-specific
-configuration parameters are ignored.
-</p>
 
 <h4>Choosing a <code>LogFactory</code> Implementation</h4>
 
-<p>From an application perspective, the first requirement is to
-retrieve an object reference to the <code>LogFactory</code> instance
-that will be used to create <code><a href="Log.html">Log</a></code>
-instances for this application.  This is normally accomplished by
-calling the static <code>getFactory()</code> method.  This method
-always returns the same factory, i.e. a unique instance of the <a
-href="impl/SLF4FLogFactory.html">SLF4FLogFactory</a> class.
-</p>
+<p>From an application perspective, the first requirement is to retrieve an
+    object reference to the <code>LogFactory</code> instance that will be used
+    to create <code><a href="Log.html">Log</a></code> instances for this
+    application.  This is normally accomplished by calling the static
+    <code>getFactory()</code> method.  This method implements the following
+    discovery algorithm to select the name of the <code>LogFactory</code>
+    implementation class this application wants to use:</p>
+<ul>
+    <li>Check for a system property named
+        <code>org.apache.commons.logging.LogFactory</code>.</li>
+    <li>Use the JDK 1.3 JAR Services Discovery mechanism (see
+        <a href="http://java.sun.com/j2se/1.3/docs/guide/jar/jar.html">
+            http://java.sun.com/j2se/1.3/docs/guide/jar/jar.html</a> for
+        more information) to look for a resource named
+        <code>META-INF/services/org.apache.commons.logging.LogFactory</code>
+        whose first line is assumed to contain the desired class name.</li>
+    <li>Look for a properties file named <code>commons-logging.properties</code>
+        visible in the application class path, with a property named
+        <code>org.apache.commons.logging.LogFactory</code> defining the
+        desired implementation class name.</li>
+    <li>Fall back to a default implementation, which is described
+        further below.</li>
+</ul>
 
+<p>If a <code>commons-logging.properties</code> file is found, all of the
+    properties defined there are also used to set configuration attributes on
+    the instantiated <code>LogFactory</code> instance.</p>
+
+<p>Once an implementation class name is selected, the corresponding class is
+    loaded from the current Thread context class loader (if there is one), or
+    from the class loader that loaded the <code>LogFactory</code> class itself
+    otherwise.  This allows a copy of <code>commons-logging.jar</code> to be
+    shared in a multiple class loader environment (such as a servlet container),
+    but still allow each web application to provide its own <code>LogFactory</code>
+    implementation, if it so desires.  An instance of this class will then be
+    created, and cached per class loader.
+
+
+<h4>The Default <code>LogFactory</code> Implementation</h4>
+
+<p>The Logging Package APIs include a default <code>LogFactory</code>
+    implementation class (<a href="impl/LogFactoryImpl.html">
+        org.apache.commons.logging.impl.LogFactoryImpl</a>) that is selected if no
+    other implementation class name can be discovered.  Its primary purpose is
+    to create (as necessary) and return <a href="Log.html">Log</a> instances
+    in response to calls to the <code>getInstance()</code> method.  The default
+    implementation uses the following rules:</p>
+<ul>
+    <li>At most one <code>Log</code> instance of the same name will be created.
+        Subsequent <code>getInstance()</code> calls to the same
+        <code>LogFactory</code> instance, with the same name or <code>Class</code>
+        parameter, will return the same <code>Log</code> instance.</li>
+    <li>When a new <code>Log</code> instance must be created, the default
+        <code>LogFactory</code> implementation uses the following discovery
+        process:
+        <ul>
+            <li>Look for a configuration attribute of this factory named
+                <code>org.apache.commons.logging.Log</code> (for backwards
+                compatibility to pre-1.0 versions of this API, an attribute
+                <code>org.apache.commons.logging.log</code> is also consulted).</li>
+            <li>Look for a system property named
+                <code>org.apache.commons.logging.Log</code> (for backwards
+                compatibility to pre-1.0 versions of this API, a system property
+                <code>org.apache.commons.logging.log</code> is also consulted).</li>
+            <li>If the Log4J logging system is available in the application
+                class path, use the corresponding wrapper class
+                (<a href="impl/Log4JLogger.html">Log4JLogger</a>).</li>
+            <li>If the application is executing on a JDK 1.4 system, use
+                the corresponding wrapper class
+                (<a href="impl/Jdk14Logger.html">Jdk14Logger</a>).</li>
+            <li>Fall back to the default simple logging implementation
+                (<a href="impl/SimpleLog.html">SimpleLog</a>).</li>
+        </ul></li>
+    <li>Load the class of the specified name from the thread context class
+        loader (if any), or from the class loader that loaded the
+        <code>LogFactory</code> class otherwise.</li>
+    <li>Instantiate an instance of the selected <code>Log</code>
+        implementation class, passing the specified name as the single
+        argument to its constructor.</li>
+</ul>
+
+<p>See the <a href="impl/SimpleLog.html">SimpleLog</a> JavaDocs for detailed
+    configuration information for this default implementation.</p>
 
 
 <h4>Configuring the Underlying Logging System</h4>
 
 <p>The basic principle is that the user is totally responsible for the
-configuration of the underlying logging system.
-Commons-logging should not change the existing configuration.</p>
+    configuration of the underlying logging system.
+    Commons-logging should not change the existing configuration.</p>
 
 <p>Each individual <a href="Log.html">Log</a> implementation may
-support its own configuration properties.  These will be documented in the
-class descriptions for the corresponding implementation class.</p>
+    support its own configuration properties.  These will be documented in the
+    class descriptions for the corresponding implementation class.</p>
 
 <p>Finally, some <code>Log</code> implementations (such as the one for Log4J)
-require an external configuration file for the entire logging environment.
-This file should be prepared in a manner that is specific to the actual logging
-technology being used.</p>
+    require an external configuration file for the entire logging environment.
+    This file should be prepared in a manner that is specific to the actual logging
+    technology being used.</p>
 
 
 <h3>Using the Logging Package APIs</h3>
 
 <p>Use of the Logging Package APIs, from the perspective of an application
-component, consists of the following steps:</p>
+    component, consists of the following steps:</p>
 <ol>
-<li>Acquire a reference to an instance of
-    <a href="Log.html">org.apache.commons.logging.Log</a>, by calling the
-    factory method
-    <a href="LogFactory.html#getInstance(java.lang.String)">
-    LogFactory.getInstance(String name)</a>.  Your application can contain
-    references to multiple loggers that are used for different
-    purposes.  A typical scenario for a server application is to have each
-    major component of the server use its own Log instance.</li>
-<li>Cause messages to be logged (if the corresponding detail level is enabled)
-    by calling appropriate methods (<code>trace()</code>, <code>debug()</code>,
-    <code>info()</code>, <code>warn()</code>, <code>error</code>, and
-    <code>fatal()</code>).</li>
+    <li>Acquire a reference to an instance of
+        <a href="Log.html">org.apache.commons.logging.Log</a>, by calling the
+        factory method
+        <a href="LogFactory.html#getInstance(java.lang.String)">
+            LogFactory.getInstance(String name)</a>.  Your application can contain
+        references to multiple loggers that are used for different
+        purposes.  A typical scenario for a server application is to have each
+        major component of the server use its own Log instance.</li>
+    <li>Cause messages to be logged (if the corresponding detail level is enabled)
+        by calling appropriate methods (<code>trace()</code>, <code>debug()</code>,
+        <code>info()</code>, <code>warn()</code>, <code>error</code>, and
+        <code>fatal()</code>).</li>
 </ol>
 
 <p>For convenience, <code>LogFactory</code> also offers a static method
-<code>getLog()</code> that combines the typical two-step pattern:</p>
+    <code>getLog()</code> that combines the typical two-step pattern:</p>
 <pre>
   Log log = LogFactory.getFactory().getInstance(Foo.class);
 </pre>
@@ -129,14 +215,14 @@ component, consists of the following steps:</p>
 </pre>
 
 <p>For example, you might use the following technique to initialize and
-use a <a href="Log.html">Log</a> instance in an application component:</p>
+    use a <a href="Log.html">Log</a> instance in an application component:</p>
 <pre>
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 public class MyComponent {
 
-  protected static Log log =
+  protected Log log =
     LogFactory.getLog(MyComponent.class);
 
   // Called once at startup time

--- a/jcl-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/jcl-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
@@ -4,6 +4,6 @@ Bundle-SymbolicName: jcl.over.slf4j
 Bundle-Name: jcl-over-slf4j
 Bundle-Vendor: SLF4J.ORG
 Bundle-RequiredExecutionEnvironment: J2SE-1.3
-Export-Package: org.apache.commons.logging;version=1.1.1, 
-  org.apache.commons.logging.impl;version=1.1.1
+Export-Package: org.apache.commons.logging;version=1.1.3,
+  org.apache.commons.logging.impl;version=1.1.3
 Import-Package: org.slf4j;version=${parsedVersion.osgiVersion}, org.slf4j.spi;version=${parsedVersion.osgiVersion}

--- a/slf4j-jcl/pom.xml
+++ b/slf4j-jcl/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.3</version>
 		</dependency>
 
   </dependencies>

--- a/slf4j-site/src/site/pages/faq.html
+++ b/slf4j-site/src/site/pages/faq.html
@@ -674,7 +674,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
          <pre class="prettyprint source">&lt;dependency>
   &lt;groupId>commons-logging&lt;/groupId>
   &lt;artifactId>commons-logging&lt;/artifactId>
-  &lt;version>1.1.1&lt;/version>
+  &lt;version>1.1.3&lt;/version>
   &lt;scope>provided&lt;/scope>
 &lt;/dependency>
 

--- a/slf4j-site/src/site/pages/legacy.html
+++ b/slf4j-site/src/site/pages/legacy.html
@@ -57,7 +57,7 @@
     
     <p>To ease migration to SLF4J from JCL, SLF4J distributions
     include the jar file <em>jcl-over-slf4j.jar</em>. This jar file is
-    intended as a drop-in replacement for JCL version 1.1.1. It
+    intended as a drop-in replacement for JCL version 1.1.3. It
     implements the public API of JCL but using SLF4J underneath, hence
     the name "JCL over SLF4J."
     </p>

--- a/slf4j-site/src/site/pages/news.html
+++ b/slf4j-site/src/site/pages/news.html
@@ -718,7 +718,7 @@
   <p>See also the <a href="compatibility.html#1_5_1">compatibility
   report for this version</a>.</p>
 
-  <p>In order to support JCL version 1.1.1, the
+  <p>In order to support JCL version 1.1.3, the
   <em>jcl<b>104</b>-over-slf4j</em> module was renamed as
   <em>jcl-over-slf4j</em>. SLF4J will no longer ship with
   <em>jcl104-over-slf4j.jar</em> but with <em>jcl-over-slf4j.jar</em>.


### PR DESCRIPTION
This change is motivated by:

* Spring 4.1 has moved to Commons Logging 1.1.3 https://github.com/spring-projects/spring-framework/commit/8ae3aa7f59bea714abd7da681f487b5cf1b13165
* Servicemix (who now build the Spring EBR bundles) have done the same: http://svn.apache.org/repos/asf/servicemix/smx4/bundles/trunk/spring-core-4.1.0.RELEASE/pom.xml
* Other projects seem affected (Eclipse Gemini): https://www.eclipse.org/forums/index.php/m/1470033/#msg_1470033
* Sakai: https://jira.sakaiproject.org/browse/SAK-28095

1.1.3 of Commons Logging was released May 2013, contains only bug fixes (and is thus binary compatible): http://commons.apache.org/proper/commons-logging/changes-report.html

This change will enable the jcl-over-slf4j bundle to be used in an OSGi env that requires commons-logging 1.1.3