### PR TITLE
Lazy load SecurityManager.

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/Util.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/Util.java
@@ -46,7 +46,7 @@ public final class Util {
         }
     }
 
-    private static final ClassContextSecurityManager SECURITY_MANAGER = new ClassContextSecurityManager();
+    private static ClassContextSecurityManager SECURITY_MANAGER = null;
 
     /**
      * Returns the name of the class which called the invoking method.
@@ -54,6 +54,11 @@ public final class Util {
      * @return the name of the class which called the invoking method.
      */
     public static Class<?> getCallingClass() {
+        synchronized (Util.class) {
+            if (SECURITY_MANAGER == null) {
+                SECURITY_MANAGER = new ClassContextSecurityManager();
+            }
+        }
         Class<?>[] trace = SECURITY_MANAGER.getClassContext();
         String thisClassName = Util.class.getName();
 


### PR DESCRIPTION
This fixes SLF4J-324, since the user can opt out of the
slf4j.detectLoggerNameMismatch if there is a SecurityManager that denies
"createSecurityManager".