### PR TITLE
Supplier added to logger interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>1.9</version>
+              <version>9</version>
             </jdk>
           </toolchains>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>1.8</version>
+              <version>8</version>
             </jdk>
           </toolchains>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,14 @@
   <properties>
     <stable.version>1.7.25</stable.version>
     <!-- java.util.ServiceLoader requires Java 6 -->
-    <jdk.version>1.6</jdk.version>
+    <jdk.version>1.8</jdk.version>
     <maven.compiler.source>${jdk.version}</maven.compiler.source>
     <maven.compiler.target>${jdk.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- used in integration testing -->
-    <slf4j.api.minimum.compatible.version>1.6.0</slf4j.api.minimum.compatible.version>
+    <slf4j.api.minimum.compatible.version>1.8.0</slf4j.api.minimum.compatible.version>
     <cal10n.version>0.8.1</cal10n.version>
     <log4j.version>1.2.17</log4j.version>
     <logback.version>1.0.13</logback.version>
@@ -165,7 +165,7 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>1.6</version>
+              <version>1.9</version>
             </jdk>
           </toolchains>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>9</version>
+              <version>1.8</version>
             </jdk>
           </toolchains>
         </configuration>

--- a/slf4j-api/src/main/java/org/slf4j/Logger.java
+++ b/slf4j-api/src/main/java/org/slf4j/Logger.java
@@ -25,6 +25,8 @@
 
 package org.slf4j;
 
+import java.util.function.Supplier;
+
 /**
  * The org.slf4j.Logger interface is the main user entry point of SLF4J API.
  * It is expected that logging takes place through concrete implementations
@@ -94,6 +96,14 @@ public interface Logger {
     public void trace(String msg);
 
     /**
+     * Log a message provided by {@link Supplier}at the TRACE level.
+     *
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void trace(Supplier<String> msgSup);
+
+    /**
      * Log a message at the TRACE level according to the specified format
      * and argument.
      * <p/>
@@ -147,6 +157,16 @@ public interface Logger {
     public void trace(String msg, Throwable t);
 
     /**
+     * Log an exception (throwable) at the TRACE level with an
+     * accompanying message provided by supplier
+     *
+     * @param msgSup the supplier providing message accompanying the exception
+     * @param t   the exception (throwable) to log
+     * @since 1.8
+     */
+    public void trace(Throwable t, Supplier<String> msgSup);
+
+    /**
      * Similar to {@link #isTraceEnabled()} method except that the
      * marker data is also taken into account.
      *
@@ -166,6 +186,15 @@ public interface Logger {
      * @since 1.4
      */
     public void trace(Marker marker, String msg);
+
+    /**
+     * Log a message provided by supplier with the specific Marker at the TRACE level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void trace(Marker marker, Supplier<String> msgSup);
 
     /**
      * This method is similar to {@link #trace(String, Object)} method except that the
@@ -215,6 +244,17 @@ public interface Logger {
     public void trace(Marker marker, String msg, Throwable t);
 
     /**
+     * This method is similar to {@link #trace(Throwable, Supplier)} method except that the
+     * marker data is also taken into consideration.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup    the message accompanying the exception
+     * @param t      the exception (throwable) to log
+     * @since 1.8
+     */
+    public void trace(Marker marker, Throwable t, Supplier<String> msgSup);
+
+    /**
      * Is the logger instance enabled for the DEBUG level?
      *
      * @return True if this Logger is enabled for the DEBUG level,
@@ -228,6 +268,15 @@ public interface Logger {
      * @param msg the message string to be logged
      */
     public void debug(String msg);
+
+    /**
+     * Log a message provided by {@link Supplier}at the DEBUG level.
+     *
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void debug(Supplier<String> msgSup);
+
 
     /**
      * Log a message at the DEBUG level according to the specified format
@@ -280,6 +329,17 @@ public interface Logger {
     public void debug(String msg, Throwable t);
 
     /**
+     * Log an exception (throwable) at the DEBUG level with an
+     * accompanying message provided by supplier
+     *
+     * @param msgSup the supplier providing message accompanying the exception
+     * @param t   the exception (throwable) to log
+     * @since 1.8
+     */
+    public void debug(Throwable t, Supplier<String> msgSup);
+
+
+    /**
      * Similar to {@link #isDebugEnabled()} method except that the
      * marker data is also taken into account.
      *
@@ -296,6 +356,16 @@ public interface Logger {
      * @param msg    the message string to be logged
      */
     public void debug(Marker marker, String msg);
+
+    /**
+     * Log a message provided by supplier with the specific Marker at the DEBUG level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void debug(Marker marker, Supplier<String> msgSup);
+
 
     /**
      * This method is similar to {@link #debug(String, Object)} method except that the
@@ -341,6 +411,18 @@ public interface Logger {
     public void debug(Marker marker, String msg, Throwable t);
 
     /**
+     * This method is similar to {@link #debug(Throwable, Supplier)} method except that the
+     * marker data is also taken into consideration.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup    the message accompanying the exception
+     * @param t      the exception (throwable) to log
+     * @since 1.8
+     */
+    public void debug(Marker marker, Throwable t, Supplier<String> msgSup);
+
+
+    /**
      * Is the logger instance enabled for the INFO level?
      *
      * @return True if this Logger is enabled for the INFO level,
@@ -354,6 +436,15 @@ public interface Logger {
      * @param msg the message string to be logged
      */
     public void info(String msg);
+
+    /**
+     * Log a message provided by {@link Supplier}at the INFO level.
+     *
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void info(Supplier<String> msgSup);
+
 
     /**
      * Log a message at the INFO level according to the specified format
@@ -406,6 +497,17 @@ public interface Logger {
     public void info(String msg, Throwable t);
 
     /**
+     * Log an exception (throwable) at the INFO level with an
+     * accompanying message provided by supplier
+     *
+     * @param msgSup the supplier providing message accompanying the exception
+     * @param t   the exception (throwable) to log
+     * @since 1.8
+     */
+    public void info(Throwable t, Supplier<String> msgSup);
+
+
+    /**
      * Similar to {@link #isInfoEnabled()} method except that the marker
      * data is also taken into consideration.
      *
@@ -421,6 +523,16 @@ public interface Logger {
      * @param msg    the message string to be logged
      */
     public void info(Marker marker, String msg);
+
+    /**
+     * Log a message provided by supplier with the specific Marker at the INFO level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void info(Marker marker, Supplier<String> msgSup);
+
 
     /**
      * This method is similar to {@link #info(String, Object)} method except that the
@@ -466,6 +578,18 @@ public interface Logger {
     public void info(Marker marker, String msg, Throwable t);
 
     /**
+     * This method is similar to {@link #info(Throwable, Supplier)} method except that the
+     * marker data is also taken into consideration.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup    the message accompanying the exception
+     * @param t      the exception (throwable) to log
+     * @since 1.8
+     */
+    public void info(Marker marker, Throwable t, Supplier<String> msgSup);
+
+
+    /**
      * Is the logger instance enabled for the WARN level?
      *
      * @return True if this Logger is enabled for the WARN level,
@@ -479,6 +603,14 @@ public interface Logger {
      * @param msg the message string to be logged
      */
     public void warn(String msg);
+
+    /**
+     * Log a message provided by {@link Supplier}at the WARN level.
+     *
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void warn(Supplier<String> msgSup);
 
     /**
      * Log a message at the WARN level according to the specified format
@@ -531,6 +663,17 @@ public interface Logger {
     public void warn(String msg, Throwable t);
 
     /**
+     * Log an exception (throwable) at the WARN level with an
+     * accompanying message provided by supplier
+     *
+     * @param msgSup the supplier providing message accompanying the exception
+     * @param t   the exception (throwable) to log
+     * @since 1.8
+     */
+    public void warn(Throwable t, Supplier<String> msgSup);
+
+
+    /**
      * Similar to {@link #isWarnEnabled()} method except that the marker
      * data is also taken into consideration.
      *
@@ -547,6 +690,16 @@ public interface Logger {
      * @param msg    the message string to be logged
      */
     public void warn(Marker marker, String msg);
+
+    /**
+     * Log a message provided by supplier with the specific Marker at the WARN level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void warn(Marker marker, Supplier<String> msgSup);
+
 
     /**
      * This method is similar to {@link #warn(String, Object)} method except that the
@@ -592,6 +745,18 @@ public interface Logger {
     public void warn(Marker marker, String msg, Throwable t);
 
     /**
+     * This method is similar to {@link #warn(Throwable, Supplier)} method except that the
+     * marker data is also taken into consideration.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup    the message accompanying the exception
+     * @param t      the exception (throwable) to log
+     * @since 1.8
+     */
+    public void warn(Marker marker, Throwable t, Supplier<String> msgSup);
+
+
+    /**
      * Is the logger instance enabled for the ERROR level?
      *
      * @return True if this Logger is enabled for the ERROR level,
@@ -605,6 +770,15 @@ public interface Logger {
      * @param msg the message string to be logged
      */
     public void error(String msg);
+
+    /**
+     * Log a message provided by {@link Supplier}at the ERROR level.
+     *
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void error(Supplier<String> msgSup);
+
 
     /**
      * Log a message at the ERROR level according to the specified format
@@ -657,6 +831,17 @@ public interface Logger {
     public void error(String msg, Throwable t);
 
     /**
+     * Log an exception (throwable) at the ERROR level with an
+     * accompanying message provided by supplier
+     *
+     * @param msgSup the supplier providing message accompanying the exception
+     * @param t   the exception (throwable) to log
+     * @since 1.8
+     */
+    public void error(Throwable t, Supplier<String> msgSup);
+
+
+    /**
      * Similar to {@link #isErrorEnabled()} method except that the
      * marker data is also taken into consideration.
      *
@@ -673,6 +858,16 @@ public interface Logger {
      * @param msg    the message string to be logged
      */
     public void error(Marker marker, String msg);
+
+    /**
+     * Log a message provided by supplier with the specific Marker at the ERROR level.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup the supplier for string to be logged
+     * @since 1.8
+     */
+    public void error(Marker marker, Supplier<String> msgSup);
+
 
     /**
      * This method is similar to {@link #error(String, Object)} method except that the
@@ -717,5 +912,17 @@ public interface Logger {
      * @param t      the exception (throwable) to log
      */
     public void error(Marker marker, String msg, Throwable t);
+
+    /**
+     * This method is similar to {@link #error(Throwable, Supplier)} method except that the
+     * marker data is also taken into consideration.
+     *
+     * @param marker the marker data specific to this log statement
+     * @param msgSup    the message accompanying the exception
+     * @param t      the exception (throwable) to log
+     * @since 1.8
+     */
+    public void error(Marker marker, Throwable t, Supplier<String> msgSup);
+
 
 }

