### PR TITLE
Adapter for Platform Logging (JEP 264)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <module>slf4j-simple</module>
     <module>slf4j-nop</module>
     <module>slf4j-jdk14</module>
+    <module>slf4j-jdk-platform-logging</module>
     <module>slf4j-log4j12</module>
     <module>slf4j-ext</module>
     <module>jcl-over-slf4j</module>
@@ -74,7 +75,7 @@
     <module>osgi-over-slf4j</module>
     <module>integration</module>
     <module>slf4j-site</module>
-    <module>slf4j-migrator</module> 
+    <module>slf4j-migrator</module>
   </modules>
 
   <dependencies>

--- a/slf4j-jdk-platform-logging/pom.xml
+++ b/slf4j-jdk-platform-logging/pom.xml
@@ -23,6 +23,19 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.0-alpha0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/slf4j-jdk-platform-logging/pom.xml
+++ b/slf4j-jdk-platform-logging/pom.xml
@@ -25,4 +25,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- target Java 9+ -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/slf4j-jdk-platform-logging/pom.xml
+++ b/slf4j-jdk-platform-logging/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>slf4j-parent</artifactId>
+    <groupId>org.slf4j</groupId>
+    <version>2.0.0-alpha0</version>
+  </parent>
+
+  <artifactId>slf4j-jdk-platform-logging</artifactId>
+  <packaging>jar</packaging>
+  <name>SLF4J JDK Platform Logging Integration</name>
+  <description>Integrated SLF4J with the Platform Logging API added by JEP 264 in Java 9</description>
+
+  <url>http://www.slf4j.org</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/slf4j-jdk-platform-logging/src/main/java/module-info.java
+++ b/slf4j-jdk-platform-logging/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module org.slf4j.jdk {
+    requires org.slf4j;
+    provides java.lang.System.LoggerFinder
+            with org.slf4j.jdk.SLF4JSystemLoggerFinder;
+}

