### PR TITLE
Fix problems in Javadoc references.

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
@@ -33,14 +33,14 @@ import java.util.Map;
 /**
  * Formats messages according to very simple substitution rules. Substitutions
  * can be made 1, 2 or more arguments.
- * 
+ *
  * <p>
  * For example,
- * 
+ *
  * <pre>
  * MessageFormatter.format(&quot;Hi {}.&quot;, &quot;there&quot;)
  * </pre>
- * 
+ *
  * will return the string "Hi there.".
  * <p>
  * The {} pair is called the <em>formatting anchor</em>. It serves to designate
@@ -50,48 +50,48 @@ import java.util.Map;
  * In case your message contains the '{' or the '}' character, you do not have
  * to do anything special unless the '}' character immediately follows '{'. For
  * example,
- * 
+ *
  * <pre>
  * MessageFormatter.format(&quot;Set {1,2,3} is not equal to {}.&quot;, &quot;1,2&quot;);
  * </pre>
- * 
+ *
  * will return the string "Set {1,2,3} is not equal to 1,2.".
- * 
+ *
  * <p>
  * If for whatever reason you need to place the string "{}" in the message
  * without its <em>formatting anchor</em> meaning, then you need to escape the
  * '{' character with '\', that is the backslash character. Only the '{'
  * character should be escaped. There is no need to escape the '}' character.
  * For example,
- * 
+ *
  * <pre>
  * MessageFormatter.format(&quot;Set \\{} is not equal to {}.&quot;, &quot;1,2&quot;);
  * </pre>
- * 
+ *
  * will return the string "Set {} is not equal to 1,2.".
- * 
+ *
  * <p>
  * The escaping behavior just described can be overridden by escaping the escape
  * character '\'. Calling
- * 
+ *
  * <pre>
  * MessageFormatter.format(&quot;File name is C:\\\\{}.&quot;, &quot;file.zip&quot;);
  * </pre>
- * 
+ *
  * will return the string "File name is C:\file.zip".
- * 
+ *
  * <p>
  * The formatting conventions are different than those of {@link MessageFormat}
  * which ships with the Java platform. This is justified by the fact that
  * SLF4J's implementation is 10 times faster than that of {@link MessageFormat}.
  * This local performance difference is both measurable and significant in the
  * larger context of the complete logging processing chain.
- * 
+ *
  * <p>
  * See also {@link #format(String, Object)},
  * {@link #format(String, Object, Object)} and
  * {@link #arrayFormat(String, Object[])} methods for more details.
- * 
+ *
  * @author Ceki G&uuml;lc&uuml;
  * @author Joern Huxhorn
  */
