### PR TITLE
Add Automatic-Module-Name to MANIFEST

### DIFF
--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -28,4 +28,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- This module replaces the real commons-logging, thus it must have the same module name -->
+      <!-- http://svn.apache.org/repos/asf/commons/proper/logging/trunk/pom.xml -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive combine.children="append">
+                <manifestEntries>
+                  <Automatic-Module-Name>org.apache.commons.logging</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/jul-to-slf4j/pom.xml
+++ b/jul-to-slf4j/pom.xml
@@ -31,4 +31,30 @@
     </dependency>
   </dependencies>
 
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive combine.children="append">
+                <manifestEntries>
+                  <Automatic-Module-Name>org.slf4j.bridge</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -37,4 +37,31 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- This module replaces the real log4j v1.2, thus it must have the same module name -->
+      <!-- https://issues.apache.org/jira/browse/LOG4J2-2056 -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive combine.children="append">
+                <manifestEntries>
+                  <Automatic-Module-Name>org.apache.log4j</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -52,6 +52,20 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
+            <id>default-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <archive combine.children="append">
+                <manifestEntries>
+                  <Automatic-Module-Name>org.slf4j</Automatic-Module-Name>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+          <execution>
             <id>bundle-test-jar</id>
             <phase>package</phase>
             <goals>


### PR DESCRIPTION
The idea of this commit is to get a release 1.7.26 done with automatic module names for the four outward-facing modules. This allows the issues of service loader, module-info and so on to be sidestepped for now.

**This PR is not intended to be merged onto the master branch.** Instead, it is intended for there to be a new branch in slf4j starting at 1232e8529f5844e03e4d528a88185413761853e2 where this is the first commit on the branch. I can't get GitHub to do this automatically, so you'd need to create the branch in slf4j first, and I can then re-raise the PR against the new branch. Alternatively, you can cherry pick this commit onto the branch.

There is a case to add `Automatic-Module-Name` to the inward-facing (impl) jars, but I'm still working out what the best strategy for those is.

thanks