### PR TITLE
Fixed spacings in nested profilers

### DIFF
--- a/slf4j-ext/src/main/java/org/slf4j/profiler/Profiler.java
+++ b/slf4j-ext/src/main/java/org/slf4j/profiler/Profiler.java
@@ -227,6 +227,7 @@ public class Profiler implements TimeInstrument {
     private String buildProfilerString(DurationUnit du, String firstPrefix, String label, String indentation) {
         StringBuilder buf = new StringBuilder();
 
+        buf.append(indentation);
         buf.append(firstPrefix);
         buf.append(" Profiler [");
         buf.append(name);

--- a/slf4j-ext/src/main/java/org/slf4j/profiler/Profiler.java
+++ b/slf4j-ext/src/main/java/org/slf4j/profiler/Profiler.java
@@ -227,7 +227,8 @@ public class Profiler implements TimeInstrument {
     private String buildProfilerString(DurationUnit du, String firstPrefix, String label, String indentation) {
         StringBuilder buf = new StringBuilder();
 
-        buf.append(indentation);
+        if (indentation.contains("    "))
+            buf.append(indentation.substring(4));
         buf.append(firstPrefix);
         buf.append(" Profiler [");
         buf.append(name);


### PR DESCRIPTION
If you try to create some nested profilers, and then log them, output will be like this.

    + Profiler [TEST]
    |-- elapsed time                     [t1]   249,672 milliseconds.
    |-- elapsed time                     [t2]   250,111 milliseconds.
    |-- elapsed time                     [t3]   249,955 milliseconds.
    |---+ Profiler [nested1]
        |-- elapsed time                     [t1]   249,969 milliseconds.
        |-- elapsed time                     [t2]   249,990 milliseconds.
        |-- elapsed time                     [t3]   250,022 milliseconds.
    |---+ Profiler [nested2]
            |-- elapsed time                     [t1]   249,999 milliseconds.
            |-- elapsed time                     [t2]   250,016 milliseconds.
            |-- elapsed time                     [t3]   250,016 milliseconds.
    |---+ Profiler [nested3]
                |-- elapsed time                     [t1]   250,000 milliseconds.
                |-- elapsed time                     [t2]   250,004 milliseconds.
                |-- elapsed time                     [t3]   250,039 milliseconds.
                |-- Subtotal                    [nested3]   750,055 milliseconds.
            |-- elapsed time                [nested3]   750,055 milliseconds.
            |-- Subtotal                    [nested2]  1500,097 milliseconds.
        |-- elapsed time                [nested2]  1500,097 milliseconds.
        |-- Subtotal                    [nested1]  2250,102 milliseconds.
    |-- elapsed time                [nested1]  2250,102 milliseconds.
    |-- Total                          [TEST]  3000,193 milliseconds.

Inside method `buildProfilerString` `indentation` value is ignored.