### PR TITLE
Use _ to shorten tag names instead of *.

### DIFF
--- a/slf4j-android/pom.xml
+++ b/slf4j-android/pom.xml
@@ -11,6 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>slf4j-android</artifactId>
+    <version>1.7.13-underscore</version>
     <packaging>jar</packaging>
     <name>SLF4J Android Binding</name>
     <description>SLF4J Android Binding</description>
@@ -20,7 +21,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${project.version}</version>
+            <version>1.7.13-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/slf4j-android/src/main/java/org/slf4j/impl/AndroidLoggerFactory.java
+++ b/slf4j-android/src/main/java/org/slf4j/impl/AndroidLoggerFactory.java
@@ -89,7 +89,7 @@ class AndroidLoggerFactory implements ILoggerFactory {
             // token of one character appended as is otherwise truncate it to one character
             int tokenLength = lastPeriodIndex - lastTokenIndex;
             if (tokenLength > 1) {
-                tagName.append('*');
+                tagName.append('_');
             }
             tagName.append('.');
             lastTokenIndex = lastPeriodIndex + 1;
@@ -114,11 +114,11 @@ class AndroidLoggerFactory implements ILoggerFactory {
     }
 
     private static String getSimpleName(String loggerName) {
-        // Take leading part and append '*' to indicate that it was truncated
+        // Take leading part and append '_' to indicate that it was truncated
         int length = loggerName.length();
         int lastPeriodIndex = loggerName.lastIndexOf('.');
         return lastPeriodIndex != -1 && length - (lastPeriodIndex + 1) <= TAG_MAX_LENGTH
             ? loggerName.substring(lastPeriodIndex + 1)
-            : '*' + loggerName.substring(length - TAG_MAX_LENGTH + 1);
+            : '_' + loggerName.substring(length - TAG_MAX_LENGTH + 1);
     }
 }

--- a/slf4j-android/src/test/java/org/slf4j/impl/AndroidLoggerFactoryTest.java
+++ b/slf4j-android/src/test/java/org/slf4j/impl/AndroidLoggerFactoryTest.java
@@ -44,13 +44,13 @@ public class AndroidLoggerFactoryTest {
 
     @Test
     public void simpleLoggerName() {
-        assertEquals("o*.t*.p*.TestClass", AndroidLoggerFactory.loggerNameToTag("org.test.package.TestClass"));
+        assertEquals("o_.t_.p_.TestClass", AndroidLoggerFactory.loggerNameToTag("org.test.package.TestClass"));
     }
 
     @Test
     public void loggerNameWithOneCharPackage() {
-        assertEquals("o.t*.p*.p*.TestClass", AndroidLoggerFactory.loggerNameToTag("o.test.project.package.TestClass"));
-        assertEquals("o.t*.p*.p.TestClass", AndroidLoggerFactory.loggerNameToTag("o.test.project.p.TestClass"));
+        assertEquals("o.t_.p_.p_.TestClass", AndroidLoggerFactory.loggerNameToTag("o.test.project.package.TestClass"));
+        assertEquals("o.t_.p_.p.TestClass", AndroidLoggerFactory.loggerNameToTag("o.test.project.p.TestClass"));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class AndroidLoggerFactoryTest {
 
     @Test
     public void veryLongLoggerName() {
-        assertEquals("*meAndShouldBeTruncated", AndroidLoggerFactory.loggerNameToTag("IAmAVeryLongLoggerNameAndShouldBeTruncated"));
+        assertEquals("_meAndShouldBeTruncated", AndroidLoggerFactory.loggerNameToTag("IAmAVeryLongLoggerNameAndShouldBeTruncated"));
     }
 
     @Test


### PR DESCRIPTION
A common method of enabling logging for a certain tag involves issuing
the setprop command via adb shell.  Unfortunately, it is impossible to
set a property on a key whose name contains a \* using this method.  As
such, \* is a bad choice for shortening tag names, since it means we
cannot use this method for setting the log level of a tag.
