### PR TITLE
Binding for edu.stanford.nlp.util.logging.Redwood

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <module>slf4j-site</module>
     <module>slf4j-migrator</module>
     <module>slf4j-bom</module>
+    <module>slf4j-redwood</module>
   </modules>
 
   <dependencies>

--- a/slf4j-redwood/LICENSE.txt
+++ b/slf4j-redwood/LICENSE.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2004-2007 QOS.ch
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+

--- a/slf4j-redwood/pom.xml
+++ b/slf4j-redwood/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-parent</artifactId>
+    <version>1.7.22-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>slf4j-redwood</artifactId>
+  <packaging>jar</packaging>
+  <name>SLF4J Redwood Binding</name>
+  <description>SLF4J Redwood Binding</description>
+  <url>http://www.slf4j.org</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <type>test-jar</type>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>edu.stanford.nlp</groupId>
+      <artifactId>stanford-corenlp</artifactId>
+      <version>3.6.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>18.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/slf4j-redwood/src/main/java/org/slf4j/impl/RedWoodLogLevel.java
+++ b/slf4j-redwood/src/main/java/org/slf4j/impl/RedWoodLogLevel.java
@@ -1,0 +1,10 @@
+package org.slf4j.impl;
+
+public enum RedWoodLogLevel {
+  TRACE,
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+  FATAL,
+}

