### PR TITLE
Update AppenderSkeleton to support Jalopy implementation

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/AppenderSkeleton.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/AppenderSkeleton.java
@@ -19,6 +19,8 @@ import org.apache.log4j.spi.OptionHandler;
 
 public class AppenderSkeleton implements OptionHandler {
 
+    protected String name; 
+    
     public void setLayout(Layout layout) {
     }
 


### PR DESCRIPTION
Add protected String `name` for backward compatibility with Jalopy 1.5-rc3. 
Jalopy sets the name directly instead using the designated setter method.