### PR TITLE
Unit Tests for osgi-over-slf4j module - raising test coverage from 0% to 100%

### DIFF
--- a/CODE_COVERAGE.md
+++ b/CODE_COVERAGE.md
@@ -1,0 +1,11 @@
+# Code Coverage Report generation
+
+To generate the code coverage report, execute the following command:
+> mvn clean verify
+
+This will generate code coverage report in each of the modules. In order to view the same, open the following file in your browser.
+> target/site/cobertura/index.html
+
+Please note that the above folder is created under each of the modules. For example:
+* jcl-over-slf4j/target/site/cobertura/index.html
+* log4j-over-slf4j/target/site/cobertura/index.html

--- a/osgi-over-slf4j/pom.xml
+++ b/osgi-over-slf4j/pom.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.slf4j</groupId>
-		<artifactId>slf4j-parent</artifactId>
-		<version>1.7.14-SNAPSHOT</version>
-	</parent>
+  <parent>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-parent</artifactId>
+    <version>1.7.14-SNAPSHOT</version>
+  </parent>
 
-	<artifactId>osgi-over-slf4j</artifactId>
+  <artifactId>osgi-over-slf4j</artifactId>
 
-	<packaging>bundle</packaging>
-	<name>OSGi LogService implemented over SLF4J</name>
+  <packaging>bundle</packaging>
+  <name>OSGi LogService implemented over SLF4J</name>
 
-	<url>http://www.slf4j.org</url>
-	<description>
+  <url>http://www.slf4j.org</url>
+  <description>
     OSGi LogService implementation over SLF4J
   </description>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.osgi</groupId>
-			<artifactId>org.osgi.core</artifactId>
-			<version>4.2.0</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.osgi</groupId>
-			<artifactId>org.osgi.enterprise</artifactId>
-			<version>4.2.0</version>
-			<scope>provided</scope>
-		</dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <version>4.2.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.enterprise</artifactId>
+      <version>4.2.0</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
 		<!-- Powermock mocking tool -->
 		<dependency>
 			<groupId>org.powermock</groupId>
@@ -52,22 +52,22 @@
 			<artifactId>powermock-module-junit4</artifactId>
 			<version>1.6.3</version>
 		</dependency>
-		
-	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.3.7</version>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>org.osgi.service.log</Export-Package>
-						<Bundle-Activator>org.slf4j.osgi.logservice.impl.Activator</Bundle-Activator>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>org.osgi.service.log</Export-Package>
+            <Bundle-Activator>org.slf4j.osgi.logservice.impl.Activator</Bundle-Activator>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/osgi-over-slf4j/pom.xml
+++ b/osgi-over-slf4j/pom.xml
@@ -1,60 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-parent</artifactId>
-    <version>1.7.14-SNAPSHOT</version>
-  </parent>
+	<parent>
+		<groupId>org.slf4j</groupId>
+		<artifactId>slf4j-parent</artifactId>
+		<version>1.7.14-SNAPSHOT</version>
+	</parent>
 
-  <artifactId>osgi-over-slf4j</artifactId>
+	<artifactId>osgi-over-slf4j</artifactId>
 
-  <packaging>bundle</packaging>
-  <name>OSGi LogService implemented over SLF4J</name>
+	<packaging>bundle</packaging>
+	<name>OSGi LogService implemented over SLF4J</name>
 
-  <url>http://www.slf4j.org</url>
-  <description>
+	<url>http://www.slf4j.org</url>
+	<description>
     OSGi LogService implementation over SLF4J
   </description>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <version>4.2.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.enterprise</artifactId>
