### PR TITLE
SLF4J-345: Move delegation check loop from log4j-over-slf4j.jar to slf4j-log4j12.jar

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/Log4jLoggerFactory.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/Log4jLoggerFactory.java
@@ -17,7 +17,6 @@
 package org.apache.log4j;
 
 import org.apache.log4j.spi.LoggerFactory;
-import org.slf4j.helpers.Util;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -35,23 +34,6 @@ class Log4jLoggerFactory {
 
     // String, Logger
     private static ConcurrentMap<String, Logger> log4jLoggers = new ConcurrentHashMap<String, Logger>();
-
-    private static final String LOG4J_DELEGATION_LOOP_URL = "http://www.slf4j.org/codes.html#log4jDelegationLoop";
-
-    // check for delegation loops
-    static {
-        try {
-            Class.forName("org.slf4j.impl.Log4jLoggerFactory");
-            String part1 = "Detected both log4j-over-slf4j.jar AND slf4j-log4j12.jar on the class path, preempting StackOverflowError. ";
-            String part2 = "See also " + LOG4J_DELEGATION_LOOP_URL + " for more details.";
-
-            Util.report(part1);
-            Util.report(part2);
-            throw new IllegalStateException(part1 + part2);
-        } catch (ClassNotFoundException e) {
-            // this is the good case
-        }
-    }
 
     public static Logger getLogger(String name) {
         org.apache.log4j.Logger instance = log4jLoggers.get(name);

--- a/slf4j-jcl/src/main/java/org/slf4j/impl/JCLLoggerFactory.java
+++ b/slf4j-jcl/src/main/java/org/slf4j/impl/JCLLoggerFactory.java
@@ -46,7 +46,7 @@ public class JCLLoggerFactory implements ILoggerFactory {
     static {
         try {
             Class.forName("org.apache.commons.logging.impl.SLF4JLogFactory");
-            String part1 = "Detected both jcl-over-slf4j.jar AND slf4j-jcl.jar on the class path, preempting StackOverflowError. ";
+            String part1 = "Detected both jcl-over-slf4j.jar AND bound slf4j-jcl.jar on the class path, preempting StackOverflowError. ";
             String part2 = "See also " + JCL_DELEGATION_LOOP_URL + " for more details.";
 
             Util.report(part1);

--- a/slf4j-log4j12/src/main/java/org/slf4j/impl/Log4jLoggerFactory.java
+++ b/slf4j-log4j12/src/main/java/org/slf4j/impl/Log4jLoggerFactory.java
@@ -28,9 +28,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.log4j.LogManager;
+import org.slf4j.helpers.Util;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.helpers.Util;
 
 /**
  * Log4jLoggerFactory is an implementation of {@link ILoggerFactory} returning
@@ -39,9 +39,6 @@ import org.slf4j.helpers.Util;
  * @author Ceki G&uuml;lc&uuml;
  */
 public class Log4jLoggerFactory implements ILoggerFactory {
-
-    // key: name (String), value: a Log4jLoggerAdapter;
-    ConcurrentMap<String, Logger> loggerMap;
 
     private static final String LOG4J_DELEGATION_LOOP_URL = "http://www.slf4j.org/codes.html#log4jDelegationLoop";
 	
@@ -59,6 +56,9 @@ public class Log4jLoggerFactory implements ILoggerFactory {
             // this is the good case
         }
     }
+
+    // key: name (String), value: a Log4jLoggerAdapter;
+    ConcurrentMap<String, Logger> loggerMap;
 
     public Log4jLoggerFactory() {
         loggerMap = new ConcurrentHashMap<String, Logger>();

--- a/slf4j-log4j12/src/main/java/org/slf4j/impl/Log4jLoggerFactory.java
+++ b/slf4j-log4j12/src/main/java/org/slf4j/impl/Log4jLoggerFactory.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.log4j.LogManager;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.helpers.Util;
 
 /**
  * Log4jLoggerFactory is an implementation of {@link ILoggerFactory} returning
@@ -41,6 +42,23 @@ public class Log4jLoggerFactory implements ILoggerFactory {
 
     // key: name (String), value: a Log4jLoggerAdapter;
     ConcurrentMap<String, Logger> loggerMap;
+
+    private static final String LOG4J_DELEGATION_LOOP_URL = "http://www.slf4j.org/codes.html#log4jDelegationLoop";
+	
+    // check for delegation loops
+    static {
+        try {
+            Class.forName("org.apache.log4j.Log4jLoggerFactory");
+            String part1 = "Detected both log4j-over-slf4j.jar AND bound slf4j-log4j12.jar on the class path, preempting StackOverflowError. ";
+            String part2 = "See also " + LOG4J_DELEGATION_LOOP_URL + " for more details.";
+
+            Util.report(part1);
+            Util.report(part2);
+            throw new IllegalStateException(part1 + part2);
+        } catch (ClassNotFoundException e) {
+            // this is the good case
+        }
+    }
 
     public Log4jLoggerFactory() {
         loggerMap = new ConcurrentHashMap<String, Logger>();


### PR DESCRIPTION
Currently, the check on delegation loop for log4j is done in the log4j-over-sl4fj.jar, whereas the same check for jcl is done in the slf4j-jcl.jar. This causes different behaviour for log4j and jcl:
- For log4j, if both log4j-over-slf4j.jar and slf4j-log4j12.jar are present on the classpath, an IllegalStateException is always thrown, even if slf4j-log4j12.jar is not chosen as the actual binding.
- For jcl, if both jcl-over-slf4j.jar and slf4j-jcl.jar are present on the classpath, an IllegalStateException is ONLY thrown when slf4j-jcl.jar is chosen as the actual binding. If, for example, logback is also on the classpath and is chosen as the actual binding, then (JCLLoggerFactory class in) slf4j-jcl.jar is never initialized and therefore the delegation loop is not executed.

The log4j behaviour causes an issue for my situation, where I want to redirect log4j logging to slf4j/logback, but my classpath also contains (an older version of) slf4j-log4j12.jar. The actual binding is logback, so there is no real conflict, i.e. no danger of a delegation loop/stack overflow. Still, I'm unable to redirect log4j logging via slf4j/logback using log4j-over-slf4j.jar.

I propose to move the delegation loop check from log4j-over-slf4j.jar to slf4j-log4j12.jar, so that the delegation loop check behaviour for log4j will be the same as for jcl.

See also JIRA SLF4J-345.