### PR TITLE
fix when INITIALIZATION_STATE = NOP_FALLBACK no fixSubstituteLoggers(); see:https://jira.qos.ch/browse/SLF4J-469

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -152,10 +152,6 @@ public final class LoggerFactory {
             	PROVIDER.initialize();
             	INITIALIZATION_STATE = SUCCESSFUL_INITIALIZATION;
                 reportActualBinding(providersList);
-                fixSubstituteLoggers();
-                replayEvents();
-                // release all resources in SUBST_FACTORY
-                SUBST_PROVIDER.getSubstituteLoggerFactory().clear();
             } else {
                 INITIALIZATION_STATE = NOP_FALLBACK_INITIALIZATION;
                 Util.report("No SLF4J providers were found.");
@@ -165,6 +161,10 @@ public final class LoggerFactory {
                 Set<URL> staticLoggerBinderPathSet = findPossibleStaticLoggerBinderPathSet();
                 reportIgnoredStaticLoggerBinders(staticLoggerBinderPathSet);
             }
+            fixSubstituteLoggers();
+            replayEvents();
+            // release all resources in SUBST_FACTORY
+            SUBST_PROVIDER.getSubstituteLoggerFactory().clear();
         } catch (Exception e) {
             failedBinding(e);
             throw new IllegalStateException("Unexpected initialization failure", e);

--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -157,7 +157,6 @@ public final class LoggerFactory {
                 Util.report("No SLF4J providers were found.");
                 Util.report("Defaulting to no-operation (NOP) logger implementation");
                 Util.report("See " + NO_PROVIDERS_URL + " for further details.");
-
                 Set<URL> staticLoggerBinderPathSet = findPossibleStaticLoggerBinderPathSet();
                 reportIgnoredStaticLoggerBinders(staticLoggerBinderPathSet);
             }


### PR DESCRIPTION
if INITIALIZATION_STATE == ONGOING_INITIALIZATION
 Logger logger = LoggerFactory.getLogger(Test.class);
assert logger instanceof SubstituteLogger
assert logger._delegate == null  
logger.info("")  -->  into queue

scene1：
new thread change  INITIALIZATION_STATE = SUCCESSFUL_INITIALIZATION
fixSubstituteLoggers();
logger._delegate == realLogger
logger.info("")  -->  realLogger.info("")

scene2：
new thread change  INITIALIZATION_STATE = NOP_FALLBACK_INITIALIZATION
logger._delegate == null always, It will never be fix.
logger.info("")  -->  into queue  forever
