### PR TITLE
SLF4J-329. Add 'off' as SimpleLogger configuration.

### DIFF
--- a/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/impl/SimpleLogger.java
@@ -52,7 +52,7 @@ import org.slf4j.spi.LocationAwareLogger;
  * the special values "System.out" and "System.err". Default is "System.err".
  *
  * <li><code>org.slf4j.simpleLogger.defaultLogLevel</code> - Default log level for all instances of SimpleLogger.
- * Must be one of ("trace", "debug", "info", "warn", or "error"). If not specified, defaults to "info". </li>
+ * Must be one of ("trace", "debug", "info", "warn", "error", or "off"). If not specified, defaults to "info". </li>
  *
  * <li><code>org.slf4j.simpleLogger.log.<em>a.b.c</em></code> - Logging detail level for a SimpleLogger instance
  * named "a.b.c". Right-side value must be one of "trace", "debug", "info", "warn", or "error". When a SimpleLogger
@@ -294,6 +294,8 @@ public class SimpleLogger extends MarkerIgnoringBase {
             return LOG_LEVEL_WARN;
         } else if ("error".equalsIgnoreCase(levelStr)) {
             return LOG_LEVEL_ERROR;
+        } else if ("off".equalsIgnoreCase(levelStr)) {
+            return Integer.MAX_VALUE;
         }
         // assume INFO by default
         return LOG_LEVEL_INFO;

--- a/slf4j-simple/src/test/java/org/slf4j/impl/SimpleLoggerTest.java
+++ b/slf4j-simple/src/test/java/org/slf4j/impl/SimpleLoggerTest.java
@@ -27,9 +27,12 @@ package org.slf4j.impl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.spi.LocationAwareLogger;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
 
 public class SimpleLoggerTest {
 
@@ -75,4 +78,20 @@ public class SimpleLoggerTest {
         assertNull(simpleLogger.recursivelyComputeLevelString());
     }
 
+    @Test
+    public void isLevelEnabled() {
+        SimpleLogger simpleLogger = new SimpleLogger("a");
+        assertFalse(simpleLogger.isLevelEnabled(LocationAwareLogger.TRACE_INT));
+        assertFalse(simpleLogger.isLevelEnabled(LocationAwareLogger.DEBUG_INT));
+        assertTrue(simpleLogger.isLevelEnabled(LocationAwareLogger.INFO_INT));
+        assertTrue(simpleLogger.isLevelEnabled(LocationAwareLogger.WARN_INT));
+        assertTrue(simpleLogger.isLevelEnabled(LocationAwareLogger.ERROR_INT));
+    }
+
+    @Test
+    public void isLevelEnabled_Off() {
+        System.setProperty(A_KEY, "off");
+        SimpleLogger simpleLogger = new SimpleLogger("a");
+        assertFalse(simpleLogger.isLevelEnabled(LocationAwareLogger.ERROR_INT));
+    }
 }


### PR DESCRIPTION
This adds "off" as a valid configuration value for a SimpleLogger level.

This also satisfies part of SLF4J-276.