### PR TITLE
Introduces MDC.putAllCloseable

### DIFF
--- a/slf4j-nop/src/test/java/org/slf4j/InvocationTest.java
+++ b/slf4j-nop/src/test/java/org/slf4j/InvocationTest.java
@@ -28,6 +28,9 @@ import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Test whether invoking the SLF4J API causes problems or not.
  * 
@@ -116,6 +119,23 @@ public class InvocationTest {
         assertNull(MDC.get("k"));
         closeable.close();
         assertNull(MDC.get("k"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMultiValueMDCCloseable() {
+        Map<String, String> structuredValues = new HashMap<String, String>();
+        structuredValues.put("k1", "v1");
+        structuredValues.put("k2", "v2");
+        structuredValues.put("k3", "v3");
+        MDC.MDCCloseable closeable = MDC.putAllCloseable(structuredValues);
+        assertNull(MDC.get("k1"));
+        assertNull(MDC.get("k2"));
+        assertNull(MDC.get("k3"));
+        closeable.close();
+        assertNull(MDC.get("k1"));
+        assertNull(MDC.get("k2"));
+        assertNull(MDC.get("k3"));
         MDC.clear();
     }
 }


### PR DESCRIPTION
This feature offers the same functionality as `MDC.putCloseable` but for
multiple values. And tries to follow the `put`/`putAll` signatures one can
see on a `Map`. This would be extremely useful for structured logging when
the appender is configured to use MDC values.

The `MDCCloseable` class has been modified in such a way that if a single
value is used the consumed memory profile remains the same.

This change is similar to what has been done when `MDC.putCloseable` has been introduced 5c76844e4cd56292f46cabb3f0cfcc39f50253a2. I'm targetting branch 1.7-maintainance, but I'll be happy to port it to other branches e.g. master or 2.0 if that's necessary.