### PR TITLE
Make slf4j with java.util.ServiceLoader properly work in OSGi by using the Service Loader Mediator Specification

### DIFF
--- a/slf4j-api/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-api/src/main/resources/META-INF/MANIFEST.MF
@@ -9,3 +9,6 @@ Export-Package: org.slf4j;version=${parsedVersion.osgiVersion},
   org.slf4j.helpers;version=${parsedVersion.osgiVersion},
   org.slf4j.event;version=${parsedVersion.osgiVersion}
 Import-Package: org.slf4j.spi;version=${parsedVersion.osgiVersion}
+Require-Capability: osgi.extender;filter:="(osgi.extender=osgi.service
+ loader.processor)",osgi.serviceloader;filter:="(osgi.serviceloader=or
+ g.slf4j.spi.SLF4JServiceProvider)"


### PR DESCRIPTION
As a workaround one can create a fragment for the slf4j-api bundle, e. g. with Gradle using

```groovy
plugins {
    id 'osgi'
}

task slf4jApiFragmentJar(type: Jar) {
    baseName = project.name + '-slf4jApiFragment'
    manifest = osgiManifest {
        name = 'net.kautler.test.osgi.slf4j.api.fragment'
        symbolicName = 'net.kautler.test.osgi.slf4j.api.fragment'
        version = '1.0.0'
        classesDir = temporaryDir
        classpath = files()
        instruction 'Fragment-Host', 'slf4j.api'
        instruction 'Require-Capability', '' +
                'osgi.extender;' +
                'filter:="(osgi.extender=osgi.serviceloader.processor)",' +
                'osgi.serviceloader;' +
                'filter:="(osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider)"'
    }
}
```
