### PR TITLE
Minor change to avoid getLevel to return null

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
@@ -116,12 +116,12 @@ public class Category {
 
     /**
      * Returns the assigned {@link Level}, if any, for this Category. This
-     * implementation always returns null.
+     * implementation always returns the effective level.
      *
-     * @return Level - the assigned Level, can be <code>null</code>.
+     * @return Level - the assigned Level, can not be <code>null</code>.
      */
     final public Level getLevel() {
-        return this.getEffectiveLevel(); // ajuste para compatilizar esta bridge com um projeto que nao espera receber nulo.
+        return this.getEffectiveLevel(); 
     }
 
     /**

--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/Category.java
@@ -39,6 +39,7 @@ import java.util.Enumeration;
  *
  * @author S&eacute;bastien Pennec
  * @author Ceki G&uuml;lc&uuml;
+ * @author Elifazio Bernardes da Silva
  */
 @SuppressWarnings("rawtypes")
 public class Category {
@@ -120,7 +121,7 @@ public class Category {
      * @return Level - the assigned Level, can be <code>null</code>.
      */
     final public Level getLevel() {
-        return null;
+        return this.getEffectiveLevel(); // ajuste para compatilizar esta bridge com um projeto que nao espera receber nulo.
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.slf4j</groupId>
   <artifactId>slf4j-parent</artifactId>
-  <version>1.7.30</version>
+  <version>1.7.31</version>
 
   <packaging>pom</packaging>
   <name>SLF4J</name>


### PR DESCRIPTION
I have got a legacy project that access log4j api directly and does not expect to receive null on getLevel method. So I made a little change on version 1.7.30 to return effective level on getLevel, this avoid nullpointer on the legacy project.