### PR TITLE
Ignore errors that can occur when converting a message to a string

### DIFF
--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -35,6 +35,12 @@
       <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -35,12 +35,6 @@
       <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
@@ -16,7 +16,6 @@
 
 package org.apache.log4j;
 
-import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.helpers.NullEnumeration;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;

--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
@@ -16,6 +16,7 @@
 
 package org.apache.log4j;
 
+import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.helpers.NullEnumeration;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
@@ -331,7 +332,11 @@ public class Category {
         if (message == null) {
             return (String) message;
         } else {
-            return message.toString();
+            try {
+                return message.toString();
+            } catch (Exception e) {
+                return null;
+            }
         }
     }
 

--- a/log4j-over-slf4j/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/log4j-over-slf4j/src/test/java/org/apache/log4j/CategoryTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.logging.*;
 
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.*;
 
 /**
  * Created by thsnoopy@naver.com on 2017. 3. 16..
@@ -22,11 +21,19 @@ public class CategoryTest {
     Logger log4jLogger = Logger.getLogger("testLogger");
     List<LogRecord> logRecordList = listHandler.getList();
 
-    Object mockObject = mock(Object.class);
-    when(mockObject.toString()).thenThrow(new RuntimeException("nope"));
-    log4jLogger.log(org.apache.log4j.Level.DEBUG, mockObject);
+    Foo sampleLogData = new Foo();
+    log4jLogger.log(org.apache.log4j.Level.DEBUG, sampleLogData);
 
     LogRecord logRecord = logRecordList.get(0);
     assertNull(logRecord.getMessage());
   }
+}
+
+class Foo {
+  private String name;
+
+  public String toString() {
+    return "name.length : " + name.length();
+  }
+
 }

--- a/log4j-over-slf4j/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/log4j-over-slf4j/src/test/java/org/apache/log4j/CategoryTest.java
@@ -1,0 +1,32 @@
+package org.apache.log4j;
+
+import org.dummy.ListHandler;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.logging.*;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by thsnoopy@naver.com on 2017. 3. 16..
+ */
+public class CategoryTest {
+  @Test
+  public void testToStringExceptionGuard() {
+    ListHandler listHandler = new ListHandler();
+    java.util.logging.Logger root = java.util.logging.Logger.getLogger("");
+    root.addHandler(listHandler);
+    root.setLevel(java.util.logging.Level.FINE);
+    Logger log4jLogger = Logger.getLogger("testLogger");
+    List<LogRecord> logRecordList = listHandler.getList();
+
+    Object mockObject = mock(Object.class);
+    when(mockObject.toString()).thenThrow(new RuntimeException("nope"));
+    log4jLogger.log(org.apache.log4j.Level.DEBUG, mockObject);
+
+    LogRecord logRecord = logRecordList.get(0);
+    assertNull(logRecord.getMessage());
+  }
+}

--- a/log4j-over-slf4j/src/test/java/org/dummy/ListHandler.java
+++ b/log4j-over-slf4j/src/test/java/org/dummy/ListHandler.java
@@ -46,4 +46,8 @@ public class ListHandler extends Handler {
         list.add(logRecord);
     }
 
+    public List<LogRecord> getList() {
+        return list;
+    }
+
 }


### PR DESCRIPTION
An exception may occur when converting a message to a string.
For example, someone's incorrect implementation in toString method.
I think it is better to ignore the exception and let the Category(Logger) continue to run.
What do you think about it?