--- a/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/event/EventRecodingLogger.java
@@ -1,10 +1,12 @@
 package org.slf4j.event;
 
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.helpers.SubstituteLogger;
+import org.slf4j.helpers.Util;
 
 public class EventRecodingLogger implements Logger {
 
@@ -24,6 +26,14 @@ public class EventRecodingLogger implements Logger {
 
     private void recordEvent(Level level, String msg, Object[] args, Throwable throwable) {
         recordEvent(level, null, msg, args, throwable);
+    }
+
+    private void recordEvent(Level level, Supplier<String> msgSup, Throwable throwable) {
+        recordEvent(level, null, msgSup, throwable);
+    }
+    private void recordEvent(Level level, Marker marker, Supplier<String> msgSup, Throwable throwable) {
+        //TODO here we call Supplier.get regarless of logging level (performance issue?)
+        recordEvent(level, marker, Util.msgSafeGet(msgSup), null, throwable);
     }
 
     private void recordEvent(Level level, Marker marker, String msg, Object[] args, Throwable throwable) {
@@ -49,6 +59,11 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.TRACE, msg, null, null);
     }
 
+    @Override
+    public void trace(Supplier<String> msgSup) {
+        recordEvent(Level.TRACE, msgSup, null);
+    }
+
     public void trace(String format, Object arg) {
         recordEvent(Level.TRACE, format, new Object[] { arg }, null);
     }
@@ -65,6 +80,11 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.TRACE, msg, null, t);
     }
 
+    @Override
+    public void trace(Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.TRACE, msgSup, t);
+    }
+
     public boolean isTraceEnabled(Marker marker) {
         return true;
     }
@@ -72,6 +92,11 @@ public class EventRecodingLogger implements Logger {
     public void trace(Marker marker, String msg) {
         recordEvent(Level.TRACE, marker, msg, null, null);
 
+    }
+
+    @Override
+    public void trace(Marker marker, Supplier<String> msgSup) {
+        recordEvent(Level.TRACE, marker, msgSup, null);
     }
 
     public void trace(Marker marker, String format, Object arg) {
@@ -91,12 +116,22 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.TRACE, marker, msg, null, t);
     }
 
+    @Override
+    public void trace(Marker marker, Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.TRACE, marker, msgSup, t);
+    }
+
     public boolean isDebugEnabled() {
         return true;
     }
 
     public void debug(String msg) {
         recordEvent(Level.TRACE, msg, null, null);
+    }
+
+    @Override
+    public void debug(Supplier<String> msgSup) {
+        recordEvent(Level.DEBUG, msgSup, null);
     }
 
     public void debug(String format, Object arg) {
@@ -117,12 +152,22 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.DEBUG, msg, null, t);
     }
 
+    @Override
+    public void debug(Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.DEBUG, msgSup, t);
+    }
+
     public boolean isDebugEnabled(Marker marker) {
         return true;
     }
 
     public void debug(Marker marker, String msg) {
         recordEvent(Level.DEBUG, marker, msg, null, null);
+    }
+
+    @Override
+    public void debug(Marker marker, Supplier<String> msgSup) {
+        recordEvent(Level.DEBUG, marker, msgSup, null);
     }
 
     public void debug(Marker marker, String format, Object arg) {
@@ -141,12 +186,22 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.DEBUG, marker, msg, null, t);
     }
 
+    @Override
+    public void debug(Marker marker, Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.DEBUG, marker, msgSup, t);
+    }
+
     public boolean isInfoEnabled() {
         return true;
     }
 
     public void info(String msg) {
         recordEvent(Level.INFO, msg, null, null);
+    }
+
+    @Override
+    public void info(Supplier<String> msgSup) {
+        recordEvent(Level.INFO, msgSup, null);
     }
 
     public void info(String format, Object arg) {
@@ -165,12 +220,22 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.INFO, msg, null, t);
     }
 
+    @Override
+    public void info(Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.INFO, msgSup, t);
+    }
+
     public boolean isInfoEnabled(Marker marker) {
         return true;
     }
 
     public void info(Marker marker, String msg) {
         recordEvent(Level.INFO, marker, msg, null, null);
+    }
+
+    @Override
+    public void info(Marker marker, Supplier<String> msgSup) {
+        recordEvent(Level.INFO, marker, msgSup, null);
     }
 
     public void info(Marker marker, String format, Object arg) {
@@ -190,12 +255,22 @@ public class EventRecodingLogger implements Logger {
 
     }
 
+    @Override
+    public void info(Marker marker, Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.INFO, marker, msgSup, t);
+    }
+
     public boolean isWarnEnabled() {
         return true;
     }
 
     public void warn(String msg) {
         recordEvent(Level.WARN, msg, null, null);
+    }
+
+    @Override
+    public void warn(Supplier<String> msgSup) {
+        recordEvent(Level.WARN, msgSup, null);
     }
 
     public void warn(String format, Object arg) {
@@ -215,12 +290,22 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.WARN, msg, null, t);
     }
 
+    @Override
+    public void warn(Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.WARN, msgSup, t);
+    }
+
     public boolean isWarnEnabled(Marker marker) {
         return true;
     }
 
     public void warn(Marker marker, String msg) {
         recordEvent(Level.WARN, msg, null, null);
+    }
+
+    @Override
+    public void warn(Marker marker, Supplier<String> msgSup) {
+        recordEvent(Level.WARN, marker, msgSup, null);
     }
 
     public void warn(Marker marker, String format, Object arg) {
@@ -240,12 +325,22 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.WARN, marker, msg, null, t);
     }
 
+    @Override
+    public void warn(Marker marker, Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.WARN, marker, msgSup, t);
+    }
+
     public boolean isErrorEnabled() {
         return true;
     }
 
     public void error(String msg) {
         recordEvent(Level.ERROR, msg, null, null);
+    }
+
+    @Override
+    public void error(Supplier<String> msgSup) {
+        recordEvent(Level.ERROR, msgSup, null);
     }
 
     public void error(String format, Object arg) {
@@ -267,6 +362,11 @@ public class EventRecodingLogger implements Logger {
         recordEvent(Level.ERROR, msg, null, t);
     }
 
+    @Override
+    public void error(Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.ERROR, msgSup, t);
+    }
+
     public boolean isErrorEnabled(Marker marker) {
         return true;
     }
