### PR TITLE
BugFix SLF4J-411 - EventRecodingLogger.debug(String) logs at TRACE

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
@@ -96,7 +96,7 @@ public class EventRecodingLogger implements Logger {
     }
 
     public void debug(String msg) {
-        recordEvent(Level.TRACE, msg, null, null);
+        recordEvent(Level.DEBUG, msg, null, null);
     }
 
     public void debug(String format, Object arg) {
@@ -220,7 +220,7 @@ public class EventRecodingLogger implements Logger {
     }
 
     public void warn(Marker marker, String msg) {
-        recordEvent(Level.WARN, msg, null, null);
+        recordEvent(Level.WARN, marker, msg, null, null);
     }
 
     public void warn(Marker marker, String format, Object arg) {

--- a/slf4j-api/src/test/java/org/slf4j/event/EventRecordingLoggerTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/event/EventRecordingLoggerTest.java
@@ -1,0 +1,197 @@
+package org.slf4j.event;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Marker;
+import org.slf4j.helpers.SubstituteLogger;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Tests {@link EventRecodingLogger}.
+ */
+@RunWith(Parameterized.class)
+public class EventRecordingLoggerTest {
+
+  private Level level;
+  private Queue<SubstituteLoggingEvent> eventQueue;
+  private SubstituteLogger subLogger;
+  private EventRecodingLogger eventRecodingLogger;
+  private LevelScopedLoggerInvoker invoker;
+
+  public EventRecordingLoggerTest(Level level) {
+    this.level = level;
+    this.eventQueue = new LinkedBlockingQueue<SubstituteLoggingEvent>();
+    this.subLogger = new SubstituteLogger("logger.test", eventQueue, false);
+    this.eventRecodingLogger = new EventRecodingLogger(subLogger, eventQueue);
+    this.invoker = new LevelScopedLoggerInvoker(eventRecodingLogger, level);
+  }
+
+  @Parameterized.Parameters(name = "level: {0}")
+  public static Collection<Level> levels() {
+    return Arrays.asList(Level.values());
+  }
+
+  @Test
+  public void logString() {
+    invoker.log("foo");
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), "foo");
+    assertEquals(event.getThrowable(), null);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), null);
+    assertArrayEquals(event.getArgumentArray(), null);
+  }
+
+  @Test
+  public void logStringObject() {
+    String msg = "foo {}";
+    invoker.log(msg, 5);
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), msg);
+    assertEquals(event.getThrowable(), null);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), null);
+    assertArrayEquals(event.getArgumentArray(), new Object[]{5});
+  }
+
+  @Test
+  public void logStringObjectObject() {
+    String msg = "foo {} {}";
+    invoker.log(msg, 5, false);
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), msg);
+    assertEquals(event.getThrowable(), null);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), null);
+    assertArrayEquals(event.getArgumentArray(), new Object[]{5, false});
+  }
+
+  @Test
+  public void logStringObjectObjectsVarArg() {
+    String msg = "foo {} {} {}";
+    invoker.log(msg, 5, false, 2.2);
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), msg);
+    assertEquals(event.getThrowable(), null);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), null);
+    assertArrayEquals(event.getArgumentArray(), new Object[]{5, false, 2.2});
+  }
+
+  @Test
+  public void logStringThrowable() {
+    String msg = "foo";
+    Throwable t = new IllegalArgumentException("pony");
+    invoker.log(msg, t);
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), msg);
+    assertEquals(event.getThrowable(), t);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), null);
+    assertArrayEquals(event.getArgumentArray(), null);
+  }
+
+  @Test
+  public void isEnabled() {
+    assertTrue(invoker.isEnabled());
+  }
+
+  @Test
+  public void isEnabledMarker() {
+    Marker marker = new NullMarker();
+    assertTrue(invoker.isEnabled(marker));
+  }
+
+  @Test
+  public void logMarkerString() {
+    Marker marker = new NullMarker();
+    invoker.log(marker, "foo");
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), "foo");
+    assertEquals(event.getThrowable(), null);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), marker);
+    assertArrayEquals(event.getArgumentArray(), null);
+  }
+
+  @Test
+  public void logMarkerStringObject() {
+    Marker marker = new NullMarker();
+    String msg = "foo {}";
+    invoker.log(marker, msg, 5);
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), msg);
+    assertEquals(event.getThrowable(), null);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), marker);
+    assertArrayEquals(event.getArgumentArray(), new Object[]{5});
+  }
+
+  @Test
+  public void logMarkerStringObjectObject() {
+    Marker marker = new NullMarker();
+    String msg = "foo {} {}";
+    invoker.log(marker, msg, 5, false);
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), msg);
+    assertEquals(event.getThrowable(), null);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), marker);
+    assertArrayEquals(event.getArgumentArray(), new Object[]{5, false});
+  }
+
+  @Test
+  public void logMarkerStringObjectObjectsVarArg() {
+    Marker marker = new NullMarker();
+    String msg = "foo {} {} {}";
+    invoker.log(marker, msg, 5, false, 2.2);
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), msg);
+    assertEquals(event.getThrowable(), null);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), marker);
+    assertArrayEquals(event.getArgumentArray(), new Object[]{5, false, 2.2});
+  }
+
+  @Test
+  public void logMarkerStringThrowable() {
+    Marker marker = new NullMarker();
+    String msg = "foo";
+    Throwable t = new IllegalArgumentException("pony");
+    invoker.log(marker, msg, t);
+    assertEquals(eventQueue.size(), 1);
+    SubstituteLoggingEvent event = eventQueue.remove();
+    assertEquals(event.getLevel(), level);
+    assertEquals(event.getMessage(), msg);
+    assertEquals(event.getThrowable(), t);
+    assertEquals(event.getLogger(), subLogger);
+    assertEquals(event.getMarker(), marker);
+    assertArrayEquals(event.getArgumentArray(), null);
+  }
+
+}

