### PR TITLE
Upgrades to Junit 4.12

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -56,7 +56,7 @@
           <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>${junit.version}</version>
           </dependency>
           <dependency>
             <groupId>ant</groupId>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>${junit.version}</version>
     </dependency>
     <!-- declaration to circumvent  http://jira.codehaus.org/browse/MANTRUN-95 -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <cal10n.version>0.8.1</cal10n.version>
     <log4j.version>1.2.17</log4j.version>
     <logback.version>1.0.13</logback.version>
-    <junit.version>4.10</junit.version>
+    <junit.version>4.12</junit.version>
     <maven-site-plugin.version>3.3</maven-site-plugin.version>
   </properties>
 


### PR DESCRIPTION
Upgrade to latest version of Junit, 4.12. This is now used for all modules, including integration which seemed stuck on a different, older version.

`mvn clean install` ran successfully.
