### PR TITLE
Adding a bridge for Twitter-Logging to SLF4j.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <module>slf4j-site</module>
     <module>slf4j-migrator</module>
     <module>slf4j-bom</module>
+    <module>slf4j-twitter</module>
   </modules>
 
   <dependencies>
@@ -246,7 +247,6 @@
         <version>${maven-site-plugin.version}</version>
         <configuration>
           <reportPlugins>
-
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-jxr-plugin</artifactId>

--- a/slf4j-twitter/LICENSE.txt
+++ b/slf4j-twitter/LICENSE.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2004-2007 QOS.ch
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+

--- a/slf4j-twitter/pom.xml
+++ b/slf4j-twitter/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-parent</artifactId>
+    <version>1.7.22-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>slf4j-twitter</artifactId>
+  <packaging>jar</packaging>
+  <name>SLF4J Twitter-Logging Binding</name>
+  <description>SLF4J JDK14 Binding</description>
+  <url>http://www.slf4j.org</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <type>test-jar</type>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>util-logging_2.11</artifactId>
+      <version>6.34.0</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/slf4j-twitter/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/slf4j-twitter/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+import org.slf4j.spi.LoggerFactoryBinder;
+
+/**
+ * The binding of {@link LoggerFactory} class with an actual instance of 
+ * {@link ILoggerFactory} is performed using information returned by this class. 
+ * 
+ * @author Ceki G&uuml;lc&uuml;
+ */
+public class StaticLoggerBinder implements LoggerFactoryBinder {
+
+    /**
+     * The unique instance of this class.
+     * 
+     */
+    private static final StaticLoggerBinder SINGLETON = new StaticLoggerBinder();
+
+    /**
+     * Return the singleton of this class.
+     * 
+     * @return the StaticLoggerBinder singleton
+     */
+    public static final StaticLoggerBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    /**
+     * Declare the version of the SLF4J API this implementation is compiled against. 
+     * The value of this field is modified with each major release. 
+     */
+    // to avoid constant folding by the compiler, this field must *not* be final
+    public static String REQUESTED_API_VERSION = "1.6.99"; // !final
+
+    private static final String loggerFactoryClassStr = TwitterLoggerFactory.class.getName();
+
+    /** The ILoggerFactory instance returned by the {@link #getLoggerFactory} method
+     * should always be the same object
+     */
+    private final ILoggerFactory loggerFactory;
+
+    private StaticLoggerBinder() {
+        // Note: JCL gets substituted at build time by an appropriate Ant task
+        loggerFactory = new TwitterLoggerFactory();
+    }
+
+    public ILoggerFactory getLoggerFactory() {
+        return loggerFactory;
+    }
+
+    public String getLoggerFactoryClassStr() {
+        return loggerFactoryClassStr;
+    }
+}

--- a/slf4j-twitter/src/main/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/slf4j-twitter/src/main/java/org/slf4j/impl/StaticMDCBinder.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import org.slf4j.helpers.BasicMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
+
+/**
+ * This implementation is bound to {@link BasicMDCAdapter}.
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ */
+public class StaticMDCBinder {
+
+    /**
+     * The unique instance of this class.
+     */
+    public static final StaticMDCBinder SINGLETON = new StaticMDCBinder();
+
+    private StaticMDCBinder() {
+    }
+
+    /**
+     * Return the singleton of this class.
+     * 
+     * @return the StaticMDCBinder singleton
+     * @since 1.7.14
+     */
+    public static final StaticMDCBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    /**
+     * Currently this method always returns an instance of 
+     * {@link BasicMDCAdapter}.
+     */
+    public MDCAdapter getMDCA() {
+        // note that this method is invoked only from within the static initializer of
+        // the org.slf4j.MDC class.
+        return new BasicMDCAdapter();
+    }
+
+    public String getMDCAdapterClassStr() {
+        return BasicMDCAdapter.class.getName();
+    }
+}

