### PR TITLE
SLF4J-154 Inferring logger from calling class.

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -392,17 +392,18 @@ public final class LoggerFactory {
         return logger;
     }
 
-    public static Logger getLogger()
-    {
-        StackTraceElement[] stack = new Throwable().getStackTrace();
-        for(StackTraceElement item : stack) {
-            String className = item.getClassName().split("\\$")[0];
-            // Exclude our own class and any proxies
-            if(!className.equals(LoggerFactory.class.getName()) && !className.equals("com.sun.proxy")) {
-                return getLogger(className);
-            }
+    /**
+     * Return a logger named corresponding to the class of the caller,
+     * using the statically bound {@link ILoggerFactory} instance.
+     *
+     * @return logger
+     */
+    public static Logger getLogger() { // SLF4J-154
+        Class<?> autoComputedCallingClass = Util.getCallingClass();
+        if (autoComputedCallingClass != null) {
+            return getLogger(Util.getCallingClass().getName());
         }
-        Util.report("Failed to detect logger from call stack.");
+        Util.report("Failed to detect logger name from caller.");
         return getLogger(Logger.ROOT_LOGGER_NAME);
     }
 

--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -92,15 +92,6 @@ public final class LoggerFactory {
 
     static boolean DETECT_LOGGER_NAME_MISMATCH = Util.safeGetBooleanSystemProperty(DETECT_LOGGER_NAME_MISMATCH_PROPERTY);
 
-    static final ContextHelper CONTEXT = new ContextHelper();
-
-    static final class ContextHelper extends SecurityManager {
-
-        Class<?>[] getCallingClasses() {
-            return super.getClassContext();
-        }
-    }
-
     /**
      * It is LoggerFactory's responsibility to track version changes and manage
      * the compatibility list.
@@ -403,12 +394,12 @@ public final class LoggerFactory {
 
     public static Logger getLogger()
     {
-        Class<?>[] callingClasses = CONTEXT.getCallingClasses();
-        for (Class<?> callingClass : callingClasses) {
-            String className = callingClass.getName().split("\\$")[0];
+        StackTraceElement[] stack = new Throwable().getStackTrace();
+        for(StackTraceElement item : stack) {
+            String className = item.getClassName().split("\\$")[0];
             // Exclude our own class and any proxies
-            if (!className.equals(LoggerFactory.class.getName()) && !className.equals("com.sun.proxy")) {
-                return getLogger(callingClass.getName());
+            if(!className.equals(LoggerFactory.class.getName()) && !className.equals("com.sun.proxy")) {
+                return getLogger(className);
             }
         }
         Util.report("Failed to detect logger from call stack.");

--- a/slf4j-simple/src/test/java/org/slf4j/InvocationTest.java
+++ b/slf4j-simple/src/test/java/org/slf4j/InvocationTest.java
@@ -144,13 +144,20 @@ public class InvocationTest {
         String actualName = LoggerFactory.getLogger().getName();
         assertEquals(expectedName, actualName);
 
-        long start = System.nanoTime();
-        LoggerFactory.getLogger();
-        long end = System.nanoTime();
-        System.out.println("Duration: " + (end - start) + " nanoseconds");
+        expectedName = InnerCaller1.class.getName();
+        actualName = InnerCaller1.logger.getName();
+        assertEquals(expectedName, actualName);
+
+        class InnerCaller2 {
+            final Logger logger = LoggerFactory.getLogger();
+        }
+
+        expectedName = InnerCaller2.class.getName();
+        actualName = new InnerCaller2().logger.getName();
+        assertEquals(expectedName, actualName);
     }
 
-    private static class InnerCaller {
-
+    private static class InnerCaller1 {
+        static final Logger logger = LoggerFactory.getLogger();
     }
 }

--- a/slf4j-simple/src/test/java/org/slf4j/InvocationTest.java
+++ b/slf4j-simple/src/test/java/org/slf4j/InvocationTest.java
@@ -24,6 +24,7 @@
  */
 package org.slf4j;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.io.PrintStream;
@@ -135,5 +136,21 @@ public class InvocationTest {
         MDC.remove("k");
         assertNull(MDC.get("k"));
         MDC.clear();
+    }
+
+    @Test
+    public void testInferredLogger() {
+        String expectedName = getClass().getName();
+        String actualName = LoggerFactory.getLogger().getName();
+        assertEquals(expectedName, actualName);
+
+        long start = System.nanoTime();
+        LoggerFactory.getLogger();
+        long end = System.nanoTime();
+        System.out.println("Duration: " + (end - start) + " nanoseconds");
+    }
+
+    private static class InnerCaller {
+
     }
 }


### PR DESCRIPTION
Added an operation to get logger inferred from the calling class. The implementation uses the same utility that is used to detect a logger name mismatch, resulting in no extra overhead.

Tests included.