### PR TITLE
Update AppenderSkeleton to include setThreshold() method mute implementation

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/AppenderSkeleton.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/AppenderSkeleton.java
@@ -28,4 +28,6 @@ public class AppenderSkeleton implements OptionHandler {
   public void activateOptions() {
   }
 
+  public void setThreshold(Priority threshold) {
+  }
 }


### PR DESCRIPTION
Adding and muting the setThreshold method call without which the Log4j bridge is broken for underlying dependencies that are manipulating Log4j Appenders directly