### PR TITLE
Allow the logger name mismatch detector to work even if security manager creation is disabled.

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/Util.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/Util.java
@@ -24,6 +24,10 @@
  */
 package org.slf4j.helpers;
 
+import org.slf4j.helpers.callingclass.CallingClassFinder;
+import org.slf4j.helpers.callingclass.ExceptionCallingClassFinder;
+import org.slf4j.helpers.callingclass.SecurityManagerCallingClassFinder;
+
 /**
  * An internal utility class.
  *
@@ -35,95 +39,29 @@ public final class Util {
     private Util() {
     }
 
-    public static String safeGetSystemProperty(String key) {
-        if (key == null)
-            throw new IllegalArgumentException("null input");
+    private static CallingClassFinder CALLING_CLASS_FINDER = createCallingClassFinder();
 
-        String result = null;
-        try {
-            result = System.getProperty(key);
-        } catch (java.lang.SecurityException sm) {
-            ; // ignore
-        }
-        return result;
+    public static String getCallingClassName() {
+        return CALLING_CLASS_FINDER.getCallingClassName(2);
     }
 
-    public static boolean safeGetBooleanSystemProperty(String key) {
-        String value = safeGetSystemProperty(key);
-        if (value == null)
-            return false;
-        else
-            return value.equalsIgnoreCase("true");
-    }
-
-    /**
-     * In order to call {@link SecurityManager#getClassContext()}, which is a
-     * protected method, we add this wrapper which allows the method to be visible
-     * inside this package.
-     */
-    private static final class ClassContextSecurityManager extends SecurityManager {
-        protected Class<?>[] getClassContext() {
-            return super.getClassContext();
-        }
-    }
-
-    private static ClassContextSecurityManager SECURITY_MANAGER;
-    private static boolean SECURITY_MANAGER_CREATION_ALREADY_ATTEMPTED = false;
-    
-    private static ClassContextSecurityManager getSecurityManager() {
-        if(SECURITY_MANAGER != null)
-            return SECURITY_MANAGER;
-        else if(SECURITY_MANAGER_CREATION_ALREADY_ATTEMPTED)
-            return null;
-        else {
-            SECURITY_MANAGER = safeCreateSecurityManager(); 
-            SECURITY_MANAGER_CREATION_ALREADY_ATTEMPTED = true;
-            return SECURITY_MANAGER;
-        }
-    }
-    
-    private static ClassContextSecurityManager safeCreateSecurityManager() {
-        try {
-            return new ClassContextSecurityManager();
-        } catch (java.lang.SecurityException sm) {
-            return null;
-        }
-    }
-
-    /**
-     * Returns the name of the class which called the invoking method.
-     *
-     * @return the name of the class which called the invoking method.
-     */
-    public static Class<?> getCallingClass() {
-        ClassContextSecurityManager securityManager = getSecurityManager();
-        if(securityManager == null)
-            return null;
-        Class<?>[] trace = securityManager.getClassContext();
-        String thisClassName = Util.class.getName();
-
-        // Advance until Util is found
-        int i;
-        for (i = 0; i < trace.length; i++) {
-            if (thisClassName.equals(trace[i].getName()))
-                break;
-        }
-
-        // trace[i] = Util; trace[i+1] = caller; trace[i+2] = caller's caller
-        if (i >= trace.length || i + 2 >= trace.length) {
-            throw new IllegalStateException("Failed to find org.slf4j.helpers.Util or its caller in the stack; " + "this should not happen");
-        }
-
-        return trace[i + 2];
-    }
-
-    static final public void report(String msg, Throwable t) {
+    public static final void report(String msg, Throwable t) {
         System.err.println(msg);
         System.err.println("Reported exception:");
         t.printStackTrace();
     }
 
-    static final public void report(String msg) {
+    public static final void report(String msg) {
         System.err.println("SLF4J: " + msg);
+    }
+
+    private static CallingClassFinder createCallingClassFinder() {
+      CallingClassFinder finder = SecurityManagerCallingClassFinder.createInstance();
+      if (finder != null) {
+        return finder;
+      }
+      report("Failed to create custom security manager for finding calling class; " +
+             "falling back to exception stack trace.");
+      return new ExceptionCallingClassFinder();
     }
 }

--- a/slf4j-api/src/main/java/org/slf4j/helpers/callingclass/CallingClassFinder.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/callingclass/CallingClassFinder.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2004-2015 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers.callingclass;
+
+
+/**
+ * An interface for classes capable of obtaining caller information at runtime.
+ * @author Alexander Dorokhine
+ */
+public interface CallingClassFinder {
+
+    /**
+     * Returns the name of the class which called the invoking method.
+     *
+     * @param depth The depth of caller you are interested in. 0 is your own class, 1 is
+     *              your caller, 2 is your caller's caller, etc.
+     *
+     * @return the name of the class which called the invoking method.
+     */
+    public String getCallingClassName(int depth);
+}

--- a/slf4j-api/src/main/java/org/slf4j/helpers/callingclass/ExceptionCallingClassFinder.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/callingclass/ExceptionCallingClassFinder.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2004-2015 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers.callingclass;
+
+
+/**
+ * A utility class for finding a method's caller using exceptions.
+ *
+ * This is slower than {@link SecurityManagerCallingClassFinder#getCallingClassName()},
+ * but works even under environments where security manager creation is
+ * forbidden by policy.
+ *
+ * @author Alexander Dorokhine
+ */
+public class ExceptionCallingClassFinder implements CallingClassFinder {
+
+    public ExceptionCallingClassFinder() {
+    }
+
+    public String getCallingClassName(int depth) {
+        StackTraceElement[] trace = new Throwable().getStackTrace();
+        String thisClassName = ExceptionCallingClassFinder.class.getName();
+
+        // Advance until ExceptionCallingClassFinder is found
+        int i;
+        for (i = 0; i < trace.length; i++) {
+            if (thisClassName.equals(trace[i].getClassName()))
+                break;
+        }
+
+        // trace[i] = ExceptionCallingClassFinder
+        // trace[i+1] = caller [depth 0]
+        // trace[i+2] = caller's caller [depth 1]
+        if (i + 1 + depth >= trace.length) {
+            throw new IllegalArgumentException(
+                "Tried to find the " + depth + "th caller, but the stack depth is only " +
+                 trace.length);
+        }
+
+        return trace[i + 1 + depth].getClassName();
+    }
+}

--- a/slf4j-api/src/main/java/org/slf4j/helpers/callingclass/SecurityManagerCallingClassFinder.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/callingclass/SecurityManagerCallingClassFinder.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2004-2015 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers.callingclass;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * A utility class for finding a method's caller using a security manager.
+ *
+ * @author Alexander Dorokhine
+ */
+public class SecurityManagerCallingClassFinder implements CallingClassFinder {
+
+    /**
+     * In order to call {@link SecurityManager#getClassContext()}, which is a
+     * protected method, we add this wrapper which allows the method to be visible
+     * inside this package.
+     */
+    private static final class ClassContextSecurityManager extends SecurityManager {
+        protected Class<?>[] getClassContext() {
+            return super.getClassContext();
+        }
+    }
+
+    private final ClassContextSecurityManager securityManager;
+
+    private SecurityManagerCallingClassFinder(ClassContextSecurityManager securityManager) {
+        this.securityManager = securityManager;
+    }
+
+    public String getCallingClassName(int depth) {
+        Class<?>[] trace = securityManager.getClassContext();
+        String thisClassName = SecurityManagerCallingClassFinder.class.getName();
+
+        // Advance until SecurityManagerCallingClassFinder is found
+        int i;
+        for (i = 0; i < trace.length; i++) {
+            if (thisClassName.equals(trace[i].getName()))
+                break;
+        }
+
+        // trace[i] = SecurityManagerCallingClassFinder
+        // trace[i+1] = caller [depth 0]
+        // trace[i+2] = caller's caller [depth 1]
+        if (i + 1 + depth >= trace.length) {
+            throw new IllegalArgumentException(
+                "Tried to find the " + depth + "th caller, but the stack depth is only " +
+                 trace.length);
+        }
+
+        return trace[i + 1 + depth].getName();
+    }
+
+    /**
+     * @return A new instance of {@link SecurityManagerCallingClassFinder} if creation was
+     * possible, or {@code null} if {@link SecurityManager} creation is disabled by the
+     * security policy.
+     */
+    public static CallingClassFinder createInstance() {
+        if (System.getSecurityManager() == null) {
+            return new SecurityManagerCallingClassFinder(new ClassContextSecurityManager());
+        } else {
+            try {
+                return AccessController.doPrivileged(
+                    new PrivilegedAction<SecurityManagerCallingClassFinder>() {
+                        public SecurityManagerCallingClassFinder run() {
+                            return new SecurityManagerCallingClassFinder(
+                                new ClassContextSecurityManager());
+                        }
+                    });
+            } catch (SecurityException e) {
+                // Unable to create a new SecurityManager, so this approach for finding
+                // callers is not useable.
+                return null;
+            }
+        }
+    }
+}

--- a/slf4j-api/src/main/java/org/slf4j/helpers/callingclass/package.html
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/callingclass/package.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+  <body>
+    <p>Utilities for finding a method's calling class at runtime.</p>
+    <hr/>
+  </body>
+</html>

--- a/slf4j-api/src/test/java/org/slf4j/helpers/callingclass/CallingClassFinderTestBase.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/callingclass/CallingClassFinderTestBase.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2004-2015 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers.callingclass;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Abstract base class to test derived classes of {@link CallingClassFinder}.
+ * @author Alexander Dorokhine
+ */
+public abstract class CallingClassFinderTestBase {
+
+    /**
+     * @return the {@link CallingClassFinder} instance under test.
+     */
+    abstract CallingClassFinder getCallingClassFinder();
+
+    private class InstanceNestedClass {
+        String callingClassName = getCallingClassFinder().getCallingClassName(0);
+    }
+
+    @Test
+    public void testSimpleClassNameFromMethod() {
+        assertEquals("org.slf4j.helpers.callingclass.CallingClassFinderTestBase",
+                     getCallingClassFinder().getCallingClassName(0));
+    }
+
+    @Test
+    public void testNamedInnerClassName() {
+        class MyTestInstanceClass {
+            String callingClassName = getCallingClassFinder().getCallingClassName(0);
+        }
+        MyTestInstanceClass instance = new MyTestInstanceClass();
+        assertEquals("org.slf4j.helpers.callingclass." +
+                     "CallingClassFinderTestBase$1MyTestInstanceClass",
+                     instance.callingClassName);
+    }
+
+    @Test
+    public void testAnonymousInnerClassName() {
+        new Runnable() {
+            String callingClassName = getCallingClassFinder().getCallingClassName(0);
+            public void run() {
+                assertEquals("org.slf4j.helpers.callingclass." +
+                             "CallingClassFinderTestBase$1", callingClassName);
+            }
+        }.run();
+    }
+
+    @Test
+    public void testInstanceInnerClassName() {
+        assertEquals("org.slf4j.helpers.callingclass." +
+                     "CallingClassFinderTestBase$InstanceNestedClass",
+                     new InstanceNestedClass().callingClassName);
+    }
+
+    @Test
+    public void testNameFromThread() throws Exception {
+        Thread thread = new Thread() {
+            public void run() {
+                String callingClassName = getCallingClassFinder().getCallingClassName(0);
+                assertEquals("org.slf4j.helpers.callingclass.CallingClassFinderTestBase$2",
+                             callingClassName);
+            }
+        };
+        thread.start();
+        thread.join();
+    }
+
+    @Test
+    public void testStackDepth() {
+        class MyTestInstanceClass {
+            String callingClassName = getCallingClassFinder().getCallingClassName(1);
+        }
+        MyTestInstanceClass instance = new MyTestInstanceClass();
+        assertEquals("org.slf4j.helpers.callingclass.CallingClassFinderTestBase",
+                     instance.callingClassName);
+    }
+}

--- a/slf4j-api/src/test/java/org/slf4j/helpers/callingclass/ExceptionCallingClassFinderTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/callingclass/ExceptionCallingClassFinderTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2004-2015 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers.callingclass;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+
+public class ExceptionCallingClassFinderTest extends CallingClassFinderTestBase {
+
+    private static final String STATIC_CALLING_CLASS_NAME =
+            new ExceptionCallingClassFinder().getCallingClassName(0);
+
+    // Static class used for testing logger names
+    private static class StaticNestedClass {
+        static final String callingClassName =
+            new ExceptionCallingClassFinder().getCallingClassName(0);
+    }
+
+    @Override
+    CallingClassFinder getCallingClassFinder() {
+        return new ExceptionCallingClassFinder();
+    }
+
+    @Test
+    public void testSimpleClassNameFromInitializer() {
+        assertEquals("org.slf4j.helpers.callingclass." +
+                     "ExceptionCallingClassFinderTest",
+                     STATIC_CALLING_CLASS_NAME);
+    }
+
+    @Test
+    public void testStaticInnerClassName() {
+        assertEquals("org.slf4j.helpers.callingclass." +
+                     "ExceptionCallingClassFinderTest$StaticNestedClass",
+                     StaticNestedClass.callingClassName);
+    }
+
+    @Test
+    public void testNestedInnerClassName() {
+        new StaticNestedClass() {
+            String nestedCallingClassName = getCallingClassFinder().getCallingClassName(0);
+            public void run() {
+                assertEquals("org.slf4j.helpers.callingclass." +
+                             "ExceptionCallingClassFinderTest$StaticNestedClass",
+                             callingClassName);
+                assertEquals("org.slf4j.helpers.callingclass.ExceptionCallingClassFinderTest$1",
+                             nestedCallingClassName);
+            }
+        }.run();
+    }
+}

--- a/slf4j-api/src/test/java/org/slf4j/helpers/callingclass/SecurityManagerCallingClassFinderTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/callingclass/SecurityManagerCallingClassFinderTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2004-2015 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers.callingclass;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.security.Permission;
+
+import org.junit.Test;
+
+
+public class SecurityManagerCallingClassFinderTest extends CallingClassFinderTestBase {
+
+    private static final String STATIC_CALLING_CLASS_NAME =
+        SecurityManagerCallingClassFinder.createInstance().getCallingClassName(0);
+
+    // Static class used for testing logger names
+    private static class StaticNestedClass {
+        static final String callingClassName =
+            SecurityManagerCallingClassFinder.createInstance().getCallingClassName(0);
+    }
+
+    @Override
+    CallingClassFinder getCallingClassFinder() {
+        return SecurityManagerCallingClassFinder.createInstance();
+    }
+
+    @Test
+    public void testSimpleClassNameFromInitializer() {
+        assertEquals("org.slf4j.helpers.callingclass." +
+                     "SecurityManagerCallingClassFinderTest",
+                     STATIC_CALLING_CLASS_NAME);
+    }
+
+    @Test
+    public void testStaticInnerClassName() {
+        assertEquals("org.slf4j.helpers.callingclass." +
+                     "SecurityManagerCallingClassFinderTest$StaticNestedClass",
+                     StaticNestedClass.callingClassName);
+    }
+
+    @Test
+    public void testNestedInnerClassName() {
+        new StaticNestedClass() {
+            String nestedCallingClassName = getCallingClassFinder().getCallingClassName(0);
+            public void run() {
+                assertEquals("org.slf4j.helpers.callingclass." +
+                             "SecurityManagerCallingClassFinderTest$StaticNestedClass",
+                             callingClassName);
+                assertEquals("org.slf4j.helpers.callingclass." +
+                             "SecurityManagerCallingClassFinderTest$1",
+                             nestedCallingClassName);
+            }
+        }.run();
+    }
+
+    @Test
+    public void testSecurityManagerCreationDisabled() {
+        SecurityManager newSm = new SecurityManager() {
+            @Override
+            public void checkPermission(Permission perm) {
+                if (perm.implies(new RuntimePermission("createSecurityManager"))) {
+                    throw new SecurityException("Security Manager creation disabled");
+                }
+            }
+        };
+        assertNull(System.getSecurityManager());
+        try {
+            System.setSecurityManager(newSm);
+            CallingClassFinder finder = getCallingClassFinder();
+            assertNull(finder);
+        } finally {
+            System.setSecurityManager(null);
+        }
+    }
+}

--- a/slf4j-simple/src/test/java/org/slf4j/DetectLoggerNameMismatchTest.java
+++ b/slf4j-simple/src/test/java/org/slf4j/DetectLoggerNameMismatchTest.java
@@ -80,7 +80,6 @@ public class DetectLoggerNameMismatchTest {
     public void testTriggerWithProperty() {
         setTrialEnabled(true);
         LoggerFactory.getLogger(String.class);
-        String s = String.valueOf(byteArrayOutputStream);
         assertMismatchDetected(true);
     }
 
@@ -107,16 +106,21 @@ public class DetectLoggerNameMismatchTest {
         assertMismatchDetected(false);
     }
 
-    private void assertMismatchDetected(boolean mismatchDetected) {
-        assertEquals(mismatchDetected, String.valueOf(byteArrayOutputStream).contains(MISMATCH_STRING));
-    }
-
+    /*
+     * Checks that there are no errors if the actual class is a superclass of the class
+     * defining the logger.
+     */
     @Test
-    public void verifyLoggerDefinedInBaseWithOverridenGetClassMethod() {
+    public void testLoggerDefinedInBaseWithOverriddenGetClassMethod() {
         setTrialEnabled(true);
         Square square = new Square();
         assertEquals("org.slf4j.Square", square.logger.getName());
         assertMismatchDetected(false);
+    }
+
+    private void assertMismatchDetected(boolean mismatchDetected) {
+        assertEquals(mismatchDetected,
+                     String.valueOf(byteArrayOutputStream).contains(MISMATCH_STRING));
     }
 
     private static void setTrialEnabled(boolean enabled) {


### PR DESCRIPTION
Implemented by falling back to slower exception-based method if this happens.

Fixes bug SLF4J-324.
