### PR TITLE
Reslove compile error: 'javac: invalid flag: -s', when exist 1.5 tool…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         </executions>
         <configuration>
           <jdkToolchain>
-            <version>[1.5,9)</version>
+            <version>[1.6,9)</version>
           </jdkToolchain>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>


### PR DESCRIPTION
when there is JDK 1.5 configueation in toolchains.xml, the pom.xml configuration can not compile successfully
```
[INFO] -------------------------------------------------------------           
[ERROR] COMPILATION ERROR :                                                       
[INFO] -------------------------------------------------------------                  
[ERROR] javac: invalid flag: -s                                                
Usage: javac <options> <source files> 

```