### PR TITLE
Use Java5 features and remove legacy code

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -126,9 +126,9 @@ public final class LoggerFactory {
     private static boolean messageContainsOrgSlf4jImplStaticLoggerBinder(String msg) {
         if (msg == null)
             return false;
-        if (msg.indexOf("org/slf4j/impl/StaticLoggerBinder") != -1)
+        if (msg.contains("org/slf4j/impl/StaticLoggerBinder"))
             return true;
-        if (msg.indexOf("org.slf4j.impl.StaticLoggerBinder") != -1)
+        if (msg.contains("org.slf4j.impl.StaticLoggerBinder"))
             return true;
         return false;
     }
@@ -155,7 +155,7 @@ public final class LoggerFactory {
             }
         } catch (java.lang.NoSuchMethodError nsme) {
             String msg = nsme.getMessage();
-            if (msg != null && msg.indexOf("org.slf4j.impl.StaticLoggerBinder.getSingleton()") != -1) {
+            if (msg != null && msg.contains("org.slf4j.impl.StaticLoggerBinder.getSingleton()")) {
                 INITIALIZATION_STATE = FAILED_INITIALIZATION;
                 Util.report("slf4j-api 1.6.x (or later) is incompatible with this binding.");
                 Util.report("Your binding is version 1.5.5 or earlier.");
@@ -198,8 +198,8 @@ public final class LoggerFactory {
             String requested = StaticLoggerBinder.REQUESTED_API_VERSION;
 
             boolean match = false;
-            for (int i = 0; i < API_COMPATIBILITY_LIST.length; i++) {
-                if (requested.startsWith(API_COMPATIBILITY_LIST[i])) {
+            for (String aAPI_COMPATIBILITY_LIST : API_COMPATIBILITY_LIST) {
+                if (requested.startsWith(aAPI_COMPATIBILITY_LIST)) {
                     match = true;
                 }
             }
@@ -236,7 +236,7 @@ public final class LoggerFactory {
                 paths = loggerFactoryClassLoader.getResources(STATIC_LOGGER_BINDER_PATH);
             }
             while (paths.hasMoreElements()) {
-                URL path = (URL) paths.nextElement();
+                URL path = paths.nextElement();
                 staticLoggerBinderPathSet.add(path);
             }
         } catch (IOException ioe) {
@@ -257,9 +257,7 @@ public final class LoggerFactory {
     private static void reportMultipleBindingAmbiguity(Set<URL> staticLoggerBinderPathSet) {
         if (isAmbiguousStaticLoggerBinderPathSet(staticLoggerBinderPathSet)) {
             Util.report("Class path contains multiple SLF4J bindings.");
-            Iterator<URL> iterator = staticLoggerBinderPathSet.iterator();
-            while (iterator.hasNext()) {
-                URL path = (URL) iterator.next();
+            for (URL path : staticLoggerBinderPathSet) {
                 Util.report("Found binding in [" + path + "]");
             }
             Util.report("See " + MULTIPLE_BINDINGS_URL + " for an explanation.");

--- a/slf4j-api/src/main/java/org/slf4j/MDC.java
+++ b/slf4j-api/src/main/java/org/slf4j/MDC.java
@@ -91,7 +91,7 @@ public class MDC {
         } catch (NoClassDefFoundError ncde) {
             mdcAdapter = new NOPMDCAdapter();
             String msg = ncde.getMessage();
-            if (msg != null && msg.indexOf("StaticMDCBinder") != -1) {
+            if (msg != null && msg.contains("StaticMDCBinder")) {
                 Util.report("Failed to load class \"org.slf4j.impl.StaticMDCBinder\".");
                 Util.report("Defaulting to no-operation MDCAdapter implementation.");
                 Util.report("See " + NO_STATIC_MDC_BINDER_URL + " for further details.");

--- a/slf4j-api/src/main/java/org/slf4j/helpers/BasicMDCAdapter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/BasicMDCAdapter.java
@@ -45,18 +45,6 @@ public class BasicMDCAdapter implements MDCAdapter {
 
     private InheritableThreadLocal<Map<String, String>> inheritableThreadLocal = new InheritableThreadLocal<Map<String, String>>();
 
-    static boolean isJDK14() {
-        try {
-            String javaVersion = System.getProperty("java.version");
-            return javaVersion.startsWith("1.4");
-        } catch (SecurityException se) {
-            // punt and assume JDK 1.5 or later
-            return false;
-        }
-    }
-
-    static boolean IS_JDK14 = isJDK14();
-
     /**
      * Put a context value (the <code>val</code> parameter) as identified with
      * the <code>key</code> parameter into the current thread's context map.
@@ -73,9 +61,9 @@ public class BasicMDCAdapter implements MDCAdapter {
         if (key == null) {
             throw new IllegalArgumentException("key cannot be null");
         }
-        Map<String, String> map = (Map<String, String>) inheritableThreadLocal.get();
+        Map<String, String> map = inheritableThreadLocal.get();
         if (map == null) {
-            map = Collections.<String, String> synchronizedMap(new HashMap<String, String>());
+            map = Collections.synchronizedMap(new HashMap<String, String>());
             inheritableThreadLocal.set(map);
         }
         map.put(key, val);
@@ -85,9 +73,9 @@ public class BasicMDCAdapter implements MDCAdapter {
      * Get the context identified by the <code>key</code> parameter.
      */
     public String get(String key) {
-        Map<String, String> Map = (Map<String, String>) inheritableThreadLocal.get();
+        Map<String, String> Map = inheritableThreadLocal.get();
         if ((Map != null) && (key != null)) {
-            return (String) Map.get(key);
+            return Map.get(key);
         } else {
             return null;
         }
@@ -97,7 +85,7 @@ public class BasicMDCAdapter implements MDCAdapter {
      * Remove the the context identified by the <code>key</code> parameter.
      */
     public void remove(String key) {
-        Map<String, String> map = (Map<String, String>) inheritableThreadLocal.get();
+        Map<String, String> map = inheritableThreadLocal.get();
         if (map != null) {
             map.remove(key);
         }
@@ -107,16 +95,10 @@ public class BasicMDCAdapter implements MDCAdapter {
      * Clear all entries in the MDC.
      */
     public void clear() {
-        Map<String, String> map = (Map<String, String>) inheritableThreadLocal.get();
+        Map<String, String> map = inheritableThreadLocal.get();
         if (map != null) {
             map.clear();
-            // the InheritableThreadLocal.remove method was introduced in JDK 1.5
-            // Thus, invoking clear() on previous JDK 1.4 will fail
-            if (isJDK14()) {
-                inheritableThreadLocal.set(null);
-            } else {
-                inheritableThreadLocal.remove();
-            }
+            inheritableThreadLocal.remove();
         }
     }
 
@@ -127,7 +109,7 @@ public class BasicMDCAdapter implements MDCAdapter {
      * @return the keys in the MDC
      */
     public Set<String> getKeys() {
-        Map<String, String> map = (Map<String, String>) inheritableThreadLocal.get();
+        Map<String, String> map = inheritableThreadLocal.get();
         if (map != null) {
             return map.keySet();
         } else {
@@ -141,9 +123,9 @@ public class BasicMDCAdapter implements MDCAdapter {
      * 
      */
     public Map<String, String> getCopyOfContextMap() {
-        Map<String, String> oldMap = (Map<String, String>) inheritableThreadLocal.get();
+        Map<String, String> oldMap = inheritableThreadLocal.get();
         if (oldMap != null) {
-            Map<String, String> newMap = Collections.<String, String> synchronizedMap(new HashMap<String, String>());
+            Map<String, String> newMap = Collections.synchronizedMap(new HashMap<String, String>());
             synchronized (oldMap) {
                 newMap.putAll(oldMap);
             }
@@ -154,7 +136,7 @@ public class BasicMDCAdapter implements MDCAdapter {
     }
 
     public void setContextMap(Map<String, String> contextMap) {
-        Map<String, String> map = Collections.<String, String> synchronizedMap(new HashMap<String, String>(contextMap));
+        Map<String, String> map = Collections.synchronizedMap(new HashMap<String, String>(contextMap));
         inheritableThreadLocal.set(map);
     }
 

--- a/slf4j-api/src/main/java/org/slf4j/helpers/BasicMarker.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/BasicMarker.java
@@ -101,7 +101,7 @@ public class BasicMarker implements Marker {
 
         int size = referenceList.size();
         for (int i = 0; i < size; i++) {
-            Marker m = (Marker) referenceList.get(i);
+            Marker m = referenceList.get(i);
             if (referenceToRemove.equals(m)) {
                 referenceList.remove(i);
                 return true;
@@ -120,8 +120,7 @@ public class BasicMarker implements Marker {
         }
 
         if (hasReferences()) {
-            for (int i = 0; i < referenceList.size(); i++) {
-                Marker ref = (Marker) referenceList.get(i);
+            for (Marker ref : referenceList) {
                 if (ref.contains(other)) {
                     return true;
                 }
@@ -143,8 +142,7 @@ public class BasicMarker implements Marker {
         }
 
         if (hasReferences()) {
-            for (int i = 0; i < referenceList.size(); i++) {
-                Marker ref = (Marker) referenceList.get(i);
+            for (Marker ref : referenceList) {
                 if (ref.contains(name)) {
                     return true;
                 }
@@ -182,7 +180,7 @@ public class BasicMarker implements Marker {
         StringBuilder sb = new StringBuilder(this.getName());
         sb.append(' ').append(OPEN);
         while (it.hasNext()) {
-            reference = (Marker) it.next();
+            reference = it.next();
             sb.append(reference.getName());
             if (it.hasNext()) {
                 sb.append(SEP);


### PR DESCRIPTION
Since SLF4J 1.7.x a JDK of version 5 or higher is required. Due previous versions old-fashioned javacode is still in the API module of slf4j, which I try to replace with Java 5 APIs and language features.

Removes/changes of this PR:
* legacy check for JDK1.4 to choose correct cleanup method for ```InheritableThreadLocal```
* casts of values retrieved from collections 
* ```String#indexOf``` replaced by ```String#contains```
* Use for-each loops where possible