### PR TITLE
SLF4J-312 Using AbstractStringBuilder#append(str,start,end)

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
@@ -203,34 +203,34 @@ final public class MessageFormatter {
                     return new FormattingTuple(messagePattern, argArray, throwableCandidate);
                 } else { // add the tail string which contains no variables and return
                     // the result.
-                    sbuf.append(messagePattern.substring(i, messagePattern.length()));
+                    sbuf.append(messagePattern, i, messagePattern.length());
                     return new FormattingTuple(sbuf.toString(), argArray, throwableCandidate);
                 }
             } else {
                 if (isEscapedDelimeter(messagePattern, j)) {
                     if (!isDoubleEscaped(messagePattern, j)) {
                         L--; // DELIM_START was escaped, thus should not be incremented
-                        sbuf.append(messagePattern.substring(i, j - 1));
+                        sbuf.append(messagePattern, i, j - 1);
                         sbuf.append(DELIM_START);
                         i = j + 1;
                     } else {
                         // The escape character preceding the delimiter start is
                         // itself escaped: "abc x:\\{}"
                         // we have to consume one backward slash
-                        sbuf.append(messagePattern.substring(i, j - 1));
+                        sbuf.append(messagePattern, i, j - 1);
                         deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Object>());
                         i = j + 2;
                     }
                 } else {
                     // normal case
-                    sbuf.append(messagePattern.substring(i, j));
+                    sbuf.append(messagePattern, i, j);
                     deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Object>());
                     i = j + 2;
                 }
             }
         }
         // append the characters following the last {} pair.
-        sbuf.append(messagePattern.substring(i, messagePattern.length()));
+        sbuf.append(messagePattern, i, messagePattern.length());
         if (L < argArray.length - 1) {
             return new FormattingTuple(sbuf.toString(), argArray, throwableCandidate);
         } else {

--- a/slf4j-migrator/src/main/java/org/slf4j/migrator/helper/Abbreviator.java
+++ b/slf4j-migrator/src/main/java/org/slf4j/migrator/helper/Abbreviator.java
@@ -48,7 +48,7 @@ public class Abbreviator {
                 return filename;
             }
             StringBuilder buf = new StringBuilder(desiredLength);
-            buf.append(filename.substring(0, firstIndex + 1));
+            buf.append(filename, 0, firstIndex + 1);
             buf.append(FILLER);
             int nextIndex = computeNextIndex(filename, firstIndex);
             if (nextIndex != -1) {


### PR DESCRIPTION
SLF4J-312 Eliminating one stack frame by using AbstractStringBuilder#append(str,start,end). A bit more readable compared to inlined String.substring(start,end)