### PR TITLE
Fix logback mdc.html URL

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/MDC.java
+++ b/slf4j-api/src/main/java/org/slf4j/MDC.java
@@ -52,7 +52,7 @@ import org.slf4j.spi.SLF4JServiceProvider;
  * 
  * <p>
  * For more information on MDC please see the <a
- * href="http://logback.qos.ch/manual/mdc.html">chapter on MDC</a> in the
+ * href="https://logback.qos.ch/manual/mdc.html">chapter on MDC</a> in the
  * logback manual.
  * 
  * <p>


### PR DESCRIPTION
I found a strange hotel proxy which returned an error when trying to access the http URL. Accessing the https URL works fine. Since https is typically preferred nowadays anyway, the likeliness of this causing problems for anyone is hopefully rather marginal.