### PR TITLE
Only remove Throwable if unconsumed by pattern.

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
@@ -163,6 +163,20 @@ final public class MessageFormatter {
             return 0;
         }
 
+        if(-1 == messagePattern.indexOf(DELIM_START))
+        {
+            // Special case: no placeholders at all.
+
+            // This is an optimization because charAt checks bounds for every
+            // single call while indexOf(char) isn't.
+
+            // Big messages without placeholders will benefit from this shortcut.
+
+            // the result of indexOf can't be used as start index in the loop
+            // below because it could still be escaped.
+            return 0;
+        }
+
         int result = 0;
         boolean isEscaped = false;
         for(int i = 0; i < messagePattern.length(); i++) {

--- a/slf4j-api/src/test/java/org/slf4j/helpers/MessageFormatterTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/MessageFormatterTest.java
@@ -317,7 +317,12 @@ public class MessageFormatterTest {
         assertEquals(t, ft.getThrowable());
 
         ft = MessageFormatter.arrayFormat("{}{}{}{}", ia);
-        assertEquals("123{}", ft.getMessage());
+        assertEquals("123java.lang.Throwable", ft.getMessage());
+        assertTrue(Arrays.equals(ia, ft.getArgArray()));
+        assertNull(ft.getThrowable());
+
+        ft = MessageFormatter.arrayFormat("{}{}{}", ia);
+        assertEquals("123", ft.getMessage());
         assertTrue(Arrays.equals(iaWitness, ft.getArgArray()));
         assertEquals(t, ft.getThrowable());
 


### PR DESCRIPTION
This is a preparation for a [LOGBACK-1183](http://jira.qos.ch/browse/LOGBACK-1183) fix while keeping the optimizations of [LOGBACK-873](http://jira.qos.ch/browse/LOGBACK-873) in place.

It replaces the package-private method `Throwable getThrowableCandidate(Object[] argArray)` with a public `Throwable extractUnconsumedThrowable(String messagePattern, Object[] argArray)` method.

The unit test that was actually verifying the wrong behavior before has been changed and extended for both cases:
- a `Throwable` at the end of the argument array is removed if is **not** "consumed" by the message pattern.
- a `Throwable` at the end of the argument array is left intact if it **is** "consumed" by the message pattern.

"consumed" means that a placeholder in the message pattern exists that will be replaced by the `Throwable`. If we assume an argument array `{"bar", new Throwable()}` then the pattern `"foo {} {}"` **would** "consume" the `Throwable` resulting in the formatted string `"foo bar java.lang.Throwable"` while the pattern `"foo {}"` **would not** consume the `Throwable` resulting in the formatted string `"foo bar"`. This was the behavior of Logback below 1.1.

The `extractUnconsumedThrowable` method would then by used by Logback instead of `EventArgUtil.extractThrowable`.

I initially tried to fix [LOGBACK-1183](http://jira.qos.ch/browse/LOGBACK-1183) solely in Logback but had to realize that SLF4J would later remove the `Throwable` anyway while formatting the message, regardless of whether or not `EventArgUtil.extractThrowable` left it intact in the argument array.

`LoggingEvent` in Logback would then see the following change:
**Original code:**
```java
    private Throwable extractThrowableAndRearrangeArguments(Object[] argArray) {
        Throwable extractedThrowable = EventArgUtil.extractThrowable(argArray);
        if (EventArgUtil.successfulExtraction(extractedThrowable)) {
            this.argumentArray = EventArgUtil.trimmedCopy(argArray);
        }
        return extractedThrowable;
    }
```

**New code:**
```java
    private Throwable extractThrowableAndRearrangeArguments(String messagePattern, Object[] argArray) {
        Throwable extractedThrowable = MessageFormatter.extractUnconsumedThrowable(messagePattern, argArray);
        if (EventArgUtil.successfulExtraction(extractedThrowable)) {
            this.argumentArray = EventArgUtil.trimmedCopy(argArray);
        }
        return extractedThrowable;
    }
```

This private method is only called in the constructor.
**Original code:**
```java
        if (throwable == null) {
            throwable = extractThrowableAndRearrangeArguments(argArray);
        }
```

**New code:**
```java
        if (throwable == null) {
            throwable = extractThrowableAndRearrangeArguments(message, argArray);
        }
```

Applying those two changes in Logback would fix [LOGBACK-1183](http://jira.qos.ch/browse/LOGBACK-1183).