-      <version>4.2.0</version>
-      <scope>provided</scope>
-    </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.core</artifactId>
+			<version>4.2.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.enterprise</artifactId>
+			<version>4.2.0</version>
+			<scope>provided</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-  </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Export-Package>org.osgi.service.log</Export-Package>
-            <Bundle-Activator>org.slf4j.osgi.logservice.impl.Activator</Bundle-Activator>
-          </instructions>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		
+		<!-- Powermock mocking tool -->
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<version>1.6.3</version>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>1.6.3</version>
+		</dependency>
+		
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.3.7</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Export-Package>org.osgi.service.log</Export-Package>
+						<Bundle-Activator>org.slf4j.osgi.logservice.impl.Activator</Bundle-Activator>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/osgi-over-slf4j/src/test/java/org/slf4j/osgi/logservice/impl/ActivatorTest.java
+++ b/osgi-over-slf4j/src/test/java/org/slf4j/osgi/logservice/impl/ActivatorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2004-2005 QOS.ch
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute, and/or sell copies of  the Software, and to permit persons
+ * to whom  the Software is furnished  to do so, provided  that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the  Software and  that both  the above  copyright notice(s)  and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR  A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * OF  THIRD PARTY  RIGHTS. IN  NO EVENT  SHALL THE  COPYRIGHT  HOLDER OR
+ * HOLDERS  INCLUDED IN  THIS  NOTICE BE  LIABLE  FOR ANY  CLAIM, OR  ANY
+ * SPECIAL INDIRECT  OR CONSEQUENTIAL DAMAGES, OR  ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS  OF USE, DATA OR PROFITS, WHETHER  IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE  OR OTHER TORTIOUS  ACTION, ARISING OUT OF  OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as  contained in  this notice, the  name of a  copyright holder
+ * shall not be used in advertising or otherwise to promote the sale, use
+ * or other dealings in this Software without prior written authorization
+ * of the copyright holder.
+ *
+ */
+
+package org.slf4j.osgi.logservice.impl;
+
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.log.LogService;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ LogServiceFactory.class, Properties.class, BundleContext.class, Activator.class })
+public class ActivatorTest {
+
+	private BundleContext bundleContext;
+	private Activator activator;
+
+	@Before
+	public void setUp() throws Exception {
+		bundleContext = mock(BundleContext.class);
+		activator = new Activator();
+	}
+
+	@Test
+	public void testStart() throws Exception {
+		// setup
+		Properties props = mock(Properties.class);
+		LogServiceFactory factory = mock(LogServiceFactory.class);
+		whenNew(Properties.class).withAnyArguments().thenReturn(props);
+		whenNew(LogServiceFactory.class).withAnyArguments().thenReturn(factory);
+
+		// when
+		activator.start(bundleContext);
+
+		// then
+		verify(bundleContext).registerService(LogService.class.getName(), factory, props);
+	}
+
+	@Test
+	public void testStop() throws Exception {
+		// when
+		activator.stop(bundleContext);
+
+		// then
+		// Function body is empty
+		// No checking needed
+	}
+}

--- a/osgi-over-slf4j/src/test/java/org/slf4j/osgi/logservice/impl/LogServiceFactoryTest.java
+++ b/osgi-over-slf4j/src/test/java/org/slf4j/osgi/logservice/impl/LogServiceFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2005 QOS.ch
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute, and/or sell copies of  the Software, and to permit persons
+ * to whom  the Software is furnished  to do so, provided  that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the  Software and  that both  the above  copyright notice(s)  and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR  A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * OF  THIRD PARTY  RIGHTS. IN  NO EVENT  SHALL THE  COPYRIGHT  HOLDER OR
+ * HOLDERS  INCLUDED IN  THIS  NOTICE BE  LIABLE  FOR ANY  CLAIM, OR  ANY
+ * SPECIAL INDIRECT  OR CONSEQUENTIAL DAMAGES, OR  ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS  OF USE, DATA OR PROFITS, WHETHER  IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE  OR OTHER TORTIOUS  ACTION, ARISING OUT OF  OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as  contained in  this notice, the  name of a  copyright holder
+ * shall not be used in advertising or otherwise to promote the sale, use
+ * or other dealings in this Software without prior written authorization
+ * of the copyright holder.
+ *
+ */
+
+package org.slf4j.osgi.logservice.impl;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.framework.Bundle;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.osgi.logservice.impl.LogServiceFactory;
+import org.slf4j.osgi.logservice.impl.LogServiceImpl;
+
+@RunWith(PowerMockRunner.class)
+public class LogServiceFactoryTest {
+
+	private LogServiceFactory lsf;
+	private Bundle bundle;
+
+	@Before
+	public void setUp() throws Exception {
+		lsf = new LogServiceFactory();
+		bundle = mock(Bundle.class);
+	}
+
+	@Test
+	public void testGetService() {
+		// when
+		Object logService = lsf.getService(bundle, null);
+
+		// then
+		assertNotNull(logService);
+		assertThat(logService, instanceOf(LogServiceImpl.class));
+	}
+
+	@Test
+	public void testUngetService() {
+		// setup
+		Object logService = lsf.getService(bundle, null);
+
+		// when
+		lsf.ungetService(null, null, logService);
+
+		// then
+		// Function body is empty
+		// No checking needed
+	}
+}

