### PR TITLE
Changed cal10n dependency into an optional dependency

### DIFF
--- a/slf4j-ext/pom.xml
+++ b/slf4j-ext/pom.xml
@@ -32,6 +32,7 @@
     <dependency>
       <groupId>ch.qos.cal10n</groupId>
       <artifactId>cal10n-api</artifactId>
+      <optional>true</optional>
     </dependency>		
     <dependency>
       <groupId>javassist</groupId>


### PR DESCRIPTION
When including slf4j-ext as a dependency, compiler warnings are thrown from transitive dependency cal10n. I'm hoping this is not a runtime dependency for slf4j, in which case it should not be included as a transitive dependency in projects that only wish to use slf4j-ext.