### PR TITLE
Improve assertions

### DIFF
--- a/integration/src/test/java/org/slf4j/OutputVerifier.java
+++ b/integration/src/test/java/org/slf4j/OutputVerifier.java
@@ -1,5 +1,6 @@
 package org.slf4j;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 public class OutputVerifier {
@@ -7,7 +8,7 @@ public class OutputVerifier {
     static void noProvider(StringPrintStream sps) {
         dump(sps);
         int lineCount = sps.stringList.size();
-        assertTrue("number of lines should be 6 but was " + lineCount, lineCount == 6);
+        assertEquals("number of lines should be 6 but was " + lineCount, 6, lineCount);
 
         // expected output: (version 1.8)
         // SLF4J: No SLF4J providers were found.

--- a/slf4j-api/src/test/java/org/slf4j/helpers/BasicMDCAdapterTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/BasicMDCAdapterTest.java
@@ -26,6 +26,7 @@ package org.slf4j.helpers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
@@ -77,7 +78,7 @@ public class BasicMDCAdapterTest {
         mdc.put("testKey", "testValue");
         Map<String, String> copy = mdc.getCopyOfContextMap();
         mdc.put("anotherTestKey", "anotherTestValue");
-        assertFalse(copy.size() == mdc.getCopyOfContextMap().size());
+        assertNotEquals(copy.size(), mdc.getCopyOfContextMap().size());
     }
 
     @Test

--- a/slf4j-api/src/test/java/org/slf4j/helpers/SubstituteLoggerFactoryTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/SubstituteLoggerFactoryTest.java
@@ -26,7 +26,7 @@ package org.slf4j.helpers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -44,7 +44,7 @@ public class SubstituteLoggerFactoryTest {
         assertNotNull(log);
 
         Logger log2 = factory.getLogger("foo");
-        assertTrue("Loggers with same name must be same", log == log2);
+        assertSame("Loggers with same name must be same", log, log2);
     }
 
     @Test


### PR DESCRIPTION
Replace calls to `assertTrue` or `assertFalse` with assertions that produce more detailed error messages in case the assertions fail.