--- a/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/SLF4JSystemLogger.java
+++ b/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/SLF4JSystemLogger.java
@@ -1,0 +1,95 @@
+package org.slf4j.jdk;
+
+import org.slf4j.Logger;
+
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+
+import static java.util.Objects.requireNonNull;
+
+class SLF4JSystemLogger implements System.Logger {
+
+    private final Logger logger;
+
+    public SLF4JSystemLogger(Logger logger) {
+        this.logger = requireNonNull(logger);
+    }
+
+    @Override
+    public String getName() {
+        return logger.getName();
+    }
+
+    @Override
+    public boolean isLoggable(Level level) {
+        switch(level) {
+            case ALL:
+                throw new UnsupportedOperationException();
+            case TRACE:
+                return logger.isTraceEnabled();
+            case DEBUG:
+                return logger.isDebugEnabled();
+            case INFO:
+                return logger.isInfoEnabled();
+            case WARNING:
+                return logger.isWarnEnabled();
+            case ERROR:
+                return logger.isErrorEnabled();
+            case OFF:
+                throw new UnsupportedOperationException();
+        }
+        // TODO
+        return true;
+    }
+
+    @Override
+    public void log(Level level, ResourceBundle bundle, String msg, Throwable thrown) {
+        switch(level) {
+            case ALL:
+                throw new UnsupportedOperationException();
+            case TRACE:
+                logger.trace(msg, thrown);
+                break;
+            case DEBUG:
+                logger.debug(msg, thrown);
+                break;
+            case INFO:
+                logger.info(msg, thrown);
+                break;
+            case WARNING:
+                logger.warn(msg, thrown);
+                break;
+            case ERROR:
+                logger.error(msg, thrown);
+                break;
+            case OFF:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    public void log(Level level, ResourceBundle bundle, String format, Object... params) {
+        switch(level) {
+            case ALL:
+                throw new UnsupportedOperationException();
+            case TRACE:
+                logger.trace(MessageFormat.format(format, params));
+                break;
+            case DEBUG:
+                logger.debug(MessageFormat.format(format, params));
+                break;
+            case INFO:
+                logger.info(MessageFormat.format(format, params));
+                break;
+            case WARNING:
+                logger.warn(MessageFormat.format(format, params));
+                break;
+            case ERROR:
+                logger.error(MessageFormat.format(format, params));
+                break;
+            case OFF:
+                throw new UnsupportedOperationException();
+        }
+    }
+
+}

--- a/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/SLF4JSystemLogger.java
+++ b/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/SLF4JSystemLogger.java
@@ -1,13 +1,18 @@
 package org.slf4j.jdk;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.text.MessageFormat;
 import java.util.ResourceBundle;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Adapts {@link Logger} to {@link System.Logger}.
+ */
 class SLF4JSystemLogger implements System.Logger {
+
+    private static final Logger INTERNAL_LOGGER = LoggerFactory.getLogger(SLF4JSystemLogger.class);
 
     private final Logger logger;
 
@@ -24,7 +29,8 @@ class SLF4JSystemLogger implements System.Logger {
     public boolean isLoggable(Level level) {
         switch(level) {
             case ALL:
-                throw new UnsupportedOperationException();
+                // fall-through intended because `ALL` is loggable if the
+                // lowest level is enabled
             case TRACE:
                 return logger.isTraceEnabled();
             case DEBUG:
@@ -36,59 +42,74 @@ class SLF4JSystemLogger implements System.Logger {
             case ERROR:
                 return logger.isErrorEnabled();
             case OFF:
-                throw new UnsupportedOperationException();
+                // all logging is disabled if the highest level is disabled
+                return !logger.isErrorEnabled();
+            default:
+                INTERNAL_LOGGER.error(
+                        "SLF4J internal error: unknown log level {} passed to `isLoggable` (likely by the JDK).", level);
+                return true;
         }
-        // TODO
-        return true;
     }
 
     @Override
     public void log(Level level, ResourceBundle bundle, String msg, Throwable thrown) {
+        String message = bundle == null ? msg : bundle.getString(msg);
         switch(level) {
             case ALL:
-                throw new UnsupportedOperationException();
+                // fall-through intended because a message is visible on all log levels
+                // if it is logged on the lowest level
             case TRACE:
-                logger.trace(msg, thrown);
+                logger.trace(message, thrown);
                 break;
             case DEBUG:
-                logger.debug(msg, thrown);
+                logger.debug(message, thrown);
                 break;
             case INFO:
-                logger.info(msg, thrown);
+                logger.info(message, thrown);
                 break;
             case WARNING:
-                logger.warn(msg, thrown);
+                logger.warn(message, thrown);
                 break;
             case ERROR:
-                logger.error(msg, thrown);
+                logger.error(message, thrown);
                 break;
             case OFF:
-                throw new UnsupportedOperationException();
+                // don't do anything for a message on level `OFF`
+                break;
+            default:
+                INTERNAL_LOGGER.error(
+                        "SLF4J internal error: unknown log level {} passed to `log` (likely by the JDK).", level);
         }
     }
 
     @Override
     public void log(Level level, ResourceBundle bundle, String format, Object... params) {
+        String message = bundle == null ? format : bundle.getString(format);
         switch(level) {
             case ALL:
-                throw new UnsupportedOperationException();
+                // fall-through intended because a message is visible on all log levels
+                // if it is logged on the lowest level
             case TRACE:
-                logger.trace(MessageFormat.format(format, params));
+                logger.trace(message, params);
                 break;
             case DEBUG:
-                logger.debug(MessageFormat.format(format, params));
+                logger.debug(message, params);
                 break;
             case INFO:
-                logger.info(MessageFormat.format(format, params));
+                logger.info(message, params);
                 break;
             case WARNING:
-                logger.warn(MessageFormat.format(format, params));
+                logger.warn(message, params);
                 break;
             case ERROR:
-                logger.error(MessageFormat.format(format, params));
+                logger.error(message, params);
                 break;
             case OFF:
-                throw new UnsupportedOperationException();
+                // don't do anything for a message on level `OFF`
+                break;
+            default:
+                INTERNAL_LOGGER.error(
+                        "SLF4J internal error: unknown log level {} passed to `log` (likely by the JDK).", level);
         }
     }
 

--- a/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/SLF4JSystemLoggerFinder.java
+++ b/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/SLF4JSystemLoggerFinder.java
@@ -1,0 +1,15 @@
+package org.slf4j.jdk;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SLF4JSystemLoggerFinder extends System.LoggerFinder {
+
+    @Override
+    public System.Logger getLogger(String name, Module module) {
+        // TODO do we need to use the `module`?
+        Logger slf4JLogger = LoggerFactory.getLogger(name);
+        return new SLF4JSystemLogger(slf4JLogger);
+    }
+
+}

--- a/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/SLF4JSystemLoggerFinder.java
+++ b/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/SLF4JSystemLoggerFinder.java
@@ -1,14 +1,33 @@
 package org.slf4j.jdk;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Uses SLF4J's {@link LoggerFactory#getLogger(String)} to get a logger
+ * that is adapted for {@link System.Logger}.
+ */
 public class SLF4JSystemLoggerFinder extends System.LoggerFinder {
 
     @Override
     public System.Logger getLogger(String name, Module module) {
-        // TODO do we need to use the `module`?
-        Logger slf4JLogger = LoggerFactory.getLogger(name);
+        // JEP 264[1], which introduced the Platform Logging API,
+        // contains the following note:
+        //
+        //  > An implementation of the LoggerFinder service should make it
+        //  > possible to distinguish system loggers (used by system classes
+        //  > from the Bootstrap Class Loader (BCL)) and application loggers
+        //  > (created by an application for its own usage). This distinction
+        //  > is important for platform security. The creator of a logger can
+        //  > pass the class or module for which the logger is created to the
+        //  > LoggerFinder so that the LoggerFinder can figure out which kind
+        //  > of logger to return.
+        //
+        // If backends support the distinction support this distinction and
+        // once `LoggerFactory`'s API is updated to forward a module, we
+        // should do that here.
+        //
+        // [1] https://openjdk.java.net/jeps/264
+        var slf4JLogger = LoggerFactory.getLogger(name);
         return new SLF4JSystemLogger(slf4JLogger);
     }
 

--- a/slf4j-jdk-platform-logging/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-jdk-platform-logging/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Implementation-Title: slf4j-ext
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: slf4j.ext
+Bundle-Name: slf4j-jdk-platform-logging
+Bundle-Vendor: SLF4J.ORG
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/slf4j-jdk-platform-logging/src/main/resources/META-INF/services/java.lang.System$LoggerFinder
+++ b/slf4j-jdk-platform-logging/src/main/resources/META-INF/services/java.lang.System$LoggerFinder
@@ -1,0 +1,1 @@
+org.slf4j.jdk.SLF4JSystemLoggerFinder

--- a/slf4j-jdk-platform-logging/src/test/java/org/slf4j/jdk/SLF4JSystemLoggerTest.java
+++ b/slf4j-jdk-platform-logging/src/test/java/org/slf4j/jdk/SLF4JSystemLoggerTest.java
@@ -1,0 +1,77 @@
+package org.slf4j.jdk;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.ServiceLoader;
+
+import static org.junit.Assert.*;
+
+public class SLF4JSystemLoggerTest {
+
+    private static final PrintStream ERROR_OUT = System.err;
+    private static final ByteArrayOutputStream OUTPUT = new ByteArrayOutputStream();
+    private static final PrintStream ERROR_OUT_REPLACEMENT = new PrintStream(OUTPUT);
+
+    @Before
+    public void setUp() {
+        System.setErr(ERROR_OUT_REPLACEMENT);
+    }
+
+    @After
+    public void tearDown() {
+        System.setErr(ERROR_OUT);
+    }
+
+    @Test
+    public void loggerFinderLoadedAsOnlyService() {
+        // this method asserts that there is exactly one `LoggerFinder` and its of the correct type
+        getSLF4JSystemLoggerFinder();
+    }
+
+    @Test
+    public void loggerFinderReturnsLogger() {
+        var logger = getSLF4JSystemLogger();
+        assertNotNull("LoggerFinder must return logger", logger);
+    }
+
+    @Test
+    public void loggerLogsMessage() {
+        var logger = getSLF4JSystemLogger();
+        var message = "Test system logging!";
+        logger.log(System.Logger.Level.INFO, message);
+
+        String output = getOutput();
+
+        assertTrue("Captured output should contain logged message.", output.contains(message));
+    }
+
+    private static System.LoggerFinder getSLF4JSystemLoggerFinder() {
+        var loggerFinders = new ArrayList<System.LoggerFinder>();
+        // this fails when test is executed from the module path
+        // because the module declaration does not declare
+        // `uses System.LoggerFinder`
+        ServiceLoader.load(System.LoggerFinder.class).forEach(loggerFinders::add);
+        assertEquals("There should be exactly one `LoggerFinder`.", 1, loggerFinders.size());
+        var loggerFinder = loggerFinders.get(0);
+        assertEquals("The `LoggerFinder` should be of type `SLF4JSystemLoggerFinder`.",
+                     SLF4JSystemLoggerFinder.class,
+                     loggerFinder.getClass());
+        return loggerFinder;
+    }
+
+    private static System.Logger getSLF4JSystemLogger() {
+        var loggerFinder = getSLF4JSystemLoggerFinder();
+        return loggerFinder.getLogger("TestLogger", SLF4JSystemLoggerTest.class.getModule());
+    }
+
+    private static String getOutput() {
+        ERROR_OUT_REPLACEMENT.flush();
+        return OUTPUT.toString();
+    }
+
+}

--- a/slf4j-jdk-platform-logging/src/test/java/org/slf4j/jdk/SLF4JSystemLoggerTest.java
+++ b/slf4j-jdk-platform-logging/src/test/java/org/slf4j/jdk/SLF4JSystemLoggerTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.ServiceLoader;
 
 import static org.junit.Assert.*;
@@ -28,8 +27,8 @@ public class SLF4JSystemLoggerTest {
     }
 
     @Test
-    public void loggerFinderLoadedAsOnlyService() {
-        // this method asserts that there is exactly one `LoggerFinder` and its of the correct type
+    public void loggerFinderLoadedAsService() {
+        // this method asserts that a `LoggerFinder` of the correct type was loaded
         getSLF4JSystemLoggerFinder();
     }
 
@@ -51,17 +50,14 @@ public class SLF4JSystemLoggerTest {
     }
 
     private static System.LoggerFinder getSLF4JSystemLoggerFinder() {
-        var loggerFinders = new ArrayList<System.LoggerFinder>();
         // this fails when test is executed from the module path
         // because the module declaration does not declare
         // `uses System.LoggerFinder`
-        ServiceLoader.load(System.LoggerFinder.class).forEach(loggerFinders::add);
-        assertEquals("There should be exactly one `LoggerFinder`.", 1, loggerFinders.size());
-        var loggerFinder = loggerFinders.get(0);
-        assertEquals("The `LoggerFinder` should be of type `SLF4JSystemLoggerFinder`.",
-                     SLF4JSystemLoggerFinder.class,
-                     loggerFinder.getClass());
-        return loggerFinder;
+        return ServiceLoader.load(System.LoggerFinder.class).stream()
+                .filter(finderProvider -> SLF4JSystemLoggerFinder.class.isAssignableFrom(finderProvider.type()))
+                .findAny()
+                .map(ServiceLoader.Provider::get)
+                .orElseThrow();
     }
 
     private static System.Logger getSLF4JSystemLogger() {


### PR DESCRIPTION
[JEP 264: Platform Logging API and Service](http://openjdk.java.net/jeps/264) introduced a mechanism to Java 9 that allows third-party logging frameworks to handle JDK log messages (like those Swing produces; not JVM messages). This PR adapts `org.slf4j.LoggerFactory` and `org.slf4j.Logger` to the new interfaces `java.lang.System.LoggerFinder` and `java.lang.System.Logger` and - following [the `ServiceLoader` documentation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ServiceLoader.html) - creates a service provider-configuration file and a module declaration, so the integration works from class path and module path.

Closes [SLF4J-442](https://jira.qos.ch/browse/SLF4J-442).