--- a/slf4j-twitter/src/main/java/org/slf4j/impl/StaticMarkerBinder.java
+++ b/slf4j-twitter/src/main/java/org/slf4j/impl/StaticMarkerBinder.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import org.slf4j.IMarkerFactory;
+import org.slf4j.MarkerFactory;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.spi.MarkerFactoryBinder;
+
+/**
+ * 
+ * The binding of {@link MarkerFactory} class with an actual instance of 
+ * {@link IMarkerFactory} is performed using information returned by this class. 
+ * 
+ * @author Ceki G&uuml;lc&uuml;
+ */
+public class StaticMarkerBinder implements MarkerFactoryBinder {
+
+    /**
+     * The unique instance of this class.
+     */
+    public static final StaticMarkerBinder SINGLETON = new StaticMarkerBinder();
+
+    final IMarkerFactory markerFactory = new BasicMarkerFactory();
+
+    private StaticMarkerBinder() {
+    }
+
+    /**
+     * Return the singleton of this class.
+     * 
+     * @return the StaticMarkerBinder singleton
+     * @since 1.7.14
+     */
+    public static StaticMarkerBinder getSingleton() {
+        return SINGLETON;
+    }
+
+    /**
+     * Currently this method always returns an instance of 
+     * {@link BasicMarkerFactory}.
+     */
+    public IMarkerFactory getMarkerFactory() {
+        return markerFactory;
+    }
+
+    /**
+     * Currently, this method returns the class name of
+     * {@link BasicMarkerFactory}.
+     */
+    public String getMarkerFactoryClassStr() {
+        return BasicMarkerFactory.class.getName();
+    }
+
+}

