### PR TITLE
add automatic module name to manifest

### DIFF
--- a/jul-to-slf4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/jul-to-slf4j/src/main/resources/META-INF/MANIFEST.MF
@@ -5,3 +5,4 @@ Bundle-Vendor: SLF4J.ORG
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Export-Package: org.slf4j.bridge;version=${parsedVersion.osgiVersion};uses:="org.slf4j,org.slf4j.spi"
 Import-Package: org.slf4j;version=${parsedVersion.osgiVersion},org.slf4j.spi;version=${parsedVersion.osgiVersion}
+Automatic-Module-Name: jul_to_slf4j


### PR DESCRIPTION
adding automatic module name to jul-to-slf4j, fixes https://jira.qos.ch/browse/SLF4J-428