--- a/slf4j-api/src/test/java/org/slf4j/event/LevelScopedLoggerInvoker.java
+++ b/slf4j-api/src/test/java/org/slf4j/event/LevelScopedLoggerInvoker.java
@@ -1,0 +1,168 @@
+package org.slf4j.event;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Allows invoking logger methods over some abstract log level.
+ *
+ * NOTE: This implementation uses reflection. Useful for testing.
+ */
+public class LevelScopedLoggerInvoker {
+
+  private Level level;
+  private Logger logger;
+
+  public LevelScopedLoggerInvoker(Logger logger, Level level) {
+    this.level = level;
+    this.logger = logger;
+  }
+
+
+  public void log(String msg) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), String.class).invoke(logger, msg);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void log(String format, Object arg) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), String.class, Object.class).invoke(logger, format, arg);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void log(String format, Object arg1, Object arg2) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), String.class, Object.class, Object.class).invoke(logger, format, arg1, arg2);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  public void log(String format, Object... arguments) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), String.class, Object[].class).invoke(logger, format, arguments);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void log(String msg, Throwable t) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), String.class, Throwable.class).invoke(logger, msg, t);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String capitalizeLoggerName() {
+    char[] chars = level.name().toLowerCase().toCharArray();
+    chars[0] = Character.toUpperCase(chars[0]);
+    return new String(chars);
+  }
+
+  public boolean isEnabled() {
+    try {
+      String methodName = "is" + capitalizeLoggerName() + "Enabled";
+      return (Boolean) logger.getClass().getMethod(methodName).invoke(logger);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public boolean isEnabled(Marker marker) {
+    try {
+      String methodName = "is" + capitalizeLoggerName() + "Enabled";
+      return (Boolean) logger.getClass().getMethod(methodName).invoke(logger);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  public void log(Marker marker, String msg) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), Marker.class, String.class).invoke(logger, marker, msg);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void log(Marker marker, String format, Throwable t) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), Marker.class, String.class, Throwable.class).invoke(logger, marker, format, t);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  public void log(Marker marker, String format, Object arg1, Object arg2) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), Marker.class, String.class, Object.class, Object.class).invoke(logger, marker, format, arg1, arg2);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+
+  }
+
+  public void log(Marker marker, String format, Object... argArray) {
+    try {
+      logger.getClass().getMethod(level.name().toLowerCase(), Marker.class, String.class, Object[].class).invoke(logger, marker, format, argArray);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    } catch (InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/slf4j-api/src/test/java/org/slf4j/event/NullMarker.java
+++ b/slf4j-api/src/test/java/org/slf4j/event/NullMarker.java
@@ -1,0 +1,41 @@
+package org.slf4j.event;
+
+import org.slf4j.Marker;
+
+import java.util.Iterator;
+
+/**
+ * Totally fake Marker for testing.
+ */
+public class NullMarker implements Marker {
+  public String getName() {
+    return null;
+  }
+
+  public void add(Marker reference) {
+  }
+
+  public boolean remove(Marker reference) {
+    return false;
+  }
+
+  public boolean hasChildren() {
+    return false;
+  }
+
+  public boolean hasReferences() {
+    return false;
+  }
+
+  public Iterator<Marker> iterator() {
+    return null;
+  }
+
+  public boolean contains(Marker other) {
+    return false;
+  }
+
+  public boolean contains(String name) {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
Fixes:
* `EventRecodingLogger.debug(String)` logging at TRACE instead of DEBUG.
* `EventRecodingLogger.warn(Marker, String)` passing `null` instead of the marker.

https://jira.qos.ch/browse/SLF4J-411