### PR TITLE
EventRecodingLogger stores Marker in SubstituteLoggingEvent

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
@@ -33,7 +33,7 @@ public class EventRecodingLogger implements Logger {
         loggingEvent.setLevel(level);
         loggingEvent.setLogger(logger);
         loggingEvent.setLoggerName(name);
-
+        loggingEvent.setMarker(marker);
         loggingEvent.setMessage(msg);
         loggingEvent.setArgumentArray(args);
         loggingEvent.setThrowable(throwable);


### PR DESCRIPTION
fixes [SLF4J-379](http://jira.qos.ch/browse/SLF4J-379)