### PR TITLE
fix scm url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </licenses>
 
   <scm>
-    <url>https://github.com/ceki/slf4j</url>
+    <url>https://github.com/qos-ch/slf4j</url>
     <connection>git@github.com:qos-ch/slf4j.git</connection>
   </scm>  
 


### PR DESCRIPTION
Just a minor change: the SCM URL listed in the pom.xml is outdated. I changed it to point to the current github URL.