### PR TITLE
add missing setPriority method

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
@@ -346,6 +346,11 @@ public class Category {
     public void setLevel(Level level) {
         // nothing to do
     }
+
+    @Deprecated
+    public void setPriority(Priority priority) {
+        // nothing to do
+    }
     
     public boolean getAdditivity() {
         return false;


### PR DESCRIPTION
The "setPriority" method is missing from the log4j Category in the log4j-over-slf4j bridge at the moment. 

We have some older code that we are trying to use with this bridge but it's failing because of this missing method. 

https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/Category.html#setPriority(org.apache.log4j.Priority)

This is a pretty simple addition - it adds in the no-op method (the deprecation note in the log4j docs say that it should use the "setLevel" method instead - and the setLevel method is already a no-op in this bridge so making the setPriority also be a no-op seems consistent with the existing behavior)