--- a/osgi-over-slf4j/src/test/java/org/slf4j/osgi/logservice/impl/LogServiceImplLoggingTest.java
+++ b/osgi-over-slf4j/src/test/java/org/slf4j/osgi/logservice/impl/LogServiceImplLoggingTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) 2004-2005 QOS.ch
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute, and/or sell copies of  the Software, and to permit persons
+ * to whom  the Software is furnished  to do so, provided  that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the  Software and  that both  the above  copyright notice(s)  and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR  A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * OF  THIRD PARTY  RIGHTS. IN  NO EVENT  SHALL THE  COPYRIGHT  HOLDER OR
+ * HOLDERS  INCLUDED IN  THIS  NOTICE BE  LIABLE  FOR ANY  CLAIM, OR  ANY
+ * SPECIAL INDIRECT  OR CONSEQUENTIAL DAMAGES, OR  ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS  OF USE, DATA OR PROFITS, WHETHER  IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE  OR OTHER TORTIOUS  ACTION, ARISING OUT OF  OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as  contained in  this notice, the  name of a  copyright holder
+ * shall not be used in advertising or otherwise to promote the sale, use
+ * or other dealings in this Software without prior written authorization
+ * of the copyright holder.
+ *
+ */
+
+package org.slf4j.osgi.logservice.impl;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.invokeMethod;
+import static org.powermock.reflect.Whitebox.setInternalState;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogService;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.osgi.logservice.impl.LogServiceImpl;
+
+@RunWith(PowerMockRunner.class)
+public class LogServiceImplLoggingTest {
+
+	private LogService logService;
+	private Bundle bundle;
+	private ServiceReference sr;
+	private Logger loggerMock;
+
+	private final String TEST_MESSAGE = "TEST";
+	private final Exception TEST_EXCEPTION = new Exception("TEST");
+
+	@Before
+	public void setUp() throws Exception {
+		bundle = mock(Bundle.class);
+		sr = mock(ServiceReference.class);
+		loggerMock = mock(Logger.class);
+		logService = new LogServiceImpl(bundle);
+		setInternalState(logService, "delegate", loggerMock);
+	}
+
+	@Test
+	public void testLogIntStringDebug() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(LogService.LOG_DEBUG, TEST_MESSAGE);
+
+		// then
+		verify(loggerMock).debug(TEST_MESSAGE);
+	}
+
+	@Test
+	public void testLogIntStringError() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(LogService.LOG_ERROR, TEST_MESSAGE);
+
+		// then
+		verify(loggerMock).error(TEST_MESSAGE);
+	}
+
+	@Test
+	public void testLogIntStringInfo() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(LogService.LOG_INFO, TEST_MESSAGE);
+
+		// then
+		verify(loggerMock).info(TEST_MESSAGE);
+	}
+
+	@Test
+	public void testLogIntStringWarning() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(LogService.LOG_WARNING, TEST_MESSAGE);
+
+		// then
+		verify(loggerMock).warn(TEST_MESSAGE);
+	}
+
+	@Test
+	public void testLogIntStringDefault() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(Integer.MAX_VALUE, TEST_MESSAGE);
+
+		// then
+		verifyZeroInteractions(loggerMock);
+	}
+
+	@Test
+	public void testLogIntStringThrowableDebug() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(LogService.LOG_DEBUG, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verify(loggerMock).debug(TEST_MESSAGE, TEST_EXCEPTION);
+	}
+
+	@Test
+	public void testLogIntStringThrowableError() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(LogService.LOG_ERROR, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verify(loggerMock).error(TEST_MESSAGE, TEST_EXCEPTION);
+	}
+
+	@Test
+	public void testLogIntStringThrowableInfo() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(LogService.LOG_INFO, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verify(loggerMock).info(TEST_MESSAGE, TEST_EXCEPTION);
+	}
+
+	@Test
+	public void testLogIntStringThrowableWarning() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(LogService.LOG_WARNING, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verify(loggerMock).warn(TEST_MESSAGE, TEST_EXCEPTION);
+	}
+
+	@Test
+	public void testLogIntStringThrowableDefault() throws IllegalArgumentException, IllegalAccessException {
+		// when
+		logService.log(Integer.MAX_VALUE, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verifyZeroInteractions(loggerMock);
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringDebug() throws Exception {
+		// setup
+		when(loggerMock.isDebugEnabled()).thenReturn(true);
+
+		// when
+		logService.log(sr, LogService.LOG_DEBUG, TEST_MESSAGE);
+
+		// then
+		verify(loggerMock).debug((String) invokeMethod(logService, "createMessage", sr, TEST_MESSAGE));
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringError() throws Exception {
+		// setup
+		when(loggerMock.isErrorEnabled()).thenReturn(true);
+
+		// when
+		logService.log(sr, LogService.LOG_ERROR, TEST_MESSAGE);
+
+		// then
+		verify(loggerMock).error((String) invokeMethod(logService, "createMessage", sr, TEST_MESSAGE));
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringInfo() throws Exception {
+		// setup
+		when(loggerMock.isInfoEnabled()).thenReturn(true);
+
+		// when
+		logService.log(sr, LogService.LOG_INFO, TEST_MESSAGE);
+
+		// then
+		verify(loggerMock).info((String) invokeMethod(logService, "createMessage", sr, TEST_MESSAGE));
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringWarning() throws Exception {
+		// setup
+		when(loggerMock.isWarnEnabled()).thenReturn(true);
+
+		// when
+		logService.log(sr, LogService.LOG_WARNING, TEST_MESSAGE);
+
+		// then
+		verify(loggerMock).warn((String) invokeMethod(logService, "createMessage", sr, TEST_MESSAGE));
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringDefault() throws Exception {
+		// when
+		logService.log(sr, Integer.MAX_VALUE, TEST_MESSAGE);
+
+		// then
+		verifyZeroInteractions(loggerMock);
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringThrowableDebug() throws Exception {
+		// setup
+		when(loggerMock.isDebugEnabled()).thenReturn(true);
+
+		// when
+		logService.log(sr, LogService.LOG_DEBUG, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verify(loggerMock).debug((String) invokeMethod(logService, "createMessage", sr, TEST_MESSAGE), TEST_EXCEPTION);
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringThrowableError() throws Exception {
+		// setup
+		when(loggerMock.isErrorEnabled()).thenReturn(true);
+
+		// when
+		logService.log(sr, LogService.LOG_ERROR, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verify(loggerMock).error((String) invokeMethod(logService, "createMessage", sr, TEST_MESSAGE), TEST_EXCEPTION);
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringThrowableInfo() throws Exception {
+		// setup
+		when(loggerMock.isInfoEnabled()).thenReturn(true);
+
+		// when
+		logService.log(sr, LogService.LOG_INFO, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verify(loggerMock).info((String) invokeMethod(logService, "createMessage", sr, TEST_MESSAGE), TEST_EXCEPTION);
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringThrowableWarning() throws Exception {
+		// setup
+		when(loggerMock.isWarnEnabled()).thenReturn(true);
+
+		// when
+		logService.log(sr, LogService.LOG_WARNING, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verify(loggerMock).warn((String) invokeMethod(logService, "createMessage", sr, TEST_MESSAGE), TEST_EXCEPTION);
+	}
+
+	@Test
+	public void testLogServiceReferenceIntStringThrowableDefault() throws Exception {
+		// when
+		logService.log(sr, Integer.MAX_VALUE, TEST_MESSAGE, TEST_EXCEPTION);
+
+		// then
+		verifyZeroInteractions(loggerMock);
+	}
+}

--- a/osgi-over-slf4j/src/test/java/org/slf4j/osgi/logservice/impl/LogServiceImplTest.java
+++ b/osgi-over-slf4j/src/test/java/org/slf4j/osgi/logservice/impl/LogServiceImplTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2004-2005 QOS.ch
+ *
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute, and/or sell copies of  the Software, and to permit persons
+ * to whom  the Software is furnished  to do so, provided  that the above
+ * copyright notice(s) and this permission notice appear in all copies of
+ * the  Software and  that both  the above  copyright notice(s)  and this
+ * permission notice appear in supporting documentation.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR  A PARTICULAR PURPOSE AND NONINFRINGEMENT
+ * OF  THIRD PARTY  RIGHTS. IN  NO EVENT  SHALL THE  COPYRIGHT  HOLDER OR
+ * HOLDERS  INCLUDED IN  THIS  NOTICE BE  LIABLE  FOR ANY  CLAIM, OR  ANY
+ * SPECIAL INDIRECT  OR CONSEQUENTIAL DAMAGES, OR  ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS  OF USE, DATA OR PROFITS, WHETHER  IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE  OR OTHER TORTIOUS  ACTION, ARISING OUT OF  OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * Except as  contained in  this notice, the  name of a  copyright holder
+ * shall not be used in advertising or otherwise to promote the sale, use
+ * or other dealings in this Software without prior written authorization
+ * of the copyright holder.
+ *
+ */
+
+package org.slf4j.osgi.logservice.impl;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.getInternalState;
+import static org.powermock.reflect.Whitebox.invokeMethod;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.log.LogService;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.osgi.logservice.impl.LogServiceImpl;
+
+@RunWith(PowerMockRunner.class)
+public class LogServiceImplTest {
+
+	private LogService logService;
+	private Bundle bundle;
+	private ServiceReference sr;
+
+	private final String TEST_MESSAGE = "TEST";
+
+	@Before
+	public void setUp() throws Exception {
+		bundle = mock(Bundle.class);
+		sr = mock(ServiceReference.class);
+		logService = new LogServiceImpl(bundle);
+	}
+
+	@Test
+	public void testLogServiceImpl() {
+		// when
+		Logger logServiceLogger = getInternalState(logService, "delegate");
+
+		// then
+		assertNotNull(logServiceLogger);
+		assertThat(logServiceLogger, instanceOf(Logger.class));
+	}
+
+	@Test
+	public void testLogServiceCreateMessage() throws Exception {
+		// when
+		String resultString = invokeMethod(logService, "createMessage", sr, TEST_MESSAGE);
+
+		// then
+		assertEquals('[' + sr.toString() + ']' + TEST_MESSAGE, resultString);
+	}
+
+	@Test
+	public void testLogServiceCreateMessageNullSr() throws Exception {
+		// when
+		ServiceReference srNull = null;
+		String resultString = invokeMethod(logService, "createMessage", srNull, TEST_MESSAGE);
+
+		// then
+		assertEquals(getInternalState(LogServiceImpl.class, "UNKNOWN") + TEST_MESSAGE, resultString);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,33 @@
     <plugins>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <check>
+            true
+          </check>
+          <formats>
+            <format>html</format>
+            <format>xml</format>
+          </formats>
+          <outputDirectory>${project.build.directory}/site/cobertura</outputDirectory>
+          <instrumentation>
+            <ignoreTrivial>true</ignoreTrivial>
+          </instrumentation>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>cobertura</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>


### PR DESCRIPTION
Improve unit test coverage for module osgi-over-slf4j from 0% to 100% using new tests based on JUnit and PowerMock.

To run the code coverage report, see instructions in the included CODE_COVERAGE.md file.

Thanks!
Furkan Yavuz
DevFactory - Open Source Unit Testing Team