### PR TITLE
SLF4J-257 - Use log4j's implementation of MDC.clear() to avoid leaking memory.

### DIFF
--- a/slf4j-log4j12/src/main/java/org/slf4j/impl/Log4jMDCAdapter.java
+++ b/slf4j-log4j12/src/main/java/org/slf4j/impl/Log4jMDCAdapter.java
@@ -33,11 +33,7 @@ import org.slf4j.spi.MDCAdapter;
 public class Log4jMDCAdapter implements MDCAdapter {
 
     public void clear() {
-        @SuppressWarnings("rawtypes")
-        Map map = org.apache.log4j.MDC.getContext();
-        if (map != null) {
-            map.clear();
-        }
+        org.apache.log4j.MDC.clear();
     }
 
     public String get(String key) {


### PR DESCRIPTION
Fix for http://jira.qos.ch/browse/SLF4J-257