--- a/slf4j-redwood/src/main/java/org/slf4j/impl/RedWoodLoggerAdapter.java
+++ b/slf4j-redwood/src/main/java/org/slf4j/impl/RedWoodLoggerAdapter.java
@@ -1,0 +1,276 @@
+package org.slf4j.impl;
+
+import edu.stanford.nlp.util.logging.Redwood.RedwoodChannels;
+import edu.stanford.nlp.util.logging.Redwood;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.slf4j.Marker;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MarkerIgnoringBase;
+import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.spi.LocationAwareLogger;
+
+public class RedWoodLoggerAdapter extends MarkerIgnoringBase implements LocationAwareLogger {
+
+  transient final RedwoodChannels channels;
+  transient final String name;
+
+  static String SELF = RedWoodLoggerAdapter.class.getName();
+  static String SUPER = MarkerIgnoringBase.class.getName();
+
+
+  RedWoodLoggerAdapter(String name, RedwoodChannels channels) {
+    this.channels = channels;
+    this.name = name.substring(name.lastIndexOf(".") + 1);
+  }
+
+  @Override
+  public boolean isTraceEnabled() {
+    return true;
+  }
+
+  @Override
+  public void trace(String msg) {
+    trace(msg, (Throwable) null);
+  }
+
+  @Override
+  public void trace(String format, Object arg) {
+    FormattingTuple ft = MessageFormatter.format(format, arg);
+    trace(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+    trace(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void trace(String format, Object... argArray) {
+    FormattingTuple ft = MessageFormatter.format(format, argArray);
+    trace(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void trace(String msg, Throwable throwable) {
+    mytrace(msg, throwable);
+  }
+
+  @Override
+  public boolean isDebugEnabled() {
+    return true;
+  }
+
+  @Override
+  public void debug(String msg) {
+    debug(msg, (Throwable) null);
+  }
+
+  @Override
+  public void debug(String format, Object arg) {
+    FormattingTuple ft = MessageFormatter.format(format, arg);
+    debug(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+    debug(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void debug(String format, Object... argArray) {
+    FormattingTuple ft = MessageFormatter.format(format, argArray);
+    debug(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void debug(String msg, Throwable throwable) {
+    mydebug(msg, throwable);
+  }
+
+  @Override
+  public boolean isInfoEnabled() {
+    return true;
+  }
+
+  @Override
+  public void info(String msg) {
+    info(msg, (Throwable) null);
+  }
+
+  @Override
+  public void info(String format, Object arg) {
+    FormattingTuple ft = MessageFormatter.format(format, arg);
+    info(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+    info(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void info(String format, Object... argArray) {
+    FormattingTuple ft = MessageFormatter.format(format, argArray);
+    info(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void info(String msg, Throwable throwable) {
+    myinfo(msg, throwable);
+  }
+
+  @Override
+  public boolean isWarnEnabled() {
+    return true;
+  }
+
+  @Override
+  public void warn(String msg) {
+    warn(msg, (Throwable) null);
+  }
+
+  @Override
+  public void warn(String format, Object arg) {
+    FormattingTuple ft = MessageFormatter.format(format, arg);
+    warn(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void warn(String format, Object... argArray) {
+    FormattingTuple ft = MessageFormatter.format(format, argArray);
+    warn(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+    warn(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void warn(String msg, Throwable throwable) {
+    mywarn(msg, throwable);
+  }
+
+  @Override
+  public boolean isErrorEnabled() {
+    return true;
+  }
+
+  @Override
+  public void error(String msg) {
+    error(msg, (Throwable) null);
+  }
+
+  @Override
+  public void error(String format, Object arg) {
+    FormattingTuple ft = MessageFormatter.format(format, arg);
+    error(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+    error(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void error(String format, Object... argArray) {
+    FormattingTuple ft = MessageFormatter.format(format, argArray);
+    error(ft.getMessage(), ft.getThrowable());
+  }
+
+  @Override
+  public void error(String msg, Throwable throwable) {
+    myerror(msg, throwable);
+  }
+
+  private void mytrace(String msg, Throwable throwable) {
+    mylog(channels.channels(RedWoodLogLevel.TRACE), msg,throwable);
+  }
+
+  private void mydebug(String msg, Throwable throwable) {
+    mylog(channels.channels(RedWoodLogLevel.DEBUG, Redwood.DBG), msg, throwable);
+  }
+
+  private void myinfo(String msg, Throwable throwable) {
+    mylog(channels.channels(RedWoodLogLevel.INFO), msg, throwable);
+  }
+
+  private void mywarn(String msg, Throwable throwable) {
+    mylog(channels.channels(RedWoodLogLevel.WARN, Redwood.WARN), msg, throwable);
+  }
+
+  private void myerror(String msg, Throwable throwable) {
+    mylog(channels.channels(RedWoodLogLevel.ERROR, Redwood.ERR), msg, throwable);
+  }
+
+  private void mylog(RedwoodChannels channels, String msg, Throwable throwable) {
+    if (throwable != null) {
+      StringWriter sw = new StringWriter();
+      throwable.printStackTrace(new PrintWriter(sw));
+      channels.log("[" + name + "]" + msg + "\n" + sw);
+    } else {
+      channels.log("[" + name + "]" + msg);
+    }
+  }
+
+  @Override
+  public void log(Marker marker, String callerFQCN, int level, String message, Object[] argArray,
+      Throwable t) {
+    String s = fillCallerData(callerFQCN);
+    switch (level) {
+    case LocationAwareLogger.TRACE_INT:
+      trace(marker, message, t);
+      break;
+    case LocationAwareLogger.DEBUG_INT:
+      debug(marker, message, t);
+      break;
+    case LocationAwareLogger.INFO_INT:
+      info(marker, message, t);
+      break;
+    case LocationAwareLogger.WARN_INT:
+      warn(marker, message, t);
+      break;
+    case LocationAwareLogger.ERROR_INT:
+      error(marker, message, t);
+      break;
+    default:
+      throw new IllegalStateException("Level number " + level + " is not recognized.");
+    }
+  }
+
+  final private String fillCallerData(String callerFQCN) {
+    StackTraceElement[] steArray = new Throwable().getStackTrace();
+
+    int selfIndex = -1;
+    for (int i = 0; i < steArray.length; i++) {
+      final String className = steArray[i].getClassName();
+      if (className.equals(callerFQCN) || className.equals(SUPER)) {
+        selfIndex = i;
+        break;
+      }
+    }
+
+    int found = -1;
+    for (int i = selfIndex + 1; i < steArray.length; i++) {
+      final String className = steArray[i].getClassName();
+      if (!(className.equals(callerFQCN) || className.equals(SUPER))) {
+        found = i;
+        break;
+      }
+    }
+
+    if (found != -1) {
+      StackTraceElement ste = steArray[found];
+      // setting the class name has the side effect of setting
+      // the needToInferCaller variable to false.
+      return ste.toString();
+    }
+    return callerFQCN;
+  }
+}

--- a/slf4j-redwood/src/main/java/org/slf4j/impl/RedWoodLoggerFactory.java
+++ b/slf4j-redwood/src/main/java/org/slf4j/impl/RedWoodLoggerFactory.java
@@ -1,0 +1,30 @@
+package org.slf4j.impl;
+
+import com.google.common.collect.Maps;
+import edu.stanford.nlp.util.logging.Redwood;
+import edu.stanford.nlp.util.logging.Redwood.RedwoodChannels;
+import java.util.concurrent.ConcurrentMap;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+
+public class RedWoodLoggerFactory implements ILoggerFactory {
+
+  ConcurrentMap<String, Logger> loggerMap;
+
+  public RedWoodLoggerFactory() {
+    loggerMap = Maps.newConcurrentMap();
+  }
+
+  @Override
+  public Logger getLogger(String name) {
+    Logger slf4jLogger = loggerMap.get(name);
+    if (slf4jLogger != null) {
+      return slf4jLogger;
+    } else {
+      RedwoodChannels logger = Redwood.channels(name);
+      Logger newInstance = new RedWoodLoggerAdapter(name, logger);
+      Logger oldInstance = loggerMap.putIfAbsent(name, newInstance);
+      return oldInstance == null ? newInstance : oldInstance;
+    }
+  }
+}

--- a/slf4j-redwood/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/slf4j-redwood/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,0 +1,30 @@
+package org.slf4j.impl;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.spi.LoggerFactoryBinder;
+
+public class StaticLoggerBinder implements LoggerFactoryBinder {
+
+  private static final StaticLoggerBinder instance = new StaticLoggerBinder();
+  private final ILoggerFactory loggerFactory;
+  private static final String loggerFactoryClassStr = RedWoodLoggerFactory.class.getName();
+
+
+  public static StaticLoggerBinder getSingleton() {
+    return instance;
+  }
+
+  private StaticLoggerBinder() {
+    loggerFactory = new RedWoodLoggerFactory();
+  }
+
+  @Override
+  public ILoggerFactory getLoggerFactory() {
+    return loggerFactory;
+  }
+
+  @Override
+  public String getLoggerFactoryClassStr() {
+    return loggerFactoryClassStr;
+  }
+}

--- a/slf4j-redwood/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-redwood/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,12 @@
+Implementation-Title: slf4j-redwood
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: slf4j.redwood
+Bundle-Name: slf4j-redwood
+Bundle-Vendor: SLF4J.ORG
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Export-Package: org.slf4j.impl;version=${parsedVersion.osgiVersion}
+Import-Package: org.slf4j;version=${parsedVersion.osgiVersion},
+ org.slf4j.spi;version=${parsedVersion.osgiVersion},
+ org.slf4j.helpers;version=${parsedVersion.osgiVersion},
+ org.slf4j.event;version=${parsedVersion.osgiVersion}
+Fragment-Host: slf4j.api


### PR DESCRIPTION
Add "slf4j-redwood" to support Redwood Logger, which is used in Stanford
Natural Language toolkit.

https://github.com/gangeli/redwood

"Redwood was developed at Stanford by students in the Stanford NLP Group. A
tutorial in docs/tutorial.pdf, presented to the group, provides a good
introduction to the theory and use of Redwood. It also motivates what types
of projects would fit well into the paradigm."