### PR TITLE
Add a high service ranking to the registered LogService

### DIFF
--- a/osgi-over-slf4j/src/main/java/org/slf4j/osgi/logservice/impl/Activator.java
+++ b/osgi-over-slf4j/src/main/java/org/slf4j/osgi/logservice/impl/Activator.java
@@ -59,6 +59,7 @@ public class Activator implements BundleActivator {
 
         Properties props = new Properties();
         props.put("description", "An SLF4J LogService implementation.");
+        props.put(org.osgi.framework.Constants.SERVICE_RANKING, Integer.MAX_VALUE);
         ServiceFactory factory = new LogServiceFactory();
         bundleContext.registerService(LogService.class.getName(), factory, props);
     }


### PR DESCRIPTION
This PR adds a high service ranking to the registered LogService so it will take precedent over any built-in LogService provided by the OSGi runtime (e.g. Equinox). I figured if deploying the slf4j LogService most people would expect this implementation to be used, but that Equinox's built-in service is registered as well at the default service level so bundles importing LogService might get that one instead of the slf4j implementation.