### PR TITLE
Change the java indent from 2 to 4

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -31,8 +31,8 @@
           <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
           <option name="KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE" value="true" />
           <indentOptions>
-            <option name="INDENT_SIZE" value="2" />
-            <option name="TAB_SIZE" value="2" />
+            <option name="INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="4" />
           </indentOptions>
         </codeStyleSettings>
         <codeStyleSettings language="XML">


### PR DESCRIPTION
If you start working on SLF4J from IntelliJ IDEA with the current settings all new java code is indented with only 2 spaces in stead of 4. This fixes that.