@@ -106,17 +106,17 @@ final public class MessageFormatter {
      * parameter.
      * <p>
      * For example,
-     * 
+     *
      * <pre>
      * MessageFormatter.format(&quot;Hi {}.&quot;, &quot;there&quot;);
      * </pre>
-     * 
+     *
      * will return the string "Hi there.".
      * <p>
-     * 
+     *
      * @param messagePattern
      *          The message pattern which will be parsed and formatted
-     * @param argument
+     * @param arg
      *          The argument to be substituted in place of the formatting anchor
      * @return The formatted message
      */
@@ -125,18 +125,18 @@ final public class MessageFormatter {
     }
 
     /**
-     * 
+     *
      * Performs a two argument substitution for the 'messagePattern' passed as
      * parameter.
      * <p>
      * For example,
-     * 
+     *
      * <pre>
      * MessageFormatter.format(&quot;Hi {}. My name is {}.&quot;, &quot;Alice&quot;, &quot;Bob&quot;);
      * </pre>
-     * 
+     *
      * will return the string "Hi Alice. My name is Bob.".
-     * 
+     *
      * @param messagePattern
      *          The message pattern which will be parsed and formatted
      * @param arg1
@@ -150,6 +150,7 @@ final public class MessageFormatter {
     final public static FormattingTuple format(final String messagePattern, Object arg1, Object arg2) {
         return arrayFormat(messagePattern, new Object[] { arg1, arg2 });
     }
+
 
     static final Throwable getThrowableCandidate(Object[] argArray) {
         if (argArray == null || argArray.length == 0) {

--- a/slf4j-api/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/slf4j-api/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -27,13 +27,13 @@ package org.slf4j.impl;
 import org.slf4j.ILoggerFactory;
 
 /**
- * The binding of {@link LoggerFactory} class with an actual instance of
+ * The binding of {@link org.slf4j.LoggerFactory} class with an actual instance of
  * {@link ILoggerFactory} is performed using information returned by this class.
- * 
- * This class is meant to provide a dummy StaticLoggerBinder to the slf4j-api module. 
- * Real implementations are found in  each SLF4J binding project, e.g. slf4j-nop, 
+ *
+ * This class is meant to provide a dummy StaticLoggerBinder to the slf4j-api module.
+ * Real implementations are found in  each SLF4J binding project, e.g. slf4j-nop,
  * slf4j-log4j12 etc.
- * 
+ *
  * @author Ceki G&uuml;lc&uuml;
  */
 public class StaticLoggerBinder {
@@ -45,7 +45,7 @@ public class StaticLoggerBinder {
 
     /**
      * Return the singleton of this class.
-     * 
+     *
      * @return the StaticLoggerBinder singleton
      */
     public static final StaticLoggerBinder getSingleton() {
@@ -53,8 +53,8 @@ public class StaticLoggerBinder {
     }
 
     /**
-     * Declare the version of the SLF4J API this implementation is compiled against. 
-     * The value of this field is modified with each major release. 
+     * Declare the version of the SLF4J API this implementation is compiled against.
+     * The value of this field is modified with each major release.
      */
     // to avoid constant folding by the compiler, this field must *not* be final
     public static String REQUESTED_API_VERSION = "1.6.99"; // !final

--- a/slf4j-ext/src/main/java/org/slf4j/agent/AgentPremain.java
+++ b/slf4j-ext/src/main/java/org/slf4j/agent/AgentPremain.java
@@ -34,16 +34,14 @@ import org.slf4j.instrumentation.LogTransformer;
 
 /**
  * Entry point for slf4j-ext when used as a Java agent.
- * 
+ *
  */
 public class AgentPremain {
 
     /**
      * JavaAgent premain entry point as specified in the MANIFEST.MF file. See
-     * {@link http
-     * ://java.sun.com/javase/6/docs/api/java/lang/instrument/package-
-     * summary.html} for details.
-     * 
+     * <a href="http://java.sun.com/javase/6/docs/api/java/lang/instrument/package-summary.html">http://java.sun.com/javase/6/docs/api/java/lang/instrument/package-summary.html</a> for details.
+     *
      * @param agentArgument
      *            string provided after "=" up to first space
      * @param instrumentation
@@ -85,8 +83,8 @@ public class AgentPremain {
      * Consider the argument string to be a property file (by converting the
      * splitter character to line feeds), and then reading it like any other
      * property file.
-     * 
-     * 
+     *
+     *
      * @param agentArgument
      *            string given by instrumentation framework
      * @param separator
@@ -109,7 +107,7 @@ public class AgentPremain {
      * Print the start message to System.err with the time NOW, and register a
      * shutdown hook which will print the stop message to System.err with the
      * time then and the number of milliseconds passed since.
-     * 
+     *
      */
     private static void printStartStopTimes() {
         final long start = System.currentTimeMillis();

--- a/slf4j-ext/src/main/java/org/slf4j/cal10n/LocLoggerFactory.java
+++ b/slf4j-ext/src/main/java/org/slf4j/cal10n/LocLoggerFactory.java
@@ -30,19 +30,19 @@ import org.slf4j.LoggerFactory;
 import ch.qos.cal10n.IMessageConveyor;
 
 /**
- * 
+ *
  * This class is essentially a wrapper around an {@link LoggerFactory} producing
  * {@link LocLogger} instances.
- * 
+ *
  * <p>
  * Contrary to {@link LoggerFactory#getLogger(String)} method of
- * {@link LoggerFactory}, each call to {@link getLocLogger} produces a new
+ * {@link LoggerFactory}, each call to {@link #getLocLogger(String)} produces a new
  * instance of {@link LocLogger}. This should not matter because a LocLogger
- * instance does have any state beyond that of the {@link Logger} in stance it
+ * instance does have any state beyond that of the {@link Logger} instance it
  * wraps and its message conveyor.
- * 
+ *
  * @author Ceki G&uuml;c&uuml;
- * 
+ *
  */
 public class LocLoggerFactory {
 
@@ -54,7 +54,7 @@ public class LocLoggerFactory {
 
     /**
      * Get an LocLogger instance by name.
-     * 
+     *
      * @param name
      * @return LocLogger instance by name.
      */
@@ -65,7 +65,7 @@ public class LocLoggerFactory {
     /**
      * Get a new LocLogger instance by class. The returned LocLogger will be named
      * after the class.
-     * 
+     *
      * @param clazz
      * @return LocLogger instance by class
      */

--- a/slf4j-ext/src/main/java/org/slf4j/instrumentation/LogTransformer.java
+++ b/slf4j-ext/src/main/java/org/slf4j/instrumentation/LogTransformer.java
@@ -23,7 +23,7 @@
  *
  */
 /**
- * 
+ *
  */
 package org.slf4j.instrumentation;
 
@@ -57,17 +57,16 @@ public class LogTransformer implements ClassFileTransformer {
     /**
      * Builder provides a flexible way of configuring some of many options on the
      * parent class instead of providing many constructors.
-     * 
-     * {@link http
-     * ://rwhansen.blogspot.com/2007/07/theres-builder-pattern-that-joshua.html}
-     * 
+     *
+     * <a href="http://rwhansen.blogspot.com/2007/07/theres-builder-pattern-that-joshua.html">http://rwhansen.blogspot.com/2007/07/theres-builder-pattern-that-joshua.html</a>
+     *
      */
     public static class Builder {
 
         /**
          * Build and return the LogTransformer corresponding to the options set in
          * this Builder.
-         * 
+         *
          * @return
          */
         public LogTransformer build() {
@@ -82,7 +81,7 @@ public class LogTransformer implements ClassFileTransformer {
         /**
          * Should each method log entry (with parameters) and exit (with parameters
          * and returnvalue)?
-         * 
+         *
          * @param b
          *          value of flag
          * @return
@@ -105,7 +104,7 @@ public class LogTransformer implements ClassFileTransformer {
         /**
          * Should LogTransformer be verbose in what it does? This currently list the
          * names of the classes being processed.
-         * 
+         *
          * @param b
          * @return
          */
@@ -177,7 +176,7 @@ public class LogTransformer implements ClassFileTransformer {
      * transform0 sees if the className starts with any of the namespaces to
      * ignore, if so it is returned unchanged. Otherwise it is processed by
      * doClass(...)
-     * 
+     *
      * @param className
      * @param clazz
      * @param domain
@@ -227,7 +226,7 @@ public class LogTransformer implements ClassFileTransformer {
      * defined have bodies, and a static final logger object is added with the
      * name of this class as an argument, and each method then gets processed with
      * doMethod(...) to have logger calls added.
-     * 
+     *
      * @param name
      *          class name (slashes separate, not dots)
      * @param clazz
@@ -285,7 +284,7 @@ public class LogTransformer implements ClassFileTransformer {
     /**
      * process a single method - this means add entry/exit logging if requested.
      * It is only called for methods with a body.
-     * 
+     *
      * @param method
      *          method to work on
      * @throws NotFoundException


### PR DESCRIPTION
My editor trimmed trailing whitespace in addition to the real Javadoc fixes. Let me know if you'd like my to remove the whitespace changes.