### PR TITLE
Pass arguments to JUL as record parameters

### DIFF
--- a/slf4j-jdk14/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java
+++ b/slf4j-jdk14/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java
@@ -73,7 +73,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void trace(String msg) {
         if (logger.isLoggable(Level.FINEST)) {
-            log(SELF, Level.FINEST, msg, null);
+            log(SELF, Level.FINEST, msg, null, null);
         }
     }
 
@@ -94,7 +94,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void trace(String format, Object arg) {
         if (logger.isLoggable(Level.FINEST)) {
             FormattingTuple ft = MessageFormatter.format(format, arg);
-            log(SELF, Level.FINEST, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.FINEST, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -117,7 +117,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void trace(String format, Object arg1, Object arg2) {
         if (logger.isLoggable(Level.FINEST)) {
             FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
-            log(SELF, Level.FINEST, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.FINEST, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -138,7 +138,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void trace(String format, Object... argArray) {
         if (logger.isLoggable(Level.FINEST)) {
             FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
-            log(SELF, Level.FINEST, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.FINEST, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -152,7 +152,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void trace(String msg, Throwable t) {
         if (logger.isLoggable(Level.FINEST)) {
-            log(SELF, Level.FINEST, msg, t);
+            log(SELF, Level.FINEST, msg, null, t);
         }
     }
 
@@ -173,7 +173,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void debug(String msg) {
         if (logger.isLoggable(Level.FINE)) {
-            log(SELF, Level.FINE, msg, null);
+            log(SELF, Level.FINE, msg, null, null);
         }
     }
 
@@ -193,7 +193,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void debug(String format, Object arg) {
         if (logger.isLoggable(Level.FINE)) {
             FormattingTuple ft = MessageFormatter.format(format, arg);
-            log(SELF, Level.FINE, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.FINE, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -216,7 +216,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void debug(String format, Object arg1, Object arg2) {
         if (logger.isLoggable(Level.FINE)) {
             FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
-            log(SELF, Level.FINE, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.FINE, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -237,7 +237,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void debug(String format, Object... argArray) {
         if (logger.isLoggable(Level.FINE)) {
             FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
-            log(SELF, Level.FINE, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.FINE, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -251,7 +251,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void debug(String msg, Throwable t) {
         if (logger.isLoggable(Level.FINE)) {
-            log(SELF, Level.FINE, msg, t);
+            log(SELF, Level.FINE, msg, null, t);
         }
     }
 
@@ -272,7 +272,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void info(String msg) {
         if (logger.isLoggable(Level.INFO)) {
-            log(SELF, Level.INFO, msg, null);
+            log(SELF, Level.INFO, msg, null, null);
         }
     }
 
@@ -292,7 +292,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void info(String format, Object arg) {
         if (logger.isLoggable(Level.INFO)) {
             FormattingTuple ft = MessageFormatter.format(format, arg);
-            log(SELF, Level.INFO, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.INFO, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -315,7 +315,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void info(String format, Object arg1, Object arg2) {
         if (logger.isLoggable(Level.INFO)) {
             FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
-            log(SELF, Level.INFO, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.INFO, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -336,7 +336,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void info(String format, Object... argArray) {
         if (logger.isLoggable(Level.INFO)) {
             FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
-            log(SELF, Level.INFO, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.INFO, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -351,7 +351,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void info(String msg, Throwable t) {
         if (logger.isLoggable(Level.INFO)) {
-            log(SELF, Level.INFO, msg, t);
+            log(SELF, Level.INFO, msg, null, t);
         }
     }
 
@@ -373,7 +373,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void warn(String msg) {
         if (logger.isLoggable(Level.WARNING)) {
-            log(SELF, Level.WARNING, msg, null);
+            log(SELF, Level.WARNING, msg, null, null);
         }
     }
 
@@ -394,7 +394,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void warn(String format, Object arg) {
         if (logger.isLoggable(Level.WARNING)) {
             FormattingTuple ft = MessageFormatter.format(format, arg);
-            log(SELF, Level.WARNING, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.WARNING, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -417,7 +417,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void warn(String format, Object arg1, Object arg2) {
         if (logger.isLoggable(Level.WARNING)) {
             FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
-            log(SELF, Level.WARNING, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.WARNING, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -438,7 +438,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void warn(String format, Object... argArray) {
         if (logger.isLoggable(Level.WARNING)) {
             FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
-            log(SELF, Level.WARNING, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.WARNING, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -453,7 +453,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void warn(String msg, Throwable t) {
         if (logger.isLoggable(Level.WARNING)) {
-            log(SELF, Level.WARNING, msg, t);
+            log(SELF, Level.WARNING, msg, null, t);
         }
     }
 
@@ -474,7 +474,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void error(String msg) {
         if (logger.isLoggable(Level.SEVERE)) {
-            log(SELF, Level.SEVERE, msg, null);
+            log(SELF, Level.SEVERE, msg, null, null);
         }
     }
 
@@ -495,7 +495,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void error(String format, Object arg) {
         if (logger.isLoggable(Level.SEVERE)) {
             FormattingTuple ft = MessageFormatter.format(format, arg);
-            log(SELF, Level.SEVERE, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.SEVERE, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -518,7 +518,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void error(String format, Object arg1, Object arg2) {
         if (logger.isLoggable(Level.SEVERE)) {
             FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
-            log(SELF, Level.SEVERE, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.SEVERE, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -539,7 +539,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void error(String format, Object... arguments) {
         if (logger.isLoggable(Level.SEVERE)) {
             FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
-            log(SELF, Level.SEVERE, ft.getMessage(), ft.getThrowable());
+            log(SELF, Level.SEVERE, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         }
     }
 
@@ -554,7 +554,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void error(String msg, Throwable t) {
         if (logger.isLoggable(Level.SEVERE)) {
-            log(SELF, Level.SEVERE, msg, t);
+            log(SELF, Level.SEVERE, msg, null, t);
         }
     }
 
@@ -569,10 +569,11 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
      * @param msg
      * @param t
      */
-    private void log(String callerFQCN, Level level, String msg, Throwable t) {
+    private void log(String callerFQCN, Level level, String msg, Object[] args, Throwable t) {
         // millis and thread are filled by the constructor
         LogRecord record = new LogRecord(level, msg);
         record.setLoggerName(getName());
+        record.setParameters(args);
         record.setThrown(t);
         fillCallerData(callerFQCN, record);
         logger.log(record);
@@ -645,7 +646,7 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
         // do not perform this check. See also
         // http://bugzilla.slf4j.org/show_bug.cgi?id=90
         if (logger.isLoggable(julLevel)) {
-            log(callerFQCN, julLevel, message, t);
+            log(callerFQCN, julLevel, message, argArray, t);
         }
     }
 }

--- a/slf4j-jdk14/src/test/java/org/slf4j/InvocationTest.java
+++ b/slf4j-jdk14/src/test/java/org/slf4j/InvocationTest.java
@@ -71,6 +71,7 @@ public class InvocationTest {
         Logger logger = LoggerFactory.getLogger("test1");
         logger.debug("Hello world.");
         assertLogMessage("Hello world.", 0);
+        assertParameters(null, 0);
     }
 
     @Test
@@ -83,28 +84,48 @@ public class InvocationTest {
 
         int index = 0;
         logger.debug("Hello world");
-        assertLogMessage("Hello world", index++);
+        assertLogMessage("Hello world", index);
+        assertParameters(null, index++);
 
         logger.debug("Hello world {}", i1);
-        assertLogMessage("Hello world " + i1, index++);
+        assertLogMessage("Hello world " + i1, index);
+        assertParameters(new Object[] { i1 }, index++);
 
         logger.debug("val={} val={}", i1, i2);
-        assertLogMessage("val=1 val=2", index++);
+        assertLogMessage("val=1 val=2", index);
+        assertParameters(new Object[] { i1, i2 }, index++);
 
         logger.debug("val={} val={} val={}", new Object[] { i1, i2, i3 });
-        assertLogMessage("val=1 val=2 val=3", index++);
+        assertLogMessage("val=1 val=2 val=3", index);
+        assertParameters(new Object[] { i1, i2, i3 }, index++);
+
+        logger.debug("val={} val={} val={}", i1, i2, i3, e);
+        assertLogMessage("val=1 val=2 val=3", index);
+        assertException(e.getClass(), index);
+        assertParameters(new Object[] { i1, i2, i3 }, index++);
 
         logger.debug("Hello world 2", e);
         assertLogMessage("Hello world 2", index);
-        assertException(e.getClass(), index++);
+        assertException(e.getClass(), index);
+        assertParameters(null, index++);
+
         logger.info("Hello world 2.");
+        assertParameters(null, index++);
 
         logger.warn("Hello world 3.");
+        assertParameters(null, index++);
+
         logger.warn("Hello world 3", e);
+        assertParameters(null, index++);
 
         logger.error("Hello world 4.");
+        assertParameters(null, index++);
+
         logger.error("Hello world {}", new Integer(3));
+        assertParameters(new Object[] { i3 }, index++);
+
         logger.error("Hello world 4.", e);
+        assertParameters(null, index++);
     }
 
     @Test
@@ -167,6 +188,12 @@ public class InvocationTest {
         LogRecord logRecord = listHandler.recordList.get(index);
         Assert.assertNotNull(logRecord);
         assertEquals(expected, logRecord.getMessage());
+    }
+
+    private void assertParameters(Object[] parameters, int index) {
+        LogRecord logRecord = listHandler.recordList.get(index);
+        Assert.assertNotNull(logRecord);
+        Assert.assertArrayEquals(parameters, logRecord.getParameters());
     }
 
     private void assertException(Class<? extends Throwable> exceptionType, int index) {


### PR DESCRIPTION
While trying to migrate a project from JUL to SLF4J/Logback, I noticed that argument parameters are not being passed through the SLF4J JDK14 adapter.  Since these arguments are being passed through to Logback -- and I believe through the Log4j adapter to Log4j -- it seems natural that they should be passed through the adapter to JUL as well.

First pull request.  Let me know if there are any special procedures I need to follow.