### PR TITLE
Fix NOP fallback memory leak

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -152,10 +152,6 @@ public final class LoggerFactory {
             	PROVIDER.initialize();
             	INITIALIZATION_STATE = SUCCESSFUL_INITIALIZATION;
                 reportActualBinding(providersList);
-                fixSubstituteLoggers();
-                replayEvents();
-                // release all resources in SUBST_FACTORY
-                SUBST_PROVIDER.getSubstituteLoggerFactory().clear();
             } else {
                 INITIALIZATION_STATE = NOP_FALLBACK_INITIALIZATION;
                 Util.report("No SLF4J providers were found.");
@@ -165,6 +161,10 @@ public final class LoggerFactory {
                 Set<URL> staticLoggerBinderPathSet = findPossibleStaticLoggerBinderPathSet();
                 reportIgnoredStaticLoggerBinders(staticLoggerBinderPathSet);
             }
+            fixSubstituteLoggers();
+            replayEvents();
+            // release all resources in SUBST_FACTORY
+            SUBST_PROVIDER.getSubstituteLoggerFactory().clear();
         } catch (Exception e) {
             failedBinding(e);
             throw new IllegalStateException("Unexpected initialization failure", e);

--- a/slf4j-api/src/test/java/org/slf4j/NoBindingMultithreadedInitializationTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/NoBindingMultithreadedInitializationTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2004-2016 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+
+import org.slf4j.testHarness.MultithreadedInitializationTest;
+
+public class NoBindingMultithreadedInitializationTest extends MultithreadedInitializationTest {
+    final String loggerName = this.getClass().getName();
+
+    @Before
+    public void setup() {
+        System.out.println("THREAD_COUNT=" + THREAD_COUNT);
+        LoggerFactoryFriend.reset();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LoggerFactoryFriend.reset();
+    }
+
+    @Override
+    protected long getRecordedEventCount() {
+        return eventCount.get();
+    }
+}

--- a/slf4j-api/src/test/java/org/slf4j/testHarness/MultithreadedInitializationTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/testHarness/MultithreadedInitializationTest.java
@@ -23,7 +23,7 @@ abstract public class MultithreadedInitializationTest {
 
     private final List<Logger> createdLoggers = Collections.synchronizedList(new ArrayList<Logger>());
 
-    final private AtomicLong eventCount = new AtomicLong(0);
+    final protected AtomicLong eventCount = new AtomicLong(0);
     final private CyclicBarrier barrier = new CyclicBarrier(THREAD_COUNT + 1);
 
     int diff = new Random().nextInt(10000);


### PR DESCRIPTION
Substitute loggers are not getting "fixed" when no SLF4J provider is
found, which means `SUBST_PROVIDER` will add messages to its
`LinkedBlockingQueue` until the process runs out of memory.

`NoBindingMultithreadedInitializationTest` doesn't contain any
assertions of its own because `MultithreadedInitializationTest` already
asserts loggers are fixed in `assertAllSubstLoggersAreFixed`.

https://jira.qos.ch/browse/SLF4J-469