### PR TITLE
Feature to allow suppressing unsuccessful init error message

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -81,6 +81,7 @@ public final class LoggerFactory {
     static final String UNSUCCESSFUL_INIT_URL = CODES_PREFIX + "#unsuccessfulInit";
     static final String UNSUCCESSFUL_INIT_MSG = "org.slf4j.LoggerFactory in failed state. Original exception was thrown EARLIER. See also "
                     + UNSUCCESSFUL_INIT_URL;
+    static final String UNSUCCESSFUL_INIT_MSG_SUPPRESSION_SYSTEM_PROPERTY = "slf4j.suppressInitError";
 
     static final int UNINITIALIZED = 0;
     static final int ONGOING_INITIALIZATION = 1;
@@ -159,9 +160,12 @@ public final class LoggerFactory {
                 SUBST_PROVIDER.getSubstituteLoggerFactory().clear();
             } else {
                 INITIALIZATION_STATE = NOP_FALLBACK_INITIALIZATION;
-                Util.report("No SLF4J providers were found.");
-                Util.report("Defaulting to no-operation (NOP) logger implementation");
-                Util.report("See " + NO_PROVIDERS_URL + " for further details.");
+                boolean suppressError = Util.safeGetBooleanSystemProperty(UNSUCCESSFUL_INIT_MSG_SUPPRESSION_SYSTEM_PROPERTY);
+                if (!suppressError) {
+                  Util.report("No SLF4J providers were found.");
+                  Util.report("Defaulting to no-operation (NOP) logger implementation");
+                  Util.report("See " + NO_PROVIDERS_URL + " for further details.");
+                }
 
                 Set<URL> staticLoggerBinderPathSet = findPossibleStaticLoggerBinderPathSet();
                 reportIgnoredStaticLoggerBinders(staticLoggerBinderPathSet);


### PR DESCRIPTION
As you can read in https://github.com/m-m-m/util/issues/194 there are cases where one uses slf4j in general library code that is also used in command-line-interface (CLI) programs.
In my case I want to ship the CLI library without any logger binding for slf4j in order to give users the freedom to choose on their own. However the CLI library already contains CLI programs by itself. If you want to run them without additional dependencies you get a warm welcome from slf4j saying:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

In case of a CLI program this output is really undesired.

I tried to be constructive and provide a minimal invasive "fix" for the problem that allows to suppress this output by setting a system property `slf4j.suppressInitError` (I tried to follow your current code and naming conventions) to true.

You can also add a public static non-arg method to `LoggerFactory` that sets the system property to true for you if you like. Also you can think of a system property that enforces nop logger no matter what is on your classpath. But as stated before I wanted to keep the change and impact minimal so I hopefully have a high change to get this PR accepted and you see this as a helpful improvement to slf4j. Thanks in advance.
