### PR TITLE
[SLF4J-168] Use Map<String, Object> for MDC

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/NDC.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/NDC.java
@@ -54,7 +54,7 @@ public class NDC {
     public static int getDepth() {
         int i = 0;
         while (true) {
-            String val = MDC.get(PREFIX + i);
+            Object val = MDC.get(PREFIX + i);
             if (val != null) {
                 i++;
             } else {
@@ -64,26 +64,26 @@ public class NDC {
         return i;
     }
 
-    public static String pop() {
+    public static Object pop() {
         int next = getDepth();
         if (next == 0) {
             return "";
         }
         int last = next - 1;
         String key = PREFIX + last;
-        String val = MDC.get(key);
+        Object val = MDC.get(key);
         MDC.remove(key);
         return val;
     }
 
-    public static String peek() {
+    public static Object peek() {
         int next = getDepth();
         if (next == 0) {
             return "";
         }
         int last = next - 1;
         String key = PREFIX + last;
-        String val = MDC.get(key);
+        Object val = MDC.get(key);
         return val;
     }
 

--- a/log4j-over-slf4j/src/test/java/org/apache/log4j/test/NDCTest.java
+++ b/log4j-over-slf4j/src/test/java/org/apache/log4j/test/NDCTest.java
@@ -50,14 +50,14 @@ public class NDCTest {
     @Test
     public void testSmoke() {
         NDC.push("a");
-        String back = NDC.pop();
+        Object back = NDC.pop();
         assertEquals("a", back);
     }
 
     @Test
     public void testPop() {
         NDC.push("peek");
-        String back = NDC.peek();
+        Object back = NDC.peek();
         assertEquals("peek", back);
     }
 

--- a/slf4j-api/src/main/java/org/slf4j/MDC.java
+++ b/slf4j-api/src/main/java/org/slf4j/MDC.java
@@ -111,7 +111,7 @@ public class MDC {
      * @throws IllegalArgumentException
      *           in case the "key" parameter is null
      */
-    public static void put(String key, String val) throws IllegalArgumentException {
+    public static void put(String key, Object val) throws IllegalArgumentException {
         if (key == null) {
             throw new IllegalArgumentException("key parameter cannot be null");
         }
@@ -149,7 +149,7 @@ public class MDC {
      * @throws IllegalArgumentException
      *           in case the "key" parameter is null
      */
-    public static MDCCloseable putCloseable(String key, String val) throws IllegalArgumentException {
+    public static MDCCloseable putCloseable(String key, Object val) throws IllegalArgumentException {
         put(key, val);
         return new MDCCloseable(key);
     }
@@ -162,11 +162,11 @@ public class MDC {
      * This method delegates all work to the MDC of the underlying logging system.
      *
      * @param key a key
-     * @return the string value identified by the <code>key</code> parameter.
+     * @return the object identified by the <code>key</code> parameter.
      * @throws IllegalArgumentException
      *           in case the "key" parameter is null
      */
-    public static String get(String key) throws IllegalArgumentException {
+    public static Object get(String key) throws IllegalArgumentException {
         if (key == null) {
             throw new IllegalArgumentException("key parameter cannot be null");
         }
@@ -209,13 +209,13 @@ public class MDC {
     }
 
     /**
-     * Return a copy of the current thread's context map, with keys and values of
-     * type String. Returned value may be null.
+     * Return a copy of the current thread's context map, with keys of type String
+     * and values of type Object. Returned value may be null.
      * 
      * @return A copy of the current thread's context map. May be null.
      * @since 1.5.1
      */
-    public static Map<String, String> getCopyOfContextMap() {
+    public static Map<String, Object> getCopyOfContextMap() {
         if (mdcAdapter == null) {
             throw new IllegalStateException("MDCAdapter cannot be null. See also " + NULL_MDCA_URL);
         }
@@ -225,13 +225,13 @@ public class MDC {
     /**
      * Set the current thread's context map by first clearing any existing map and
      * then copying the map passed as parameter. The context map passed as
-     * parameter must only contain keys and values of type String.
+     * parameter must only contain keys of type String and values of type Object.
      * 
      * @param contextMap
-     *          must contain only keys and values of type String
+     *          must contain only keys of type String and values of type Object
      * @since 1.5.1
      */
-    public static void setContextMap(Map<String, String> contextMap) {
+    public static void setContextMap(Map<String, Object> contextMap) {
         if (mdcAdapter == null) {
             throw new IllegalStateException("MDCAdapter cannot be null. See also " + NULL_MDCA_URL);
         }

--- a/slf4j-api/src/main/java/org/slf4j/helpers/BasicMDCAdapter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/BasicMDCAdapter.java
@@ -44,13 +44,13 @@ import java.util.Map;
  */
 public class BasicMDCAdapter implements MDCAdapter {
 
-    private InheritableThreadLocal<Map<String, String>> inheritableThreadLocal = new InheritableThreadLocal<Map<String, String>>() {
+    private InheritableThreadLocal<Map<String, Object>> inheritableThreadLocal = new InheritableThreadLocal<Map<String, Object>>() {
         @Override
-        protected Map<String, String> childValue(Map<String, String> parentValue) {
+        protected Map<String, Object> childValue(Map<String, Object> parentValue) {
             if (parentValue == null) {
                 return null;
             }
-            return new HashMap<String, String>(parentValue);
+            return new HashMap<>(parentValue);
         }
     };
 
@@ -66,13 +66,13 @@ public class BasicMDCAdapter implements MDCAdapter {
      * @throws IllegalArgumentException
      *                 in case the "key" parameter is null
      */
-    public void put(String key, String val) {
+    public void put(String key, Object val) {
         if (key == null) {
             throw new IllegalArgumentException("key cannot be null");
         }
-        Map<String, String> map = inheritableThreadLocal.get();
+        Map<String, Object> map = inheritableThreadLocal.get();
         if (map == null) {
-            map = new HashMap<String, String>();
+            map = new HashMap<>();
             inheritableThreadLocal.set(map);
         }
         map.put(key, val);
@@ -81,8 +81,8 @@ public class BasicMDCAdapter implements MDCAdapter {
     /**
      * Get the context identified by the <code>key</code> parameter.
      */
-    public String get(String key) {
-        Map<String, String> map = inheritableThreadLocal.get();
+    public Object get(String key) {
+        Map<String, Object> map = inheritableThreadLocal.get();
         if ((map != null) && (key != null)) {
             return map.get(key);
         } else {
@@ -94,7 +94,7 @@ public class BasicMDCAdapter implements MDCAdapter {
      * Remove the the context identified by the <code>key</code> parameter.
      */
     public void remove(String key) {
-        Map<String, String> map = inheritableThreadLocal.get();
+        Map<String, Object> map = inheritableThreadLocal.get();
         if (map != null) {
             map.remove(key);
         }
@@ -104,7 +104,7 @@ public class BasicMDCAdapter implements MDCAdapter {
      * Clear all entries in the MDC.
      */
     public void clear() {
-        Map<String, String> map = inheritableThreadLocal.get();
+        Map<String, Object> map = inheritableThreadLocal.get();
         if (map != null) {
             map.clear();
             inheritableThreadLocal.remove();
@@ -118,7 +118,7 @@ public class BasicMDCAdapter implements MDCAdapter {
      * @return the keys in the MDC
      */
     public Set<String> getKeys() {
-        Map<String, String> map = inheritableThreadLocal.get();
+        Map<String, Object> map = inheritableThreadLocal.get();
         if (map != null) {
             return map.keySet();
         } else {
@@ -131,16 +131,16 @@ public class BasicMDCAdapter implements MDCAdapter {
      * Returned value may be null.
      *
      */
-    public Map<String, String> getCopyOfContextMap() {
-        Map<String, String> oldMap = inheritableThreadLocal.get();
+    public Map<String, Object> getCopyOfContextMap() {
+        Map<String, Object> oldMap = inheritableThreadLocal.get();
         if (oldMap != null) {
-            return new HashMap<String, String>(oldMap);
+            return new HashMap<>(oldMap);
         } else {
             return null;
         }
     }
 
-    public void setContextMap(Map<String, String> contextMap) {
-        inheritableThreadLocal.set(new HashMap<String, String>(contextMap));
+    public void setContextMap(Map<String, Object> contextMap) {
+        inheritableThreadLocal.set(new HashMap<>(contextMap));
     }
 }

--- a/slf4j-api/src/main/java/org/slf4j/helpers/NOPMDCAdapter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/NOPMDCAdapter.java
@@ -42,21 +42,21 @@ public class NOPMDCAdapter implements MDCAdapter {
     public void clear() {
     }
 
-    public String get(String key) {
+    public Object get(String key) {
         return null;
     }
 
-    public void put(String key, String val) {
+    public void put(String key, Object val) {
     }
 
     public void remove(String key) {
     }
 
-    public Map<String, String> getCopyOfContextMap() {
+    public Map<String, Object> getCopyOfContextMap() {
         return null;
     }
 
-    public void setContextMap(Map<String, String> contextMap) {
+    public void setContextMap(Map<String, Object> contextMap) {
         // NOP
     }
 

--- a/slf4j-api/src/main/java/org/slf4j/spi/MDCAdapter.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/MDCAdapter.java
@@ -44,7 +44,7 @@ public interface MDCAdapter {
      * <p>If the current thread does not have a context map it is created as a side
      * effect of this call.
      */
-    public void put(String key, String val);
+    public void put(String key, Object val);
 
     /**
      * Get the context identified by the <code>key</code> parameter.
@@ -52,7 +52,7 @@ public interface MDCAdapter {
      * 
      * @return the string value identified by the <code>key</code> parameter.
      */
-    public String get(String key);
+    public Object get(String key);
 
     /**
      * Remove the the context identified by the <code>key</code> parameter. 
@@ -76,7 +76,7 @@ public interface MDCAdapter {
      * @return A copy of the current thread's context map. May be null.
      * @since 1.5.1
      */
-    public Map<String, String> getCopyOfContextMap();
+    public Map<String, Object> getCopyOfContextMap();
 
     /**
      * Set the current thread's context map by first clearing any existing 
@@ -87,5 +87,5 @@ public interface MDCAdapter {
      * 
      * @since 1.5.1
      */
-    public void setContextMap(Map<String, String> contextMap);
+    public void setContextMap(Map<String, Object> contextMap);
 }

--- a/slf4j-api/src/test/java/org/slf4j/helpers/BasicMDCAdapterTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/BasicMDCAdapterTest.java
@@ -75,7 +75,7 @@ public class BasicMDCAdapterTest {
     @Test
     public void testGetCopyOfContextMapFromMDC() {
         mdc.put("testKey", "testValue");
-        Map<String, String> copy = mdc.getCopyOfContextMap();
+        Map<String, Object> copy = mdc.getCopyOfContextMap();
         mdc.put("anotherTestKey", "anotherTestValue");
         assertFalse(copy.size() == mdc.getCopyOfContextMap().size());
     }

--- a/slf4j-ext/src/main/java/org/slf4j/NDC.java
+++ b/slf4j-ext/src/main/java/org/slf4j/NDC.java
@@ -24,15 +24,13 @@
  */
 package org.slf4j;
 
-import org.slf4j.MDC;
-
 public class NDC {
     public final static String PREFIX = "NDC";
 
     private static int size() {
         int i = 0;
         while (true) {
-            String val = MDC.get(PREFIX + i);
+            Object val = MDC.get(PREFIX + i);
             if (val != null) {
                 i++;
             } else {
@@ -47,14 +45,14 @@ public class NDC {
         MDC.put(PREFIX + next, val);
     }
 
-    public static String pop() {
+    public static Object pop() {
         int next = size();
         if (next == 0) {
             return "";
         }
         int last = next - 1;
         String key = PREFIX + last;
-        String val = MDC.get(key);
+        Object val = MDC.get(key);
         MDC.remove(key);
         return val;
     }

--- a/slf4j-ext/src/test/java/org/slf4j/NDCTest.java
+++ b/slf4j-ext/src/test/java/org/slf4j/NDCTest.java
@@ -44,7 +44,7 @@ public class NDCTest {
     @Test
     public void testSmoke() {
         NDC.push("a");
-        String result = NDC.pop();
+        Object result = NDC.pop();
         assertEquals("a", result);
     }
 
@@ -52,8 +52,8 @@ public class NDCTest {
     public void testSmoke2() {
         NDC.push("a");
         NDC.push("b");
-        String result1 = NDC.pop();
-        String result0 = NDC.pop();
+        Object result1 = NDC.pop();
+        Object result0 = NDC.pop();
         assertEquals("b", result1);
         assertEquals("a", result0);
     }

--- a/slf4j-log4j12/src/main/java/org/slf4j/log4j12/Log4jMDCAdapter.java
+++ b/slf4j-log4j12/src/main/java/org/slf4j/log4j12/Log4jMDCAdapter.java
@@ -47,7 +47,7 @@ public class Log4jMDCAdapter implements MDCAdapter {
         }
     }
 
-    public String get(String key) {
+    public Object get(String key) {
         return (String) org.apache.log4j.MDC.get(key);
     }
 
@@ -63,7 +63,7 @@ public class Log4jMDCAdapter implements MDCAdapter {
      * @throws IllegalArgumentException
      *             in case the "key" or <b>"val"</b> parameter is null
      */
-    public void put(String key, String val) {
+    public void put(String key, Object val) {
         org.apache.log4j.MDC.put(key, val);
     }
 

--- a/slf4j-log4j12/src/test/java/org/slf4j/log4j12/InvocationTest.java
+++ b/slf4j-log4j12/src/test/java/org/slf4j/log4j12/InvocationTest.java
@@ -175,7 +175,7 @@ public class InvocationTest {
 
     @Test
     public void testMDCContextMapValues() {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, Object> map = new HashMap<>();
         map.put("ka", "va");
         map.put("kb", "vb");
 

--- a/slf4j-nop/src/main/java/org/slf4j/nop/NOPMDCAdapter.java
+++ b/slf4j-nop/src/main/java/org/slf4j/nop/NOPMDCAdapter.java
@@ -42,21 +42,21 @@ public class NOPMDCAdapter implements MDCAdapter {
     public void clear() {
     }
 
-    public String get(String key) {
+    public Object get(String key) {
         return null;
     }
 
-    public void put(String key, String val) {
+    public void put(String key, Object val) {
     }
 
     public void remove(String key) {
     }
 
-    public Map<String, String> getCopyOfContextMap() {
+    public Map<String, Object> getCopyOfContextMap() {
         return null;
     }
 
-    public void setContextMap(Map<String, String> contextMap) {
+    public void setContextMap(Map<String, Object> contextMap) {
         // NOP
     }
 


### PR DESCRIPTION
Related JIRA ticket: [SLF4J-168](https://jira.qos.ch/projects/SLF4J/issues/SLF4J-168)

For cloud development, the ability to log numeric values in JSON logs is essential to be able to do aggregations for statistics on logged numeric values in tools like Kibana. MDC currently internally uses `Map<String, String>`, which prevents that and thus hinders its adoption for this use case.

This PR changes MDC to use `Map<String, Object>` to enable the described use case, for consideration for inclusion in SLF4J 2.x.