### PR TITLE
[SLF4J-452] Make MessageFormatter escaping backslashes correctly

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
@@ -227,38 +227,24 @@ final public class MessageFormatter {
         return new FormattingTuple(sbuf.toString(), argArray, throwable);
     }
 
-    final static int countEscapeChars(String messagePattern, int delimeterStartIndex) {
+    /**
+     * Count how many escape chars exist before the delimiter.
+     * @param messagePattern The message pattern to count escape chars.
+     * @param delimiterStartIndex The 0-based index of the target delimiter.
+     * @return the number of escape chars
+     */
+    final static int countEscapeChars(String messagePattern, int delimiterStartIndex) {
         int count = 0;
-        int index = delimeterStartIndex - 1;
+        int index = delimiterStartIndex - 1;
         while (0 <= index) {
-            if (messagePattern.charAt(index) != ESCAPE_CHAR) {
+            char potentialEscape = messagePattern.charAt(index);
+            if (potentialEscape != ESCAPE_CHAR) {
                 break;
             }
             ++count;
             --index;
         }
         return count;
-    }
-
-    final static boolean isEscapedDelimeter(String messagePattern, int delimeterStartIndex) {
-
-        if (delimeterStartIndex == 0) {
-            return false;
-        }
-        char potentialEscape = messagePattern.charAt(delimeterStartIndex - 1);
-        if (potentialEscape == ESCAPE_CHAR) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    final static boolean isDoubleEscaped(String messagePattern, int delimeterStartIndex) {
-        if (delimeterStartIndex >= 2 && messagePattern.charAt(delimeterStartIndex - 2) == ESCAPE_CHAR) {
-            return true;
-        } else {
-            return false;
-        }
     }
 
     // special treatment of array values was suggested by 'lizongbo'

--- a/slf4j-api/src/test/java/org/slf4j/helpers/MessageFormatterTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/MessageFormatterTest.java
@@ -340,4 +340,17 @@ public class MessageFormatterTest {
         assertEquals(t, ft.getThrowable());
 
     }
+
+    @Test
+    public void testCountEscapeChars() {
+        assertThat(
+            MessageFormatter.countEscapeChars("{}", 0),
+            is(0));
+        assertThat(
+            MessageFormatter.countEscapeChars("\\{}", 1),
+            is(1));
+        assertThat(
+            MessageFormatter.countEscapeChars("\\\\{}", 2),
+            is(2));
+    }
 }

--- a/slf4j-api/src/test/java/org/slf4j/helpers/MessageFormatterTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/helpers/MessageFormatterTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 /**
@@ -108,6 +109,18 @@ public class MessageFormatterTest {
         // escaping the escape character
         result = MessageFormatter.format("File name is C:\\\\{}.", "App folder.zip").getMessage();
         assertEquals("File name is C:\\App folder.zip.", result);
+
+        // Triple escaped
+        result = MessageFormatter.format("\\\\\\{}Escaped", i3).getMessage();
+        assertEquals("\\{}Escaped", result);
+
+        // Quadruple escaped
+        result = MessageFormatter.format("\\\\\\\\{}Escaped", i3).getMessage();
+        assertEquals("\\\\3Escaped", result);
+
+        // Pentaple escaped
+        result = MessageFormatter.format("\\\\\\\\\\{}Escaped", i3).getMessage();
+        assertEquals("\\\\{}Escaped", result);
     }
 
     @Test


### PR DESCRIPTION
Hi! 👋  I'm an author of [findbugs-slf4j](https://github.com/KengoTODA/findbugs-slf4j/) and a big fan of SLF4J.
Thanks for sharing such a great library! SLF4J actually helps both of my hobbies and business. 🤝 


This PR will solve [SLF4J-452](https://jira.qos.ch/browse/SLF4J-452) by counting backslashes before the delimiter.
Hope that it helps us to release 1.8.0-beta5, that has [two remaining issues to resolve](https://jira.qos.ch/browse/SLF4J-452?jql=project%20%3D%20SLF4J%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20fixVersion%20%3D%201.8.0-beta5).

@ceki <strike>Sorry but I cannot find which branch is for 1.8.0 release, so I'm using `master` that is probably for 2.0.0 release.
If necessary, I'll propose another PR to backport for 1.8.0.</strike>
[Confirmed that 1.8.x will not be released anymore](http://mailman.qos.ch/pipermail/slf4j-user/2020-August/001748.html) so I think this PR is enough. Thank you! 😃 