### PR TITLE
SLF4J-334: Update LoggerWrapper to pass throwable to bound logger in parameterized queries

### DIFF
--- a/slf4j-ext/src/main/java/org/slf4j/ext/LoggerWrapper.java
+++ b/slf4j-ext/src/main/java/org/slf4j/ext/LoggerWrapper.java
@@ -98,8 +98,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.trace(format, arg);
         }
@@ -113,8 +113,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.trace(format, arg1, arg2);
         }
@@ -128,8 +128,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.arrayFormat(format, args).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, args, null);
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, args);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.trace(format, args);
         }
@@ -169,8 +169,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isTraceEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.TRACE_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.trace(marker, format, arg);
         }
@@ -183,8 +183,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isTraceEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.TRACE_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.trace(marker, format, arg1, arg2);
         }
@@ -197,8 +197,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isTraceEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.arrayFormat(format, args).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.TRACE_INT, formattedMessage, args, null);
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, args);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.TRACE_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.trace(marker, format, args);
         }
@@ -253,8 +253,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.DEBUG_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.DEBUG_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.debug(format, arg);
         }
@@ -268,8 +268,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.DEBUG_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.DEBUG_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.debug(format, arg1, arg2);
         }
@@ -338,8 +338,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isDebugEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.DEBUG_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.DEBUG_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.debug(marker, format, arg1, arg2);
         }
@@ -409,8 +409,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.info(format, arg);
         }
@@ -424,8 +424,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.info(format, arg1, arg2);
         }
@@ -439,8 +439,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.arrayFormat(format, args).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, args, null);
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, args);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.info(format, args);
         }
@@ -480,8 +480,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isInfoEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.info(marker, format, arg);
         }
@@ -494,8 +494,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isInfoEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.info(marker, format, arg1, arg2);
         }
@@ -508,8 +508,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isInfoEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.arrayFormat(format, args).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, formattedMessage, args, null);
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, args);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.info(marker, format, args);
         }
@@ -561,8 +561,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.warn(format, arg);
         }
@@ -576,8 +576,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.warn(format, arg1, arg2);
         }
@@ -591,8 +591,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.arrayFormat(format, args).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, args, null);
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, args);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.warn(format, args);
         }
@@ -632,8 +632,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isWarnEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.warn(marker, format, arg);
         }
@@ -646,8 +646,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isWarnEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.warn(marker, format, arg1, arg2);
         }
@@ -660,8 +660,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isWarnEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.arrayFormat(format, args).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, formattedMessage, args, null);
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, args);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.warn(marker, format, args);
         }
@@ -716,8 +716,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.error(format, arg);
         }
@@ -731,8 +731,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.error(format, arg1, arg2);
         }
@@ -746,8 +746,8 @@ public class LoggerWrapper implements Logger {
             return;
 
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.arrayFormat(format, args).getMessage();
-            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, args, null);
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, args);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.error(format, args);
         }
@@ -787,8 +787,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isErrorEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, new Object[] { arg }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.error(marker, format, arg);
         }
@@ -801,8 +801,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isErrorEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.format(format, arg1, arg2).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, new Object[] { arg1, arg2 }, null);
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.error(marker, format, arg1, arg2);
         }
@@ -815,8 +815,8 @@ public class LoggerWrapper implements Logger {
         if (!logger.isErrorEnabled(marker))
             return;
         if (instanceofLAL) {
-            String formattedMessage = MessageFormatter.arrayFormat(format, args).getMessage();
-            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, formattedMessage, args, null);
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, args);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, ft.getMessage(), ft.getArgArray(), ft.getThrowable());
         } else {
             logger.error(marker, format, args);
         }


### PR DESCRIPTION
Added logic in LoggerWrapper to send the ArgArray and Throwable parsed from the original parameters to the underlying logger.

Issue described here: http://jira.qos.ch/browse/SLF4J-334
