### PR TITLE
A few toolchains etc. tweaks to try and get Travis build working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+dist: trusty
 language: java
+jdk:
+  - oraclejdk9
 notifications:
   email:
       - notification@qos.ch

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
         <version>1.1</version>
         <executions>
           <execution>
+            <id>toolchain</id>
             <goals>
               <goal>toolchain</goal>
             </goals>
@@ -452,6 +453,31 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>travis</id>
+      <activation>
+        <property>
+          <name>env.TRAVIS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-toolchains-plugin</artifactId>
+            <version>1.1</version>
+            <executions>
+              <execution>
+                <id>toolchain</id>
+                <phase>none</phase>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,9 @@
             <jdk>
               <version>1.6</version>
             </jdk>
+            <jdk>
+              <version>1.9</version>
+            </jdk>
           </toolchains>
         </configuration>
       </plugin>


### PR DESCRIPTION
Travis build on master has been down for a bit.  This change:

- Sets Travis `dist` to `trusty`.
- Requires `oraclejdk9` in Travis because we now depend on it.
- Disables `maven-toolchains-plugin` when running in Travis, they won't support it, see travis-ci/travis-ci#2727 .