### PR TITLE
1.7.x support for JPMS

### DIFF
--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -28,5 +28,8 @@
     </dependency>
   </dependencies>
 
- 
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.over.jcl</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/jul-to-slf4j/pom.xml
+++ b/jul-to-slf4j/pom.xml
@@ -30,5 +30,9 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.to.jul</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -36,5 +36,9 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.over.log4j</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/osgi-over-slf4j/pom.xml
+++ b/osgi-over-slf4j/pom.xml
@@ -42,5 +42,8 @@
     </dependency>
   </dependencies>
 
-  
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.over.osgi</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <maven-site-plugin.version>3.3</maven-site-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <javadoc.plugin.version>2.10.4</javadoc.plugin.version>
+    <project.Automatic-Module-Name>org.slf4j.parent</project.Automatic-Module-Name>
   </properties>
 
   <developers>
@@ -167,6 +168,7 @@
         <configuration>
           <archive>
             <manifestEntries>
+              <Automatic-Module-Name>${project.Automatic-Module-Name}</Automatic-Module-Name>
               <Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
               <Bundle-Description>${project.description}</Bundle-Description>
               <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>

--- a/slf4j-android/pom.xml
+++ b/slf4j-android/pom.xml
@@ -31,4 +31,8 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <project.Automatic-Module-Name>org.slf4j.android</project.Automatic-Module-Name>
+    </properties>
+
 </project>

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -117,4 +117,8 @@
     </pluginManagement>
   </build>
 
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.api</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/slf4j-ext/pom.xml
+++ b/slf4j-ext/pom.xml
@@ -83,4 +83,8 @@
 
   </build>
 
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.ext</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/slf4j-jcl/pom.xml
+++ b/slf4j-jcl/pom.xml
@@ -29,4 +29,8 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.jcl</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/slf4j-jdk14/pom.xml
+++ b/slf4j-jdk14/pom.xml
@@ -31,5 +31,8 @@
     </dependency>
   </dependencies>
 
-  
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.jdk14</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/slf4j-log4j12/pom.xml
+++ b/slf4j-log4j12/pom.xml
@@ -37,5 +37,8 @@
     </dependency>
   </dependencies>
 
-  
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.log4j12</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/slf4j-migrator/pom.xml
+++ b/slf4j-migrator/pom.xml
@@ -16,4 +16,8 @@
   <name>SLF4J Migrator</name>
   <description>SLF4J Migrator</description>
 
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.migrator</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/slf4j-nop/pom.xml
+++ b/slf4j-nop/pom.xml
@@ -24,5 +24,8 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.nop</project.Automatic-Module-Name>
+  </properties>
 
 </project>

--- a/slf4j-simple/pom.xml
+++ b/slf4j-simple/pom.xml
@@ -31,5 +31,8 @@
     </dependency>
   </dependencies>
 
-  
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.simple</project.Automatic-Module-Name>
+  </properties>
+
 </project>

--- a/slf4j-site/pom.xml
+++ b/slf4j-site/pom.xml
@@ -65,4 +65,8 @@
     </plugins>
   </build>
 
+  <properties>
+    <project.Automatic-Module-Name>org.slf4j.site</project.Automatic-Module-Name>
+  </properties>
+
 </project>


### PR DESCRIPTION
Can this be merge into the 1.7 release branch and released.

This allows downstream projects to switch to JPMS depending upon an "Automatic-Module-Name", instead of a file based name i.e. slf4j.api.

I've got multiple code branches ready to submit to github projects once this is merged and release.

The only module i really need is the api project, i've guest what you might want other projects to be called and have no problems with them being changed.