### PR TITLE
Treat a null map as an empty map in MDC.setContextMap

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/MDC.java
+++ b/slf4j-api/src/main/java/org/slf4j/MDC.java
@@ -235,6 +235,9 @@ public class MDC {
         if (mdcAdapter == null) {
             throw new IllegalStateException("MDCAdapter cannot be null. See also " + NULL_MDCA_URL);
         }
+        if (contextMap == null) {
+            contextMap = new HashMap<String, String>();
+        }
         mdcAdapter.setContextMap(contextMap);
     }
 


### PR DESCRIPTION
This is to address https://jira.qos.ch/browse/SLF4J-414 and also https://jira.qos.ch/browse/LOGBACK-944