--- a/slf4j-twitter/src/main/java/org/slf4j/impl/TwiterLoggerAdapter.java
+++ b/slf4j-twitter/src/main/java/org/slf4j/impl/TwiterLoggerAdapter.java
@@ -1,0 +1,687 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import com.twitter.logging.LogRecord;
+import com.twitter.logging.Level;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.EventConstants;
+import org.slf4j.event.LoggingEvent;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MarkerIgnoringBase;
+import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.spi.LocationAwareLogger;
+import scala.Option;
+
+/**
+ * A wrapper over {@link com.twitter.logging.Logger com.twitter.logging.Logger} in
+ * conformity with the {@link Logger} interface. Note that the logging levels
+ * mentioned in this class refer to those defined in the com.twitter.logging package
+ * whihc in turn refers to the java.util.logging package.
+ *
+ * This is heavily based on the JDK14LoggerAddapter
+ * 
+ * @author Ceki G&uuml;lc&uuml;
+ * @author Peter Royal
+ * @author Dirk Walter
+ */
+public final class TwiterLoggerAdapter extends MarkerIgnoringBase implements LocationAwareLogger {
+
+    private static final long serialVersionUID = -8053026990503422791L;
+
+    transient final com.twitter.logging.Logger logger;
+
+    // WARN: TwiterLoggerAdapter constructor should have only package access so
+    // that only TwitterLoggerFactory be able to create one.
+    TwiterLoggerAdapter(com.twitter.logging.Logger logger) {
+        this.logger = logger;
+        this.name = logger.name();
+    }
+
+    /**
+     * Is this logger instance enabled for the FINEST level?
+     * 
+     * @return True if this Logger is enabled for level FINEST, false otherwise.
+     */
+    public boolean isTraceEnabled() {
+        return logger.isLoggable(Level.TRACE$.MODULE$.get());
+    }
+
+    /**
+     * Log a message object at level FINEST.
+     * 
+     * @param msg
+     *          - the message object to be logged
+     */
+    public void trace(String msg) {
+        if (logger.isLoggable(Level.TRACE$.MODULE$.get())) {
+            log(SELF, Level.TRACE$.MODULE$.get(), msg, null);
+        }
+    }
+
+    /**
+     * Log a message at level FINEST according to the specified format and
+     * argument.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for level FINEST.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    public void trace(String format, Object arg) {
+        if (logger.isLoggable(Level.TRACE$.MODULE$.get())) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.TRACE$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level FINEST according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the FINEST level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg1
+     *          the first argument
+     * @param arg2
+     *          the second argument
+     */
+    public void trace(String format, Object arg1, Object arg2) {
+        if (logger.isLoggable(Level.TRACE$.MODULE$.get())) {
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            log(SELF, Level.TRACE$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level FINEST according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the FINEST level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param argArray
+     *          an array of arguments
+     */
+    public void trace(String format, Object... argArray) {
+        if (logger.isLoggable(Level.TRACE$.MODULE$.get())) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
+            log(SELF, Level.TRACE$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at level FINEST with an accompanying message.
+     * 
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void trace(String msg, Throwable t) {
+        if (logger.isLoggable(Level.TRACE$.MODULE$.get())) {
+            log(SELF, Level.TRACE$.MODULE$.get(), msg, t);
+        }
+    }
+
+    /**
+     * Is this logger instance enabled for the FINE level?
+     * 
+     * @return True if this Logger is enabled for level FINE, false otherwise.
+     */
+    public boolean isDebugEnabled() {
+        return logger.isLoggable(Level.DEBUG$.MODULE$.get());
+    }
+
+    /**
+     * Log a message object at level FINE.
+     * 
+     * @param msg
+     *          - the message object to be logged
+     */
+    public void debug(String msg) {
+        if (logger.isLoggable(Level.DEBUG$.MODULE$.get())) {
+            log(SELF, Level.DEBUG$.MODULE$.get(), msg, null);
+        }
+    }
+
+    /**
+     * Log a message at level FINE according to the specified format and argument.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for level FINE.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    public void debug(String format, Object arg) {
+        if (logger.isLoggable(Level.DEBUG$.MODULE$.get())) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.DEBUG$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level FINE according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the FINE level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg1
+     *          the first argument
+     * @param arg2
+     *          the second argument
+     */
+    public void debug(String format, Object arg1, Object arg2) {
+        if (logger.isLoggable(Level.DEBUG$.MODULE$.get())) {
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            log(SELF, Level.DEBUG$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level FINE according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the FINE level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param argArray
+     *          an array of arguments
+     */
+    public void debug(String format, Object... argArray) {
+        if (logger.isLoggable(Level.DEBUG$.MODULE$.get())) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
+            log(SELF, Level.DEBUG$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at level FINE with an accompanying message.
+     * 
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void debug(String msg, Throwable t) {
+        if (logger.isLoggable(Level.DEBUG$.MODULE$.get())) {
+            log(SELF, Level.DEBUG$.MODULE$.get(), msg, t);
+        }
+    }
+
+    /**
+     * Is this logger instance enabled for the INFO level?
+     * 
+     * @return True if this Logger is enabled for the INFO level, false otherwise.
+     */
+    public boolean isInfoEnabled() {
+        return logger.isLoggable(Level.fromJava(java.util.logging.Level.INFO).get());
+    }
+
+    /**
+     * Log a message object at the INFO level.
+     * 
+     * @param msg
+     *          - the message object to be logged
+     */
+    public void info(String msg) {
+        logger.info(msg);
+    }
+
+    /**
+     * Log a message at level INFO according to the specified format and argument.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the INFO level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    public void info(String format, Object arg) {
+        logger.info(format, arg);
+    }
+
+    /**
+     * Log a message at the INFO level according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the INFO level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg1
+     *          the first argument
+     * @param arg2
+     *          the second argument
+     */
+    public void info(String format, Object arg1, Object arg2) {
+        logger.info(format, arg1, arg2);
+    }
+
+    /**
+     * Log a message at level INFO according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the INFO level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param argArray
+     *          an array of arguments
+     */
+    public void info(String format, Object... argArray) {
+        logger.info(format, argArray);
+    }
+
+    /**
+     * Log an exception (throwable) at the INFO level with an accompanying
+     * message.
+     * 
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void info(String msg, Throwable t) {
+        logger.info(t, msg);
+    }
+
+    /**
+     * Is this logger instance enabled for the WARNING level?
+     * 
+     * @return True if this Logger is enabled for the WARNING level, false
+     *         otherwise.
+     */
+    public boolean isWarnEnabled() {
+        return logger.isLoggable(Level.WARNING);
+    }
+
+    /**
+     * Log a message object at the WARNING level.
+     * 
+     * @param msg
+     *          - the message object to be logged
+     */
+    public void warn(String msg) {
+        if (logger.isLoggable(Level.WARNING)) {
+            log(SELF, Level.WARNING$.MODULE$.get(), msg, null);
+        }
+    }
+
+    /**
+     * Log a message at the WARNING level according to the specified format and
+     * argument.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the WARNING level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    public void warn(String format, Object arg) {
+        if (logger.isLoggable(Level.WARNING)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.WARNING$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at the WARNING level according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the WARNING level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg1
+     *          the first argument
+     * @param arg2
+     *          the second argument
+     */
+    public void warn(String format, Object arg1, Object arg2) {
+        if (logger.isLoggable(Level.WARNING)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            log(SELF, Level.WARNING$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level WARNING according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the WARNING level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param argArray
+     *          an array of arguments
+     */
+    public void warn(String format, Object... argArray) {
+        if (logger.isLoggable(Level.WARNING)) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
+            log(SELF, Level.WARNING$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at the WARNING level with an accompanying
+     * message.
+     * 
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void warn(String msg, Throwable t) {
+        if (logger.isLoggable(Level.WARNING)) {
+            log(SELF, Level.WARNING$.MODULE$.get(), msg, t);
+        }
+    }
+
+    /**
+     * Is this logger instance enabled for level SEVERE?
+     * 
+     * @return True if this Logger is enabled for level SEVERE, false otherwise.
+     */
+    public boolean isErrorEnabled() {
+        return logger.isLoggable(Level.SEVERE);
+    }
+
+    /**
+     * Log a message object at the SEVERE level.
+     * 
+     * @param msg
+     *          - the message object to be logged
+     */
+    public void error(String msg) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            log(SELF, Level.ERROR$.MODULE$.get(), msg, null);
+        }
+    }
+
+    /**
+     * Log a message at the SEVERE level according to the specified format and
+     * argument.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the SEVERE level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    public void error(String format, Object arg) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.ERROR$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at the SEVERE level according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the SEVERE level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arg1
+     *          the first argument
+     * @param arg2
+     *          the second argument
+     */
+    public void error(String format, Object arg1, Object arg2) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg1, arg2);
+            log(SELF, Level.ERROR$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level SEVERE according to the specified format and
+     * arguments.
+     * 
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the SEVERE level.
+     * </p>
+     * 
+     * @param format
+     *          the format string
+     * @param arguments
+     *          an array of arguments
+     */
+    public void error(String format, Object... arguments) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
+            log(SELF, Level.ERROR$.MODULE$.get(), ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at the SEVERE level with an accompanying
+     * message.
+     * 
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void error(String msg, Throwable t) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            log(SELF, Level.ERROR$.MODULE$.get(), msg, t);
+        }
+    }
+
+    /**
+     * Log the message at the specified level with the specified throwable if any.
+     * This method creates a LogRecord and fills in caller date before calling
+     * this instance's JDK14 logger.
+     * 
+     * See bug report #13 for more details.
+     * 
+     * @param level
+     * @param msg
+     * @param t
+     */
+    private void log(String callerFQCN, Level level, String msg, Throwable t) {
+        // millis and thread are filled by the constructor
+        LogRecord record = new LogRecord(level, msg);
+        record.setLoggerName(getName());
+        record.setThrown(t);
+        // Note: parameters in record are not set because SLF4J only
+        // supports a single formatting style
+        fillCallerData(callerFQCN, record);
+        logger.log(record);
+    }
+
+    static String SELF = TwiterLoggerAdapter.class.getName();
+    static String SUPER = MarkerIgnoringBase.class.getName();
+
+    /**
+     * Fill in caller data if possible.
+     * 
+     * @param record
+     *          The record to update
+     */
+    final private void fillCallerData(String callerFQCN, LogRecord record) {
+        StackTraceElement[] steArray = new Throwable().getStackTrace();
+
+        int selfIndex = -1;
+        for (int i = 0; i < steArray.length; i++) {
+            final String className = steArray[i].getClassName();
+            if (className.equals(callerFQCN) || className.equals(SUPER)) {
+                selfIndex = i;
+                break;
+            }
+        }
+
+        int found = -1;
+        for (int i = selfIndex + 1; i < steArray.length; i++) {
+            final String className = steArray[i].getClassName();
+            if (!(className.equals(callerFQCN) || className.equals(SUPER))) {
+                found = i;
+                break;
+            }
+        }
+
+        if (found != -1) {
+            StackTraceElement ste = steArray[found];
+            // setting the class name has the side effect of setting
+            // the needToInferCaller variable to false.
+            record.setSourceClassName(ste.getClassName());
+            record.setSourceMethodName(ste.getMethodName());
+        }
+    }
+
+    public void log(Marker marker, String callerFQCN, int level, String message, Object[] argArray, Throwable t) {
+        Level julLevel = slf4jLevelIntToJULLevel(level);
+        // the logger.isLoggable check avoids the unconditional
+        // construction of location data for disabled log
+        // statements. As of 2008-07-31, callers of this method
+        // do not perform this check. See also
+        // http://jira.qos.ch/browse/SLF4J-81
+        if (logger.isLoggable(julLevel)) {
+            log(callerFQCN, julLevel, message, t);
+        }
+    }
+
+    private Level slf4jLevelIntToJULLevel(int slf4jLevelInt) {
+        java.util.logging.Level julLevel;
+        switch (slf4jLevelInt) {
+        case LocationAwareLogger.TRACE_INT:
+            julLevel = java.util.logging.Level.FINEST;
+            break;
+        case LocationAwareLogger.DEBUG_INT:
+            julLevel = java.util.logging.Level.FINE;
+            break;
+        case LocationAwareLogger.INFO_INT:
+            julLevel = java.util.logging.Level.INFO;
+            break;
+        case LocationAwareLogger.WARN_INT:
+            julLevel = Level.WARNING;
+            break;
+        case LocationAwareLogger.ERROR_INT:
+            julLevel = Level.SEVERE;
+            break;
+        default:
+            throw new IllegalStateException("Level number " + slf4jLevelInt + " is not recognized.");
+        }
+
+        Option<Level> ret = Level.fromJava(julLevel);
+        return ret.isDefined() ? ret.get() : null;
+    }
+
+    /**
+     * @since 1.7.15
+     */
+    public void log(LoggingEvent event) {
+        Level julLevel = slf4jLevelIntToJULLevel(event.getLevel().toInt());
+        if (logger.isLoggable(julLevel)) {
+            LogRecord record = eventToRecord(event, julLevel);
+            logger.log(record);
+        }
+    }
+
+    private LogRecord eventToRecord(LoggingEvent event, Level julLevel) {
+        String format = event.getMessage();
+        Object[] arguments = event.getArgumentArray();
+        FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
+        if (ft.getThrowable() != null && event.getThrowable() != null) {
+            throw new IllegalArgumentException("both last element in argument array and last argument are of type Throwable");
+        }
+
+        Throwable t = event.getThrowable();
+        if (ft.getThrowable() != null) {
+            t = ft.getThrowable();
+            throw new IllegalStateException("fix above code");
+        }
+
+        LogRecord record = new LogRecord(julLevel, ft.getMessage());
+        record.setLoggerName(event.getLoggerName());
+        record.setMillis(event.getTimeStamp());
+        record.setSourceClassName(EventConstants.NA_SUBST);
+        record.setSourceMethodName(EventConstants.NA_SUBST);
+
+        record.setThrown(t);
+        return record;
+    }
+}

--- a/slf4j-twitter/src/main/java/org/slf4j/impl/TwitterLoggerFactory.java
+++ b/slf4j-twitter/src/main/java/org/slf4j/impl/TwitterLoggerFactory.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.ILoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * TwitterLoggerFactory is an implementation of {@link ILoggerFactory} returning
+ * the appropriately named {@link TwiterLoggerAdapter} instance.
+ *
+ * This is heavily based on the JDK14LoggerFactory
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ * @author Dirk Walter
+ */
+public class TwitterLoggerFactory implements ILoggerFactory {
+
+    // key: name (String), value: a TwiterLoggerAdapter;
+    ConcurrentMap<String, Logger> loggerMap;
+
+    public TwitterLoggerFactory() {
+        loggerMap = new ConcurrentHashMap<String, Logger>();
+        // ensure jul initialization. see SLF4J-359 
+        // note that call to java.util.logging.LogManager.getLogManager() fails on the Google App Engine platform. See SLF4J-363
+        com.twitter.logging.Logger.get("");
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.slf4j.ILoggerFactory#getLogger(java.lang.String)
+     */
+    public Logger getLogger(String name) {
+        // the root logger is called "" in JUL
+        if (name.equalsIgnoreCase(Logger.ROOT_LOGGER_NAME)) {
+            name = "slf4j";
+        }
+
+        Logger slf4jLogger = loggerMap.get(name);
+        if (slf4jLogger != null)
+            return slf4jLogger;
+        else {
+            com.twitter.logging.Logger julLogger = com.twitter.logging.Logger.get(name);
+            Logger newInstance = new TwiterLoggerAdapter(julLogger);
+            Logger oldInstance = loggerMap.putIfAbsent(name, newInstance);
+            return oldInstance == null ? newInstance : oldInstance;
+        }
+    }
+}

--- a/slf4j-twitter/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-twitter/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,12 @@
+Implementation-Title: slf4j-twitter
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: slf4j.twitter
+Bundle-Name: slf4j-twitter
+Bundle-Vendor: SLF4J.ORG
+Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Export-Package: org.slf4j.impl;version=${parsedVersion.osgiVersion}
+Import-Package: org.slf4j;version=${parsedVersion.osgiVersion},
+ org.slf4j.spi;version=${parsedVersion.osgiVersion},
+ org.slf4j.helpers;version=${parsedVersion.osgiVersion},
+ org.slf4j.event;version=${parsedVersion.osgiVersion}
+Fragment-Host: slf4j.api

--- a/slf4j-twitter/src/test/java/org/slf4j/InvocationTest.java
+++ b/slf4j-twitter/src/test/java/org/slf4j/InvocationTest.java
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Test whether invoking the SLF4J API causes problems or not.
+ *
+ * @author Ceki Gulcu
+ */
+public class InvocationTest {
+
+    Level oldLevel;
+    java.util.logging.Logger root = java.util.logging.Logger.getLogger("");
+
+    ListHandler listHandler = new ListHandler();
+
+    @Before
+    public void setUp() throws Exception {
+        oldLevel = root.getLevel();
+        root.setLevel(Level.FINE);
+        // removeAllHandlers(root);
+        root.addHandler(listHandler);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        root.setLevel(oldLevel);
+        removeListHandlers(root);
+    }
+
+    @Test
+    public void test1() {
+        Logger logger = LoggerFactory.getLogger("test1");
+        logger.debug("Hello world.");
+        assertLogMessage("Hello world.", 0);
+    }
+
+    @Test
+    public void verifyMessageFormatting() {
+        Integer i1 = new Integer(1);
+        Integer i2 = new Integer(2);
+        Integer i3 = new Integer(3);
+        Exception e = new Exception("This is a test exception.");
+        Logger logger = LoggerFactory.getLogger("test2");
+
+        int index = 0;
+        logger.debug("Hello world");
+        assertLogMessage("Hello world", index++);
+
+        logger.debug("Hello world {}", i1);
+        assertLogMessage("Hello world " + i1, index++);
+
+        logger.debug("val={} val={}", i1, i2);
+        assertLogMessage("val=1 val=2", index++);
+
+        logger.debug("val={} val={} val={}", new Object[] { i1, i2, i3 });
+        assertLogMessage("val=1 val=2 val=3", index++);
+
+        logger.debug("Hello world 2", e);
+        assertLogMessage("Hello world 2", index);
+        assertException(e.getClass(), index++);
+        logger.info("Hello world 2.");
+
+        logger.warn("Hello world 3.");
+        logger.warn("Hello world 3", e);
+
+        logger.error("Hello world 4.");
+        logger.error("Hello world {}", new Integer(3));
+        logger.error("Hello world 4.", e);
+    }
+
+    @Test
+    public void testNull() {
+        Logger logger = LoggerFactory.getLogger("testNull");
+        logger.debug(null);
+        logger.info(null);
+        logger.warn(null);
+        logger.error(null);
+
+        Exception e = new Exception("This is a test exception.");
+        logger.debug(null, e);
+        logger.info(null, e);
+        logger.warn(null, e);
+        logger.error(null, e);
+    }
+
+    @Test
+    public void testMarker() {
+        Logger logger = LoggerFactory.getLogger("testMarker");
+        Marker blue = MarkerFactory.getMarker("BLUE");
+        logger.debug(blue, "hello");
+        logger.info(blue, "hello");
+        logger.warn(blue, "hello");
+        logger.error(blue, "hello");
+
+        logger.debug(blue, "hello {}", "world");
+        logger.info(blue, "hello {}", "world");
+        logger.warn(blue, "hello {}", "world");
+        logger.error(blue, "hello {}", "world");
+
+        logger.debug(blue, "hello {} and {} ", "world", "universe");
+        logger.info(blue, "hello {} and {} ", "world", "universe");
+        logger.warn(blue, "hello {} and {} ", "world", "universe");
+        logger.error(blue, "hello {} and {} ", "world", "universe");
+    }
+
+    @Test
+    public void testMDC() {
+        MDC.put("k", "v");
+        assertNotNull(MDC.get("k"));
+        assertEquals("v", MDC.get("k"));
+
+        MDC.remove("k");
+        assertNull(MDC.get("k"));
+
+        MDC.put("k1", "v1");
+        assertEquals("v1", MDC.get("k1"));
+        MDC.clear();
+        assertNull(MDC.get("k1"));
+
+        try {
+            MDC.put(null, "x");
+            fail("null keys are invalid");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+
+    private void assertLogMessage(String expected, int index) {
+        LogRecord logRecord = listHandler.recordList.get(index);
+        Assert.assertNotNull(logRecord);
+        assertEquals(expected, logRecord.getMessage());
+    }
+
+    private void assertException(Class<? extends Throwable> exceptionType, int index) {
+        LogRecord logRecord = listHandler.recordList.get(index);
+        Assert.assertNotNull(logRecord);
+        assertEquals(exceptionType, logRecord.getThrown().getClass());
+    }
+
+    void removeListHandlers(java.util.logging.Logger logger) {
+        Handler[] handlers = logger.getHandlers();
+        for (Handler h : handlers) {
+            if (h instanceof ListHandler)
+                logger.removeHandler(h);
+        }
+    }
+
+    static private class ListHandler extends java.util.logging.Handler {
+
+        List<LogRecord> recordList = new ArrayList<LogRecord>();
+
+        @Override
+        public void publish(LogRecord record) {
+            recordList.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+    }
+}

--- a/slf4j-twitter/src/test/java/org/slf4j/LoggerFactoryFriend.java
+++ b/slf4j-twitter/src/test/java/org/slf4j/LoggerFactoryFriend.java
@@ -1,0 +1,7 @@
+package org.slf4j;
+
+public class LoggerFactoryFriend {
+    static public void reset() {
+        LoggerFactory.reset();
+    }
+}

--- a/slf4j-twitter/src/test/java/org/slf4j/helpers/CountingHandler.java
+++ b/slf4j-twitter/src/test/java/org/slf4j/helpers/CountingHandler.java
@@ -1,0 +1,24 @@
+package org.slf4j.helpers;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+public class CountingHandler extends Handler {
+
+    final AtomicLong eventCount = new AtomicLong(0);
+    
+    @Override
+    public void publish(LogRecord record) {
+        eventCount.getAndIncrement();
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() throws SecurityException {
+    }
+
+}

--- a/slf4j-twitter/src/test/java/org/slf4j/helpers/JDK14MultithreadedInitializationTest.java
+++ b/slf4j-twitter/src/test/java/org/slf4j/helpers/JDK14MultithreadedInitializationTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2004-2016 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers;
+
+import static org.junit.Assert.fail;
+
+import java.util.logging.Handler;
+
+import org.junit.After;
+import org.junit.Before;
+
+public class JDK14MultithreadedInitializationTest extends MultithreadedInitializationTest {
+
+    java.util.logging.Logger julRootLogger = java.util.logging.Logger.getLogger("");
+    java.util.logging.Logger julOrgLogger = java.util.logging.Logger.getLogger("org");
+
+    @Before
+    public void addRecordingHandler() {
+        System.out.println("THREAD_COUNT=" + THREAD_COUNT);
+        removeAllHandlers(julRootLogger);
+        removeAllHandlers(julOrgLogger);
+        julOrgLogger.addHandler(new CountingHandler());
+    }
+
+    private void removeAllHandlers(java.util.logging.Logger logger) {
+        Handler[] handlers = logger.getHandlers();
+        for (int i = 0; i < handlers.length; i++) {
+            logger.removeHandler(handlers[i]);
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        removeAllHandlers(julOrgLogger);
+    }
+
+    protected long getRecordedEventCount() {
+        CountingHandler ra = findRecordingHandler();
+        if (ra == null) {
+            fail("failed to fing RecordingHandler");
+        }
+        return ra.eventCount.get();
+    }
+
+    private CountingHandler findRecordingHandler() {
+        Handler[] handlers = julOrgLogger.getHandlers();
+        for (Handler h : handlers) {
+            if (h instanceof CountingHandler)
+                return (CountingHandler) h;
+        }
+        return null;
+    }
+
+}

--- a/slf4j-twitter/src/test/java/org/slf4j/impl/JDK14AdapterLoggerNameTest.java
+++ b/slf4j-twitter/src/test/java/org/slf4j/impl/JDK14AdapterLoggerNameTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Random;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JDK14AdapterLoggerNameTest {
+    private MockHandler mockHandler;
+    static Random random = new Random(System.currentTimeMillis());
+    long diff = random.nextInt(10000);
+    String loggerName = "JDK14AdapterLoggerNameTest"+diff;
+    
+    Logger logger = Logger.getLogger(loggerName);
+    
+    @Before
+    public void setUp() throws Exception {
+        Logger logger = Logger.getLogger(loggerName);
+        addMockHandler(logger);
+    }
+
+
+
+    @After
+    public void tearDown() throws Exception {
+        removeHandlers(Logger.getLogger(loggerName));
+    }
+
+    @Test
+    public void testLoggerNameUsingJdkLogging() throws Exception {
+        logger.info("test message");
+        assertCorrectLoggerName();
+    }
+
+    @Test
+    public void testLoggerNameUsingSlf4j() throws Exception {
+        TwitterLoggerFactory factory = new TwitterLoggerFactory();
+        org.slf4j.Logger logger = factory.getLogger(loggerName);
+        logger.info("test message");
+        assertCorrectLoggerName();
+    }
+
+    private void addMockHandler(Logger logger) {
+        mockHandler = new MockHandler();
+        removeHandlers(logger);
+        logger.addHandler(mockHandler);
+    }
+    
+    private void removeHandlers(Logger logger) {
+        logger.setUseParentHandlers(false);
+        Handler[] handlers = logger.getHandlers();
+        for (int i = 0; i < handlers.length; i++) {
+            logger.removeHandler(handlers[i]);
+        }
+    }
+
+    private void assertCorrectLoggerName() {
+        assertNotNull("no log record", mockHandler.record);
+        assertNotNull("missing logger name", mockHandler.record.getLoggerName());
+    }
+
+    private class MockHandler extends java.util.logging.Handler {
+        public LogRecord record;
+
+        public void close() throws SecurityException {
+        }
+
+        public void flush() {
+        }
+
+        public void publish(LogRecord record) {
+            this.record = record;
+        }
+
+    }
+}

--- a/slf4j-twitter/src/test/java/org/slf4j/impl/PerfTest.java
+++ b/slf4j-twitter/src/test/java/org/slf4j/impl/PerfTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.impl;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.BogoPerf;
+
+@Ignore
+public class PerfTest {
+
+    static long REFERENCE_BIPS = 9000;
+
+    @Test
+    public void issue63() {
+
+        int LEN = 1000 * 1000 * 10;
+        debugLoop(LEN); // warm up
+        double avg = debugLoop(LEN);
+        long referencePerf = 93;
+        BogoPerf.assertDuration(avg, referencePerf, REFERENCE_BIPS);
+
+        // when the code is guarded by a logger.isLoggable condition,
+        // duration is about 16 *micro*seconds for 1000 iterations
+        // when it is not guarded the figure is 90 milliseconds,
+        // i.e a ration of 1 to 5000
+    }
+
+    double debugLoop(int len) {
+        Logger logger = LoggerFactory.getLogger(PerfTest.class);
+        long start = System.currentTimeMillis();
+        for (int i = 0; i < len; i++) {
+            logger.debug("hello");
+        }
+
+        long end = System.currentTimeMillis();
+
+        long duration = end - start;
+        return duration;
+    }
+
+}

--- a/slf4j-twitter/src/test/java/org/slf4j/issue/LoggerSerializationTest.java
+++ b/slf4j-twitter/src/test/java/org/slf4j/issue/LoggerSerializationTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.issue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * See http://jira.qos.ch/browse/SLF4J-252
+ * @author Thorbjorn Ravn Andersen
+ */
+public class LoggerSerializationTest {
+
+    static class LoggerHolder implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private Logger log = LoggerFactory.getLogger(LoggerHolder.class);
+
+        public String toString() {
+            return "log=" + getLog();
+        }
+
+        public Logger getLog() {
+            return log;
+        }
+    }
+
+    @Test
+    public void testCanLoggerBeSerialized() throws IOException, ClassNotFoundException {
+
+        LoggerHolder lh1 = new LoggerHolder();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(lh1);
+        out.close();
+
+        lh1 = null;
+
+        byte[] serializedLoggerHolder = baos.toByteArray();
+
+        InputStream is = new ByteArrayInputStream(serializedLoggerHolder);
+        ObjectInputStream in = new ObjectInputStream(is);
+        LoggerHolder lh2 = (LoggerHolder) in.readObject();
+
+        Assert.assertNotNull(lh2);
+        Assert.assertNotNull(lh2.getLog());
+        lh2.getLog().info("You must see this message as a log message");
+    }
+
+}


### PR DESCRIPTION
It's mostly the same as jul but with a few tweaks.

The jul bridge works for sending logs over, but this one has the changes needed to support their
admin tools.

Accordingly the code is mostly taken from the jul bridge, I'm just pushing it out here so it can be of use to other people. (and selfishly so it will just show up in my repositories whenever a new version is released.
