### PR TITLE
SLF4JBridgeHandler : bug fix

### DIFF
--- a/jul-to-slf4j/src/main/java/org/slf4j/bridge/SLF4JBridgeHandler.java
+++ b/jul-to-slf4j/src/main/java/org/slf4j/bridge/SLF4JBridgeHandler.java
@@ -298,6 +298,7 @@ public class SLF4JBridgeHandler extends Handler {
         // see also http://jira.qos.ch/browse/SLF4J-99
         if (message == null) {
             message = "";
+            record.setMessage(message);
         }
         if (slf4jLogger instanceof LocationAwareLogger) {
             callLocationAwareLogger((LocationAwareLogger) slf4jLogger, record);


### PR DESCRIPTION
In complement to : http://jira.qos.ch/browse/SLF4J-99 Null message problem.
The message was checked if null but never updated to empty string in the record.
