### PR TITLE
Fix the SCM connection URL in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <scm>
     <url>https://github.com/qos-ch/slf4j</url>
-    <connection>scm:git@github.com:qos-ch/slf4j.git</connection>
+    <connection>scm:git:https://github.com/qos-ch/slf4j.git</connection>
   </scm>  
 
   <properties>


### PR DESCRIPTION
The "connection" should be an URL valid for read-only access and has to follow
the syntax as described at https://maven.apache.org/pom.html#SCM.