@@ -274,6 +374,11 @@ public class EventRecodingLogger implements Logger {
     public void error(Marker marker, String msg) {
         recordEvent(Level.ERROR, marker, msg, null, null);
 
+    }
+
+    @Override
+    public void error(Marker marker, Supplier<String> msgSup) {
+        recordEvent(Level.ERROR, marker, msgSup, null);
     }
 
     public void error(Marker marker, String format, Object arg) {
@@ -291,6 +396,11 @@ public class EventRecodingLogger implements Logger {
 
     public void error(Marker marker, String msg, Throwable t) {
         recordEvent(Level.ERROR, marker, msg, null, t);
+    }
+
+    @Override
+    public void error(Marker marker, Throwable t, Supplier<String> msgSup) {
+        recordEvent(Level.ERROR, marker, msgSup, t);
     }
 
 }

--- a/slf4j-api/src/main/java/org/slf4j/helpers/MarkerIgnoringBase.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/MarkerIgnoringBase.java
@@ -27,6 +27,8 @@ package org.slf4j.helpers;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
+import java.util.function.Supplier;
+
 /**
  * This class serves as base for adapters or native implementations of logging systems 
  * lacking Marker support. In this implementation, methods taking marker data 
@@ -47,6 +49,10 @@ public abstract class MarkerIgnoringBase extends NamedLoggerBase implements Logg
         trace(msg);
     }
 
+    public void trace(Marker marker, Supplier<String> msgSup) {
+        trace(msgSup);
+    }
+
     public void trace(Marker marker, String format, Object arg) {
         trace(format, arg);
     }
@@ -63,12 +69,20 @@ public abstract class MarkerIgnoringBase extends NamedLoggerBase implements Logg
         trace(msg, t);
     }
 
+    public void trace(Marker marker, Throwable t, Supplier<String> msgSup) {
+        trace(t, msgSup);
+    }
+
     public boolean isDebugEnabled(Marker marker) {
         return isDebugEnabled();
     }
 
     public void debug(Marker marker, String msg) {
         debug(msg);
+    }
+
+    public void debug(Marker marker, Supplier<String> msgSup) {
+        debug(msgSup);
     }
 
     public void debug(Marker marker, String format, Object arg) {
@@ -87,12 +101,20 @@ public abstract class MarkerIgnoringBase extends NamedLoggerBase implements Logg
         debug(msg, t);
     }
 
+    public void debug(Marker marker, Throwable t, Supplier<String> msgSup) {
+        debug(t, msgSup);
+    }
+
     public boolean isInfoEnabled(Marker marker) {
         return isInfoEnabled();
     }
 
     public void info(Marker marker, String msg) {
         info(msg);
+    }
+
+    public void info(Marker marker, Supplier<String> msgSup) {
+        info(msgSup);
     }
 
     public void info(Marker marker, String format, Object arg) {
@@ -111,12 +133,20 @@ public abstract class MarkerIgnoringBase extends NamedLoggerBase implements Logg
         info(msg, t);
     }
 
+    public void info(Marker marker, Throwable t, Supplier<String> msgSup) {
+        info(t, msgSup);
+    }
+
     public boolean isWarnEnabled(Marker marker) {
         return isWarnEnabled();
     }
 
     public void warn(Marker marker, String msg) {
         warn(msg);
+    }
+
+    public void warn(Marker marker, Supplier<String> msgSup) {
+        warn(msgSup);
     }
 
     public void warn(Marker marker, String format, Object arg) {
@@ -135,12 +165,20 @@ public abstract class MarkerIgnoringBase extends NamedLoggerBase implements Logg
         warn(msg, t);
     }
 
+    public void warn(Marker marker, Throwable t, Supplier<String> msgSup) {
+        warn(t, msgSup);
+    }
+
     public boolean isErrorEnabled(Marker marker) {
         return isErrorEnabled();
     }
 
     public void error(Marker marker, String msg) {
         error(msg);
+    }
+
+    public void error(Marker marker, Supplier<String> msgSup) {
+        error(msgSup);
     }
 
     public void error(Marker marker, String format, Object arg) {
@@ -157,6 +195,10 @@ public abstract class MarkerIgnoringBase extends NamedLoggerBase implements Logg
 
     public void error(Marker marker, String msg, Throwable t) {
         error(msg, t);
+    }
+
+    public void error(Marker marker, Throwable t, Supplier<String> msgSup) {
+        error(t, msgSup);
     }
 
     public String toString() {

--- a/slf4j-api/src/main/java/org/slf4j/helpers/NOPLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/NOPLogger.java
@@ -27,6 +27,8 @@ package org.slf4j.helpers;
 import org.slf4j.Logger;
 import org.slf4j.helpers.MarkerIgnoringBase;
 
+import java.util.function.Supplier;
+
 /**
  * A direct NOP (no operation) implementation of {@link Logger}.
  *
@@ -68,6 +70,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    /** A NOP implementation. */
+    public void trace(Supplier<String> msgSup) {
+        // NOP
+    }
+
     /** A NOP implementation.  */
     final public void trace(String format, Object arg) {
         // NOP
@@ -88,6 +95,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    /** A NOP implementation. */
+    public void trace(Throwable t, Supplier<String> msgSup) {
+        // NOP
+    }
+
     /**
      * Always returns false.
      * @return always false
@@ -98,6 +110,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void debug(String msg) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    public void debug(Supplier<String> msgSup) {
         // NOP
     }
 
@@ -121,6 +138,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    /** A NOP implementation. */
+    public void debug(Throwable t, Supplier<String> msgSup) {
+        // NOP
+    }
+
     /**
      * Always returns false.
      * @return always false
@@ -132,6 +154,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void info(String msg) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    public void info(Supplier<String> msgSup) {
         // NOP
     }
 
@@ -155,6 +182,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    /** A NOP implementation. */
+    public void info(Throwable t, Supplier<String> msgSup) {
+        // NOP
+    }
+
     /**
      * Always returns false.
      * @return always false
@@ -165,6 +197,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void warn(String msg) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    public void warn(Supplier<String> msgSup) {
         // NOP
     }
 
@@ -189,12 +226,22 @@ public class NOPLogger extends MarkerIgnoringBase {
     }
 
     /** A NOP implementation. */
+    public void warn(Throwable t, Supplier<String> msgSup) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
     final public boolean isErrorEnabled() {
         return false;
     }
 
     /** A NOP implementation. */
     final public void error(String msg) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    public void error(Supplier<String> msgSup) {
         // NOP
     }
 
@@ -215,6 +262,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void error(String msg, Throwable t) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    public void error(Throwable t, Supplier<String> msgSup) {
         // NOP
     }
 }

--- a/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
@@ -27,6 +27,7 @@ package org.slf4j.helpers;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.Marker;
@@ -73,6 +74,11 @@ public class SubstituteLogger implements Logger {
         delegate().trace(msg);
     }
 
+    @Override
+    public void trace(Supplier<String> msgSup) {
+        delegate().trace(msgSup);
+    }
+
     public void trace(String format, Object arg) {
         delegate().trace(format, arg);
     }
@@ -89,12 +95,22 @@ public class SubstituteLogger implements Logger {
         delegate().trace(msg, t);
     }
 
+    @Override
+    public void trace(Throwable t, Supplier<String> msgSup) {
+        delegate().trace(t, msgSup);
+    }
+
     public boolean isTraceEnabled(Marker marker) {
         return delegate().isTraceEnabled(marker);
     }
 
     public void trace(Marker marker, String msg) {
         delegate().trace(marker, msg);
+    }
+
+    @Override
+    public void trace(Marker marker, Supplier<String> msgSup) {
+        delegate().trace(marker, msgSup);
     }
 
     public void trace(Marker marker, String format, Object arg) {
@@ -113,12 +129,22 @@ public class SubstituteLogger implements Logger {
         delegate().trace(marker, msg, t);
     }
 
+    @Override
+    public void trace(Marker marker, Throwable t, Supplier<String> msgSup) {
+        delegate().trace(marker, t, msgSup);
+    }
+
     public boolean isDebugEnabled() {
         return delegate().isDebugEnabled();
     }
 
     public void debug(String msg) {
         delegate().debug(msg);
+    }
+
+    @Override
+    public void debug(Supplier<String> msgSup) {
+        delegate().debug(msgSup);
     }
 
     public void debug(String format, Object arg) {
@@ -137,12 +163,22 @@ public class SubstituteLogger implements Logger {
         delegate().debug(msg, t);
     }
 
+    @Override
+    public void debug(Throwable t, Supplier<String> msgSup) {
+        delegate().debug(t, msgSup);
+    }
+
     public boolean isDebugEnabled(Marker marker) {
         return delegate().isDebugEnabled(marker);
     }
 
     public void debug(Marker marker, String msg) {
         delegate().debug(marker, msg);
+    }
+
+    @Override
+    public void debug(Marker marker, Supplier<String> msgSup) {
+        delegate().debug(marker, msgSup);
     }
 
     public void debug(Marker marker, String format, Object arg) {
@@ -161,12 +197,22 @@ public class SubstituteLogger implements Logger {
         delegate().debug(marker, msg, t);
     }
 
+    @Override
+    public void debug(Marker marker, Throwable t, Supplier<String> msgSup) {
+        delegate().debug(marker, t, msgSup);
+    }
+
     public boolean isInfoEnabled() {
         return delegate().isInfoEnabled();
     }
 
     public void info(String msg) {
         delegate().info(msg);
+    }
+
+    @Override
+    public void info(Supplier<String> msgSup) {
+        delegate().info(msgSup);
     }
 
     public void info(String format, Object arg) {
@@ -185,12 +231,22 @@ public class SubstituteLogger implements Logger {
         delegate().info(msg, t);
     }
 
+    @Override
+    public void info(Throwable t, Supplier<String> msgSup) {
+        delegate().info(t, msgSup);
+    }
+
     public boolean isInfoEnabled(Marker marker) {
         return delegate().isInfoEnabled(marker);
     }
 
     public void info(Marker marker, String msg) {
         delegate().info(marker, msg);
+    }
+
+    @Override
+    public void info(Marker marker, Supplier<String> msgSup) {
+        delegate().info(marker, msgSup);
     }
 
     public void info(Marker marker, String format, Object arg) {
@@ -209,12 +265,22 @@ public class SubstituteLogger implements Logger {
         delegate().info(marker, msg, t);
     }
 
+    @Override
+    public void info(Marker marker, Throwable t, Supplier<String> msgSup) {
+        delegate().info(marker, t, msgSup);
+    }
+
     public boolean isWarnEnabled() {
         return delegate().isWarnEnabled();
     }
 
     public void warn(String msg) {
         delegate().warn(msg);
+    }
+
+    @Override
+    public void warn(Supplier<String> msgSup) {
+        delegate().warn(msgSup);
     }
 
     public void warn(String format, Object arg) {
@@ -233,12 +299,22 @@ public class SubstituteLogger implements Logger {
         delegate().warn(msg, t);
     }
 
+    @Override
+    public void warn(Throwable t, Supplier<String> msgSup) {
+        delegate().warn(t, msgSup);
+    }
+
     public boolean isWarnEnabled(Marker marker) {
         return delegate().isWarnEnabled(marker);
     }
 
     public void warn(Marker marker, String msg) {
         delegate().warn(marker, msg);
+    }
+
+    @Override
+    public void warn(Marker marker, Supplier<String> msgSup) {
+        delegate().warn(marker, msgSup);
     }
 
     public void warn(Marker marker, String format, Object arg) {
@@ -257,12 +333,22 @@ public class SubstituteLogger implements Logger {
         delegate().warn(marker, msg, t);
     }
 
+    @Override
+    public void warn(Marker marker, Throwable t, Supplier<String> msgSup) {
+        delegate().warn(marker, t, msgSup);
+    }
+
     public boolean isErrorEnabled() {
         return delegate().isErrorEnabled();
     }
 
     public void error(String msg) {
         delegate().error(msg);
+    }
+
+    @Override
+    public void error(Supplier<String> msgSup) {
+        delegate().error(msgSup);
     }
 
     public void error(String format, Object arg) {
@@ -281,12 +367,22 @@ public class SubstituteLogger implements Logger {
         delegate().error(msg, t);
     }
 
+    @Override
+    public void error(Throwable t, Supplier<String> msgSup) {
+        delegate().error(t, msgSup);
+    }
+
     public boolean isErrorEnabled(Marker marker) {
         return delegate().isErrorEnabled(marker);
     }
 
     public void error(Marker marker, String msg) {
         delegate().error(marker, msg);
+    }
+
+    @Override
+    public void error(Marker marker, Supplier<String> msgSup) {
+        delegate().error(marker, msgSup);
     }
 
     public void error(Marker marker, String format, Object arg) {
@@ -303,6 +399,11 @@ public class SubstituteLogger implements Logger {
 
     public void error(Marker marker, String msg, Throwable t) {
         delegate().error(marker, msg, t);
+    }
+
+    @Override
+    public void error(Marker marker, Throwable t, Supplier<String> msgSup) {
+        delegate().error(marker, t, msgSup);
     }
 
     @Override
@@ -372,10 +473,10 @@ public class SubstituteLogger implements Logger {
         if (isDelegateEventAware()) {
             try {
                 logMethodCache.invoke(_delegate, event);
-            } catch (IllegalAccessException e) {
-            } catch (IllegalArgumentException e) {
-            } catch (InvocationTargetException e) {
-            }
+            } catch (IllegalAccessException
+                    | IllegalArgumentException
+                    | InvocationTargetException e) {
+            } 
         }
     }
 

--- a/slf4j-api/src/main/java/org/slf4j/helpers/Util.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/Util.java
@@ -24,6 +24,8 @@
  */
 package org.slf4j.helpers;
 
+import java.util.function.Supplier;
+
 /**
  * An internal utility class.
  *
@@ -34,6 +36,13 @@ public final class Util {
 
 	
     private Util() {
+    }
+
+    public static String msgSafeGet(Supplier<String> msgSup) {
+        if(msgSup != null) {
+            return msgSup.get();
+        }
+        return null;
     }
 
     public static String safeGetSystemProperty(String key) {

--- a/slf4j-ext/src/main/java/org/slf4j/ext/LoggerWrapper.java
+++ b/slf4j-ext/src/main/java/org/slf4j/ext/LoggerWrapper.java
@@ -28,7 +28,10 @@ import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.helpers.Util;
 import org.slf4j.spi.LocationAwareLogger;
+
+import java.util.function.Supplier;
 
 /**
  * A helper class wrapping an {@link org.slf4j.Logger} instance preserving
@@ -87,6 +90,21 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, msg, null, null);
         } else {
             logger.trace(msg);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void trace(Supplier<String> msgSup) {
+        if (!logger.isTraceEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, msg, null, null);
+        } else {
+            logger.trace(msgSup);
         }
     }
 
@@ -152,6 +170,22 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void trace(Throwable t, Supplier<String> msgSup) {
+        if (!logger.isTraceEnabled())
+            return;
+
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, msg, null, t);
+        } else {
+            logger.trace(t, msgSup);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public void trace(Marker marker, String msg) {
         if (!logger.isTraceEnabled(marker))
             return;
@@ -160,6 +194,21 @@ public class LoggerWrapper implements Logger {
         } else {
             logger.trace(marker, msg);
         }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void trace(Marker marker, Supplier<String> msgSup) {
+        if (!logger.isTraceEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.TRACE_INT, msg, null, null);
+        } else {
+            logger.trace(marker, msgSup);
+        }
+
     }
 
     /**
@@ -220,6 +269,20 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void trace(Marker marker, Throwable t, Supplier<String> msgSup) {
+        if (!logger.isTraceEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.TRACE_INT, msg, null, t);
+        } else {
+            logger.trace(marker, t, msgSup);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public boolean isDebugEnabled() {
         return logger.isDebugEnabled();
     }
@@ -243,6 +306,22 @@ public class LoggerWrapper implements Logger {
         } else {
             logger.debug(msg);
         }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void debug(Supplier<String> msgSup) {
+        if (!logger.isDebugEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, null);
+        } else {
+            logger.debug(msgSup);
+        }
+
     }
 
     /**
@@ -307,6 +386,21 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void debug(Throwable t, Supplier<String> msgSup) {
+        if (!logger.isDebugEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, t);
+        } else {
+            logger.debug(t, msgSup);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public void debug(Marker marker, String msg) {
         if (!logger.isDebugEnabled(marker))
             return;
@@ -314,6 +408,20 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, null);
         } else {
             logger.debug(marker, msg);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void debug(Marker marker, Supplier<String> msgSup) {
+        if (!logger.isDebugEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, null);
+        } else {
+            logger.debug(marker, msgSup);
         }
     }
 
@@ -376,6 +484,21 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void debug(Marker marker, Throwable t, Supplier<String> msgSup) {
+        if (!logger.isDebugEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.DEBUG_INT, msg, null, t);
+        } else {
+            logger.debug(marker, t, msgSup);
+        }
+
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public boolean isInfoEnabled() {
         return logger.isInfoEnabled();
     }
@@ -398,6 +521,21 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, msg, null, null);
         } else {
             logger.info(msg);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void info(Supplier<String> msgSup) {
+        if (!logger.isInfoEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, msg, null, null);
+        } else {
+            logger.info(msgSup);
         }
     }
 
@@ -463,6 +601,21 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void info(Throwable t, Supplier<String> msgSup) {
+        if (!logger.isInfoEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.INFO_INT, msg, null, t);
+        } else {
+            logger.info(t, msgSup);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public void info(Marker marker, String msg) {
         if (!logger.isInfoEnabled(marker))
             return;
@@ -470,6 +623,20 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, msg, null, null);
         } else {
             logger.info(marker, msg);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void info(Marker marker, Supplier<String> msgSup) {
+        if (!logger.isInfoEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, msg, null, null);
+        } else {
+            logger.info(marker, msgSup);
         }
     }
 
@@ -528,6 +695,20 @@ public class LoggerWrapper implements Logger {
         }
     }
 
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void info(Marker marker, Throwable t, Supplier<String> msgSup) {
+        if (!logger.isInfoEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.INFO_INT, msg, null, t);
+        } else {
+            logger.info(marker, t, msgSup);
+        }
+    }
+
     public boolean isWarnEnabled() {
         return logger.isWarnEnabled();
     }
@@ -550,6 +731,21 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, msg, null, null);
         } else {
             logger.warn(msg);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void warn(Supplier<String> msgSup) {
+        if (!logger.isWarnEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, msg, null, null);
+        } else {
+            logger.warn(msgSup);
         }
     }
 
@@ -615,6 +811,21 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void warn(Throwable t, Supplier<String> msgSup) {
+        if (!logger.isWarnEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.WARN_INT, msg, null, t);
+        } else {
+            logger.warn(t, msgSup);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public void warn(Marker marker, String msg) {
         if (!logger.isWarnEnabled(marker))
             return;
@@ -622,6 +833,20 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, msg, null, null);
         } else {
             logger.warn(marker, msg);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void warn(Marker marker, Supplier<String> msgSup) {
+        if (!logger.isWarnEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, msg, null, null);
+        } else {
+            logger.warn(marker, msgSup);
         }
     }
 
@@ -683,6 +908,20 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void warn(Marker marker, Throwable t, Supplier<String> msgSup) {
+        if (!logger.isWarnEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.WARN_INT, msg, null, t);
+        } else {
+            logger.warn(marker, t, msgSup);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public boolean isErrorEnabled() {
         return logger.isErrorEnabled();
     }
@@ -705,6 +944,21 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, msg, null, null);
         } else {
             logger.error(msg);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void error(Supplier<String> msgSup) {
+        if (!logger.isErrorEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, msg, null, null);
+        } else {
+            logger.error(msgSup);
         }
     }
 
@@ -770,6 +1024,21 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void error(Throwable t, Supplier<String> msgSup) {
+        if (!logger.isErrorEnabled())
+            return;
+
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.ERROR_INT, msg, null, t);
+        } else {
+            logger.error(t, msgSup);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public void error(Marker marker, String msg) {
         if (!logger.isErrorEnabled(marker))
             return;
@@ -777,6 +1046,20 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, msg, null, null);
         } else {
             logger.error(marker, msg);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void error(Marker marker, Supplier<String> msgSup) {
+        if (!logger.isErrorEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, msg, null, null);
+        } else {
+            logger.error(marker, msgSup);
         }
     }
 
@@ -832,6 +1115,20 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, msg, null, t);
         } else {
             logger.error(marker, msg, t);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void error(Marker marker, Throwable t, Supplier<String> msgSup) {
+        if (!logger.isErrorEnabled(marker))
+            return;
+        if (instanceofLAL) {
+            String msg = Util.msgSafeGet(msgSup);
+            ((LocationAwareLogger) logger).log(marker, fqcn, LocationAwareLogger.ERROR_INT, msg, null, t);
+        } else {
+            logger.error(marker, t, msgSup);
         }
     }
 

--- a/slf4j-jdk14/src/main/java/org/slf4j/jul/JDK14LoggerAdapter.java
+++ b/slf4j-jdk14/src/main/java/org/slf4j/jul/JDK14LoggerAdapter.java
@@ -24,6 +24,7 @@
  */
 package org.slf4j.jul;
 
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -34,6 +35,7 @@ import org.slf4j.event.LoggingEvent;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MarkerIgnoringBase;
 import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.helpers.Util;
 import org.slf4j.spi.LocationAwareLogger;
 
 /**
@@ -77,6 +79,19 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
         if (logger.isLoggable(Level.FINEST)) {
             log(SELF, Level.FINEST, msg, null);
         }
+    }
+
+    /**
+     * Log a message object provided by supplier at level FINEST.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void trace(Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.FINEST)) {
+            log(SELF, Level.FINEST, Util.msgSafeGet(msgSup), null);
+        }
+
     }
 
     /**
@@ -159,6 +174,21 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     }
 
     /**
+     * Log an exception (throwable) at level FINEST with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void trace(Throwable t, Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.FINEST)) {
+            log(SELF, Level.FINEST, Util.msgSafeGet(msgSup), t);
+        }
+    }
+
+    /**
      * Is this logger instance enabled for the FINE level?
      * 
      * @return True if this Logger is enabled for level FINE, false otherwise.
@@ -176,6 +206,18 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void debug(String msg) {
         if (logger.isLoggable(Level.FINE)) {
             log(SELF, Level.FINE, msg, null);
+        }
+    }
+
+    /**
+     * Log a message object provided by supplier at level FINE.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void debug(Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.FINE)) {
+            log(SELF, Level.FINE, Util.msgSafeGet(msgSup), null);
         }
     }
 
@@ -258,6 +300,21 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     }
 
     /**
+     * Log an exception (throwable) at level FINEST with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void debug(Throwable t, Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.FINE)) {
+            log(SELF, Level.FINE, Util.msgSafeGet(msgSup), t);
+        }
+    }
+
+    /**
      * Is this logger instance enabled for the INFO level?
      * 
      * @return True if this Logger is enabled for the INFO level, false otherwise.
@@ -275,6 +332,18 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void info(String msg) {
         if (logger.isLoggable(Level.INFO)) {
             log(SELF, Level.INFO, msg, null);
+        }
+    }
+
+    /**
+     * Log a message object provided by supplier at level INFO.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void info(Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.INFO)) {
+            log(SELF, Level.INFO, Util.msgSafeGet(msgSup), null);
         }
     }
 
@@ -358,6 +427,21 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     }
 
     /**
+     * Log an exception (throwable) at level INFO with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void info(Throwable t, Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.INFO)) {
+            log(SELF, Level.INFO, Util.msgSafeGet(msgSup), t);
+        }
+    }
+
+    /**
      * Is this logger instance enabled for the WARNING level?
      * 
      * @return True if this Logger is enabled for the WARNING level, false
@@ -376,6 +460,18 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void warn(String msg) {
         if (logger.isLoggable(Level.WARNING)) {
             log(SELF, Level.WARNING, msg, null);
+        }
+    }
+
+    /**
+     * Log a message object provided by supplier at level WARNING.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void warn(Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.WARNING)) {
+            log(SELF, Level.WARNING, Util.msgSafeGet(msgSup), null);
         }
     }
 
@@ -460,6 +556,21 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     }
 
     /**
+     * Log an exception (throwable) at level WARNING with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void warn(Throwable t, Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.WARNING)) {
+            log(SELF, Level.WARNING, Util.msgSafeGet(msgSup), t);
+        }
+    }
+
+    /**
      * Is this logger instance enabled for level SEVERE?
      * 
      * @return True if this Logger is enabled for level SEVERE, false otherwise.
@@ -477,6 +588,18 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
     public void error(String msg) {
         if (logger.isLoggable(Level.SEVERE)) {
             log(SELF, Level.SEVERE, msg, null);
+        }
+    }
+
+    /**
+     * Log a message object provided by supplier at level SEVERE.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void error(Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            log(SELF, Level.SEVERE, Util.msgSafeGet(msgSup), null);
         }
     }
 
@@ -558,6 +681,22 @@ public final class JDK14LoggerAdapter extends MarkerIgnoringBase implements Loca
         if (logger.isLoggable(Level.SEVERE)) {
             log(SELF, Level.SEVERE, msg, t);
         }
+    }
+
+    /**
+     * Log an exception (throwable) at level SEVERE with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void error(Throwable t, Supplier<String> msgSup) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            log(SELF, Level.SEVERE, Util.msgSafeGet(msgSup), t);
+        }
+
     }
 
     /**

--- a/slf4j-jdk14/src/test/java/org/slf4j/jul/InvocationTest.java
+++ b/slf4j-jdk14/src/test/java/org/slf4j/jul/InvocationTest.java
@@ -32,6 +32,7 @@ import org.slf4j.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -79,12 +80,17 @@ public class InvocationTest {
         Integer i1 = new Integer(1);
         Integer i2 = new Integer(2);
         Integer i3 = new Integer(3);
+        Supplier<String> s1 = () -> "supplier1";
+        Supplier<String> s2 = () -> "supplier2";
         Exception e = new Exception("This is a test exception.");
         Logger logger = LoggerFactory.getLogger("test2");
 
         int index = 0;
         logger.debug("Hello world");
         assertLogMessage("Hello world", index++);
+
+        logger.debug(s1);
+        assertLogMessage("supplier1", index++);
 
         logger.debug("Hello world {}", i1);
         assertLogMessage("Hello world " + i1, index++);
@@ -98,23 +104,48 @@ public class InvocationTest {
         logger.debug("Hello world 2", e);
         assertLogMessage("Hello world 2", index);
         assertException(e.getClass(), index++);
+
+        logger.debug(e, s2);
+        assertLogMessage("supplier2", index);
+        assertException(e.getClass(), index++);
+
         logger.info("Hello world 2.");
+        logger.info(() -> "Hello world supplier 2.");
 
         logger.warn("Hello world 3.");
         logger.warn("Hello world 3", e);
+        logger.warn(() -> "Hello world supplier 3.");
+        logger.warn(e, () -> "Hello world supplier 3.");
 
         logger.error("Hello world 4.");
         logger.error("Hello world {}", new Integer(3));
         logger.error("Hello world 4.", e);
+        logger.error(() -> "Hello world supplier 4.");
+        logger.error(e, () -> "Hello world supplier 4.");
     }
 
     @Test
-    public void testNull() {
+    public void testMsgNull() {
         Logger logger = LoggerFactory.getLogger("testNull");
-        logger.debug(null);
-        logger.info(null);
-        logger.warn(null);
-        logger.error(null);
+        logger.debug((String)null);
+        logger.info((String)null);
+        logger.warn((String)null);
+        logger.error((String)null);
+
+        Exception e = new Exception("This is a test exception.");
+        logger.debug(null, e);
+        logger.info(null, e);
+        logger.warn(null, e);
+        logger.error(null, e);
+    }
+
+    @Test
+    public void testMsgSupNull() {
+        Logger logger = LoggerFactory.getLogger("testNull");
+        logger.debug((Supplier<String>)null);
+        logger.info((Supplier<String>)null);
+        logger.warn((Supplier<String>)null);
+        logger.error((Supplier<String>)null);
 
         Exception e = new Exception("This is a test exception.");
         logger.debug(null, e);
@@ -141,6 +172,16 @@ public class InvocationTest {
         logger.info(blue, "hello {} and {} ", "world", "universe");
         logger.warn(blue, "hello {} and {} ", "world", "universe");
         logger.error(blue, "hello {} and {} ", "world", "universe");
+    }
+
+    @Test
+    public void testMarkerSup() {
+        Logger logger = LoggerFactory.getLogger("testMarker");
+        Marker blue = MarkerFactory.getMarker("BLUE");
+        logger.debug(blue, () -> "hello");
+        logger.info(blue, () -> "hello");
+        logger.warn(blue, () -> "hello");
+        logger.error(blue, () -> "hello");
     }
 
     @Test

--- a/slf4j-log4j12/src/main/java/org/slf4j/log4j12/Log4jLoggerAdapter.java
+++ b/slf4j-log4j12/src/main/java/org/slf4j/log4j12/Log4jLoggerAdapter.java
@@ -27,6 +27,7 @@ package org.slf4j.log4j12;
 import static org.slf4j.event.EventConstants.NA_SUBST;
 
 import java.io.Serializable;
+import java.util.function.Supplier;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LocationInfo;
@@ -37,6 +38,7 @@ import org.slf4j.event.LoggingEvent;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MarkerIgnoringBase;
 import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.helpers.Util;
 import org.slf4j.spi.LocationAwareLogger;
 
 /**
@@ -112,6 +114,19 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void trace(String msg) {
         logger.log(FQCN, traceCapable ? Level.TRACE : Level.DEBUG, msg, null);
+    }
+
+    /**
+     * Log a message object provided by supplier at level TRACE.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void trace(Supplier<String> msgSup) {
+        if (isTraceEnabled()) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, traceCapable ? Level.TRACE : Level.DEBUG, msg, null);
+        }
     }
 
     /**
@@ -192,6 +207,23 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
     }
 
     /**
+     * Log an exception (throwable) at level TRACE with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void trace(Throwable t, Supplier<String> msgSup) {
+        if (isTraceEnabled()) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, traceCapable ? Level.TRACE : Level.DEBUG, msg, t);
+        }
+
+    }
+
+    /**
      * Is this logger instance enabled for the DEBUG level?
      * 
      * @return True if this Logger is enabled for level DEBUG, false otherwise.
@@ -208,6 +240,19 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void debug(String msg) {
         logger.log(FQCN, Level.DEBUG, msg, null);
+    }
+
+    /**
+     * Log a message object provided by supplier at level DEBUG.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void debug(Supplier<String> msgSup) {
+        if (logger.isDebugEnabled()) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, Level.DEBUG, msg, null);
+        }
     }
 
     /**
@@ -287,6 +332,22 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
     }
 
     /**
+     * Log an exception (throwable) at level DEBUG with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void debug(Throwable t, Supplier<String> msgSup) {
+        if (logger.isDebugEnabled()) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, Level.DEBUG, msg, t);
+        }
+    }
+
+    /**
      * Is this logger instance enabled for the INFO level?
      * 
      * @return True if this Logger is enabled for the INFO level, false otherwise.
@@ -303,6 +364,19 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void info(String msg) {
         logger.log(FQCN, Level.INFO, msg, null);
+    }
+
+    /**
+     * Log a message object provided by supplier at level INFO.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void info(Supplier<String> msgSup) {
+        if (logger.isInfoEnabled()) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, Level.INFO, msg, null);
+        }
     }
 
     /**
@@ -372,7 +446,7 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
     /**
      * Log an exception (throwable) at the INFO level with an accompanying
      * message.
-     * 
+     *
      * @param msg
      *          the message accompanying the exception
      * @param t
@@ -380,6 +454,22 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void info(String msg, Throwable t) {
         logger.log(FQCN, Level.INFO, msg, t);
+    }
+
+    /**
+     * Log an exception (throwable) at level INFO with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void info(Throwable t, Supplier<String> msgSup) {
+        if (logger.isInfoEnabled()) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, Level.INFO, msg, t);
+        }
     }
 
     /**
@@ -399,6 +489,19 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void warn(String msg) {
         logger.log(FQCN, Level.WARN, msg, null);
+    }
+
+    /**
+     * Log a message object provided by supplier at level WARNING.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void warn(Supplier<String> msgSup) {
+        if(logger.isEnabledFor(Level.WARN)) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, Level.WARN, msg, null);
+        }
     }
 
     /**
@@ -480,6 +583,22 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
     }
 
     /**
+     * Log an exception (throwable) at level WARNING with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void warn(Throwable t, Supplier<String> msgSup) {
+        if (logger.isEnabledFor(Level.WARN)) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, Level.WARN, msg, t);
+        }
+    }
+
+    /**
      * Is this logger instance enabled for level ERROR?
      * 
      * @return True if this Logger is enabled for level ERROR, false otherwise.
@@ -496,6 +615,19 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void error(String msg) {
         logger.log(FQCN, Level.ERROR, msg, null);
+    }
+
+    /**
+     * Log a message object provided by supplier at level SEVERE.
+     *
+     * @param msgSup
+     *          - the supplier for message object to be logged
+     */
+    public void error(Supplier<String> msgSup) {
+        if (logger.isEnabledFor(Level.ERROR)) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, Level.ERROR, msg, null);
+        }
     }
 
     /**
@@ -574,6 +706,22 @@ public final class Log4jLoggerAdapter extends MarkerIgnoringBase implements Loca
      */
     public void error(String msg, Throwable t) {
         logger.log(FQCN, Level.ERROR, msg, t);
+    }
+
+    /**
+     * Log an exception (throwable) at level SEVERE with an accompanying message
+     * provided by supplier
+     *
+     * @param msgSup
+     *          the supplier for message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    public void error(Throwable t, Supplier<String> msgSup) {
+        if (logger.isEnabledFor(Level.ERROR)) {
+            String msg = Util.msgSafeGet(msgSup);
+            logger.log(FQCN, Level.ERROR, msg, t);
+        }
     }
 
     public void log(Marker marker, String callerFQCN, int level, String msg, Object[] argArray, Throwable t) {

--- a/slf4j-log4j12/src/test/java/org/slf4j/log4j12/InvocationTest.java
+++ b/slf4j-log4j12/src/test/java/org/slf4j/log4j12/InvocationTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.fail;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
@@ -99,13 +100,28 @@ public class InvocationTest {
     }
 
     @Test
-    public void testNull() {
+    public void testMsgNull() {
         Logger logger = LoggerFactory.getLogger("testNull");
-        logger.trace(null);
-        logger.debug(null);
-        logger.info(null);
-        logger.warn(null);
-        logger.error(null);
+        logger.debug((String)null);
+        logger.info((String)null);
+        logger.warn((String)null);
+        logger.error((String)null);
+
+        Exception e = new Exception("This is a test exception.");
+        logger.debug(null, e);
+        logger.info(null, e);
+        logger.warn(null, e);
+        logger.error(null, e);
+        assertEquals(8, listAppender.list.size());
+    }
+
+    @Test
+    public void testMsgSupNull() {
+        Logger logger = LoggerFactory.getLogger("testNull");
+        logger.debug((Supplier<String>)null);
+        logger.info((Supplier<String>)null);
+        logger.warn((Supplier<String>)null);
+        logger.error((Supplier<String>)null);
 
         Exception e = new Exception("This is a test exception.");
         logger.debug(null, e);

--- a/slf4j-nop/src/main/java/org/slf4j/nop/NOPLogger.java
+++ b/slf4j-nop/src/main/java/org/slf4j/nop/NOPLogger.java
@@ -27,6 +27,8 @@ package org.slf4j.nop;
 import org.slf4j.Logger;
 import org.slf4j.helpers.MarkerIgnoringBase;
 
+import java.util.function.Supplier;
+
 /**
  * A direct NOP (no operation) implementation of {@link Logger}.
  *
@@ -68,6 +70,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    @Override
+    public void trace(Supplier<String> msgSup) {
+        // NOP
+    }
+
     /** A NOP implementation.  */
     final public void trace(String format, Object arg) {
         // NOP
@@ -88,6 +95,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    @Override
+    public void trace(Throwable t, Supplier<String> msgSup) {
+        // NOP
+    }
+
     /**
      * Always returns false.
      * @return always false
@@ -98,6 +110,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void debug(String msg) {
+        // NOP
+    }
+
+    @Override
+    public void debug(Supplier<String> msgSup) {
         // NOP
     }
 
@@ -121,6 +138,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    @Override
+    public void debug(Throwable t, Supplier<String> msgSup) {
+        // NOP
+    }
+
     /**
      * Always returns false.
      * @return always false
@@ -132,6 +154,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void info(String msg) {
+        // NOP
+    }
+
+    @Override
+    public void info(Supplier<String> msgSup) {
         // NOP
     }
 
@@ -155,6 +182,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    @Override
+    public void info(Throwable t, Supplier<String> msgSup) {
+        // NOP
+    }
+
     /**
      * Always returns false.
      * @return always false
@@ -165,6 +197,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void warn(String msg) {
+        // NOP
+    }
+
+    @Override
+    public void warn(Supplier<String> msgSup) {
         // NOP
     }
 
@@ -188,6 +225,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    @Override
+    public void warn(Throwable t, Supplier<String> msgSup) {
+        // NOP
+    }
+
     /** A NOP implementation. */
     final public boolean isErrorEnabled() {
         return false;
@@ -195,6 +237,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void error(String msg) {
+        // NOP
+    }
+
+    @Override
+    public void error(Supplier<String> msgSup) {
         // NOP
     }
 
@@ -215,6 +262,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void error(String msg, Throwable t) {
+        // NOP
+    }
+
+    @Override
+    public void error(Throwable t, Supplier<String> msgSup) {
         // NOP
     }
 }

--- a/slf4j-nop/src/test/java/org/slf4j/nop/InvocationTest.java
+++ b/slf4j-nop/src/test/java/org/slf4j/nop/InvocationTest.java
@@ -33,6 +33,8 @@ import org.slf4j.MDC;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
+import java.util.function.Supplier;
+
 /**
  * Test whether invoking the SLF4J API causes problems or not.
  * 
@@ -52,16 +54,23 @@ public class InvocationTest {
         Integer i1 = new Integer(1);
         Integer i2 = new Integer(2);
         Integer i3 = new Integer(3);
+        Supplier<String> s1 = () -> "supplier1";
+        Supplier<String> s2 = () -> "supplier2";
         Exception e = new Exception("This is a test exception.");
         Logger logger = LoggerFactory.getLogger("test2");
 
         logger.debug("Hello world 1.");
+        logger.debug(s1);
         logger.debug("Hello world {}", i1);
         logger.debug("val={} val={}", i1, i2);
         logger.debug("val={} val={} val={}", new Object[] { i1, i2, i3 });
 
         logger.debug("Hello world 2", e);
+        logger.debug(e, s2);
         logger.info("Hello world 2.");
+        logger.info(() -> "Hello world supplier 2.");
+        logger.warn(() -> "Hello world supplier 3.");
+        logger.warn(e, () -> "Hello world supplier 3.");
 
         logger.warn("Hello world 3.");
         logger.warn("Hello world 3", e);
@@ -69,15 +78,32 @@ public class InvocationTest {
         logger.error("Hello world 4.");
         logger.error("Hello world {}", new Integer(3));
         logger.error("Hello world 4.", e);
+        logger.error(() -> "Hello world supplier 4.");
+        logger.error(e, () -> "Hello world supplier 4.");
     }
 
     @Test
-    public void testNull() {
+    public void testMsgNull() {
         Logger logger = LoggerFactory.getLogger("testNull");
-        logger.debug(null);
-        logger.info(null);
-        logger.warn(null);
-        logger.error(null);
+        logger.debug((String)null);
+        logger.info((String)null);
+        logger.warn((String)null);
+        logger.error((String)null);
+
+        Exception e = new Exception("This is a test exception.");
+        logger.debug(null, e);
+        logger.info(null, e);
+        logger.warn(null, e);
+        logger.error(null, e);
+    }
+
+    @Test
+    public void testMsgSupNull() {
+        Logger logger = LoggerFactory.getLogger("testNull");
+        logger.debug((Supplier<String>)null);
+        logger.info((Supplier<String>)null);
+        logger.warn((Supplier<String>)null);
+        logger.error((Supplier<String>)null);
 
         Exception e = new Exception("This is a test exception.");
         logger.debug(null, e);
@@ -104,6 +130,16 @@ public class InvocationTest {
         logger.info(blue, "hello {} and {} ", "world", "universe");
         logger.warn(blue, "hello {} and {} ", "world", "universe");
         logger.error(blue, "hello {} and {} ", "world", "universe");
+    }
+
+    @Test
+    public void testMarkerSup() {
+        Logger logger = LoggerFactory.getLogger("testMarker");
+        Marker blue = MarkerFactory.getMarker("BLUE");
+        logger.debug(blue, () -> "hello");
+        logger.info(blue, () -> "hello");
+        logger.warn(blue, () -> "hello");
+        logger.error(blue, () -> "hello");
     }
 
     @Test

--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
@@ -26,12 +26,14 @@ package org.slf4j.simple;
 
 import java.io.PrintStream;
 import java.util.Date;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.event.LoggingEvent;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MarkerIgnoringBase;
 import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.helpers.Util;
 import org.slf4j.spi.LocationAwareLogger;
 
 /**
@@ -372,6 +374,22 @@ public class SimpleLogger extends MarkerIgnoringBase {
     }
 
     /**
+     * For supplied messages, get message and then log.
+     *
+     * @param level
+     * @param msgSup
+     * @param t
+     *            a list of 3 ore more arguments
+     */
+    private void supplyLog(int level, Supplier<String> msgSup, Throwable t) {
+        if (!isLevelEnabled(level)) {
+            return;
+        }
+        final String msg = Util.msgSafeGet(msgSup);
+        log(level, msg, t);
+    }
+
+    /**
      * Is the given log level currently enabled?
      *
      * @param logLevel
@@ -394,6 +412,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
      */
     public void trace(String msg) {
         log(LOG_LEVEL_TRACE, msg, null);
+    }
+
+    @Override
+    public void trace(Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_TRACE, msgSup, null);
     }
 
     /**
@@ -425,6 +448,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
         log(LOG_LEVEL_TRACE, msg, t);
     }
 
+    @Override
+    public void trace(Throwable t, Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_TRACE, msgSup, t);
+    }
+
     /** Are {@code debug} messages currently enabled? */
     public boolean isDebugEnabled() {
         return isLevelEnabled(LOG_LEVEL_DEBUG);
@@ -436,6 +464,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
      */
     public void debug(String msg) {
         log(LOG_LEVEL_DEBUG, msg, null);
+    }
+
+    @Override
+    public void debug(Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_DEBUG, msgSup, null);
     }
 
     /**
@@ -467,6 +500,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
         log(LOG_LEVEL_DEBUG, msg, t);
     }
 
+    @Override
+    public void debug(Throwable t, Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_DEBUG, msgSup, t);
+    }
+
     /** Are {@code info} messages currently enabled? */
     public boolean isInfoEnabled() {
         return isLevelEnabled(LOG_LEVEL_INFO);
@@ -478,6 +516,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
      */
     public void info(String msg) {
         log(LOG_LEVEL_INFO, msg, null);
+    }
+
+    @Override
+    public void info(Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_INFO, msgSup, null);
     }
 
     /**
@@ -509,6 +552,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
         log(LOG_LEVEL_INFO, msg, t);
     }
 
+    @Override
+    public void info(Throwable t, Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_INFO, msgSup, t);
+    }
+
     /** Are {@code warn} messages currently enabled? */
     public boolean isWarnEnabled() {
         return isLevelEnabled(LOG_LEVEL_WARN);
@@ -520,6 +568,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
      */
     public void warn(String msg) {
         log(LOG_LEVEL_WARN, msg, null);
+    }
+
+    @Override
+    public void warn(Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_WARN, msgSup, null);
     }
 
     /**
@@ -551,6 +604,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
         log(LOG_LEVEL_WARN, msg, t);
     }
 
+    @Override
+    public void warn(Throwable t, Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_WARN, msgSup, t);
+    }
+
     /** Are {@code error} messages currently enabled? */
     public boolean isErrorEnabled() {
         return isLevelEnabled(LOG_LEVEL_ERROR);
@@ -562,6 +620,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
      */
     public void error(String msg) {
         log(LOG_LEVEL_ERROR, msg, null);
+    }
+
+    @Override
+    public void error(Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_ERROR, msgSup, null);
     }
 
     /**
@@ -591,6 +654,11 @@ public class SimpleLogger extends MarkerIgnoringBase {
     /** Log a message of level ERROR, including an exception. */
     public void error(String msg, Throwable t) {
         log(LOG_LEVEL_ERROR, msg, t);
+    }
+
+    @Override
+    public void error(Throwable t, Supplier<String> msgSup) {
+        supplyLog(LOG_LEVEL_ERROR, msgSup, t);
     }
 
     public void log(LoggingEvent event) {

--- a/slf4j-simple/src/test/java/org/slf4j/simple/InvocationTest.java
+++ b/slf4j-simple/src/test/java/org/slf4j/simple/InvocationTest.java
@@ -27,6 +27,7 @@ package org.slf4j.simple;
 import static org.junit.Assert.assertNull;
 
 import java.io.PrintStream;
+import java.util.function.Supplier;
 
 import org.junit.After;
 import org.junit.Before;
@@ -69,23 +70,32 @@ public class InvocationTest {
         Integer i1 = new Integer(1);
         Integer i2 = new Integer(2);
         Integer i3 = new Integer(3);
+        Supplier<String> s1 = () -> "supplier1";
+        Supplier<String> s2 = () -> "supplier2";
         Exception e = new Exception("This is a test exception.");
         Logger logger = LoggerFactory.getLogger("test2");
 
         logger.debug("Hello world 1.");
+        logger.debug(s1);
         logger.debug("Hello world {}", i1);
         logger.debug("val={} val={}", i1, i2);
         logger.debug("val={} val={} val={}", new Object[] { i1, i2, i3 });
 
         logger.debug("Hello world 2", e);
+        logger.debug(e, s2);
         logger.info("Hello world 2.");
+        logger.info(() -> "Hello world supplier 2.");
 
         logger.warn("Hello world 3.");
         logger.warn("Hello world 3", e);
+        logger.warn(() -> "Hello world supplier 3.");
+        logger.warn(e, () -> "Hello world supplier 3.");
 
         logger.error("Hello world 4.");
         logger.error("Hello world {}", new Integer(3));
         logger.error("Hello world 4.", e);
+        logger.error(() -> "Hello world supplier 4.");
+        logger.error(e, () -> "Hello world supplier 4.");
     }
 
     // http://jira.qos.ch/browse/SLF4J-69
@@ -99,12 +109,27 @@ public class InvocationTest {
     }
 
     @Test
-    public void testNull() {
+    public void testMsgNull() {
         Logger logger = LoggerFactory.getLogger("testNull");
-        logger.debug(null);
-        logger.info(null);
-        logger.warn(null);
-        logger.error(null);
+        logger.debug((String)null);
+        logger.info((String)null);
+        logger.warn((String)null);
+        logger.error((String)null);
+
+        Exception e = new Exception("This is a test exception.");
+        logger.debug(null, e);
+        logger.info(null, e);
+        logger.warn(null, e);
+        logger.error(null, e);
+    }
+
+    @Test
+    public void testMsgSupNull() {
+        Logger logger = LoggerFactory.getLogger("testNull");
+        logger.debug((Supplier<String>)null);
+        logger.info((Supplier<String>)null);
+        logger.warn((Supplier<String>)null);
+        logger.error((Supplier<String>)null);
 
         Exception e = new Exception("This is a test exception.");
         logger.debug(null, e);
@@ -131,6 +156,16 @@ public class InvocationTest {
         logger.info(blue, "hello {} and {} ", "world", "universe");
         logger.warn(blue, "hello {} and {} ", "world", "universe");
         logger.error(blue, "hello {} and {} ", "world", "universe");
+    }
+
+    @Test
+    public void testMarkerSup() {
+        Logger logger = LoggerFactory.getLogger("testMarker");
+        Marker blue = MarkerFactory.getMarker("BLUE");
+        logger.debug(blue, () -> "hello");
+        logger.info(blue, () -> "hello");
+        logger.warn(blue, () -> "hello");
+        logger.error(blue, () -> "hello");
     }
 
     @Test

--- a/slf4j-site/src/site/pages/faq.html
+++ b/slf4j-site/src/site/pages/faq.html
@@ -1113,7 +1113,15 @@ logger.debug("The new entry is {}.", entry);</pre>
       
       <pre class="prettyprint source">logger.debug("File name is C:\\\\{}.", "file.zip");</pre>
       <p>will print as "File name is C:\file.zip".</p>
-      
+
+      <p><b>Log in functional style</b></p>
+
+      <p>Starting from version 1.8 slf4j supports passing supplier which return a string message</p>
+
+      <pre class="prettyprint source">logger.debug(() -> "Calc" + " heavy " + "message here");</pre>
+
+      <p>The supplier will be invoked only when debug level is turned on</p>
+
     </dd>
     
     <!-- ================================================= -->


### PR DESCRIPTION
The java 8 `Supplier<String>` is added to Logger interface.

Inspired from [kotlin logger](https://github.com/MicroUtils/kotlin-logging)

Some points to pay attention:

1. Could you please look at `org.slf4j.event.EventRecodingLogger#recordEvent(org.slf4j.event.Level, org.slf4j.Marker, java.util.function.Supplier<java.lang.String>, java.lang.Throwable)` method (TODO added). It gets message from supplier without checking log level. This may leads to performance issues. It is unclear (at least for me) how is `org.slf4j.event.SubstituteLoggingEvent` handled. If it is just a class in same jvm so we can add a `.setSupplier` method to it. But if this class is plain dto and it can be serializsed adding supplier method is not a solution. Could you please review this point?
2. `org.slf4j.jul.JDK14LoggerAdapter.java`
At first glace this class should not have any `Supplier` methods. But I changed it in the same way as other classes because minimal jdk version was `1.6`, so `JDK14LoggerAdapter` is not restricted to `1.4`. But I can be wrong. Could you please check this? If adding `Supplier<String>` is not a solution should `JDK14LoggerAdapter` be deleted?
3. I have made javadocs for new methods similar as others, but english is not my native language - could you please check javadocs?

I saw that this project is not being developed intensively and most of PR about comments to javadocs or typos and so on. But this changes about API and if you provide feedback quickly and I quickly make new changes -> new slf4j API will be quickly published :)
