### PR TITLE
[SLF4J-450] Allow binding to be explicitly specified

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -25,9 +25,12 @@
 package org.slf4j;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -79,6 +82,10 @@ public final class LoggerFactory {
     static final String UNSUCCESSFUL_INIT_URL = CODES_PREFIX + "#unsuccessfulInit";
     static final String UNSUCCESSFUL_INIT_MSG = "org.slf4j.LoggerFactory in failed state. Original exception was thrown EARLIER. See also "
                     + UNSUCCESSFUL_INIT_URL;
+    /**
+     * @see <a href="https://jira.qos.ch/browse/SLF4J-450">SLF4J-450</a>
+     */
+    static final String BINDING_PROP = "slf4j.binding";
 
     static final int UNINITIALIZED = 0;
     static final int ONGOING_INITIALIZATION = 1;
@@ -143,6 +150,16 @@ public final class LoggerFactory {
     }
 
     private final static void bind() {
+        String explicitlySpecified = System.getProperty(BINDING_PROP);
+        PROVIDER = loadExplicitlySpecified(explicitlySpecified);
+        if (null != PROVIDER) {
+            PROVIDER.initialize();
+            INITIALIZATION_STATE = SUCCESSFUL_INITIALIZATION;
+            reportActualBinding(Collections.singletonList(PROVIDER));
+            postBindCleanUp();
+            return;
+        }
+
         try {
             List<SLF4JServiceProvider> providersList = findServiceProviders();
             reportMultipleBindingAmbiguity(providersList);
@@ -165,6 +182,27 @@ public final class LoggerFactory {
         } catch (Exception e) {
             failedBinding(e);
             throw new IllegalStateException("Unexpected initialization failure", e);
+        }
+    }
+
+    static SLF4JServiceProvider loadExplicitlySpecified(String explicitlySpecified) {
+        if (null == explicitlySpecified) {
+            return null;
+        }
+        try {
+            Class<?> clazz = Class.forName(explicitlySpecified);
+            Constructor<?> constructor = clazz.getConstructor();
+            constructor.setAccessible(true);
+            Object provider = constructor.newInstance();
+            return (SLF4JServiceProvider) provider;
+        } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            String message = String.format("Failed to instantiate the specified SLF4JServiceProvider (%s)", explicitlySpecified);
+            Util.report(message, e);
+            return null;
+        } catch (ClassCastException e) {
+            String message = String.format("Specified SLF4JServiceProvider (%s) does not implement SLF4JServiceProvider interface", explicitlySpecified);
+            Util.report(message, e);
+            return null;
         }
     }
 

--- a/slf4j-api/src/test/java/org/slf4j/LoggerFactoryTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/LoggerFactoryTest.java
@@ -1,0 +1,85 @@
+package org.slf4j;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.spi.MDCAdapter;
+import org.slf4j.spi.SLF4JServiceProvider;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class LoggerFactoryTest {
+    private PrintStream rawSyserr;
+    private ByteArrayOutputStream mockedSyserr;
+
+    @Before
+    public void setUp() {
+        rawSyserr = System.err;
+        mockedSyserr = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(mockedSyserr));
+    }
+
+    @After
+    public void cleanUp() {
+        System.setErr(rawSyserr);
+    }
+
+    @Test
+    public void testExplicitlySpecified() {
+        assertThat(LoggerFactory.loadExplicitlySpecified("org.slf4j.LoggerFactoryTest$TestingProvider"),
+                   is(instanceOf(TestingProvider.class)));
+    }
+
+    @Test
+    public void testExplicitlySpecifiedNull() {
+        assertNull(LoggerFactory.loadExplicitlySpecified(null));
+    }
+
+    @Test
+    public void testExplicitlySpecifyMissingServiceProvider() {
+        assertNull(LoggerFactory.loadExplicitlySpecified("com.example.ServiceProvider"));
+        assertThat(mockedSyserr.toString(),
+                   containsString("Failed to instantiate the specified SLF4JServiceProvider (com.example.ServiceProvider)"));
+    }
+
+    @Test
+    public void testExplicitlySpecifyNonServiceProvider() {
+        assertNull(LoggerFactory.loadExplicitlySpecified("java.lang.String"));
+        assertThat(mockedSyserr.toString(),
+                   containsString("Specified SLF4JServiceProvider (java.lang.String) does not implement SLF4JServiceProvider interface"));
+    }
+
+    public static class TestingProvider implements SLF4JServiceProvider {
+        @Override
+        public ILoggerFactory getLoggerFactory() {
+            return null;
+        }
+
+        @Override
+        public IMarkerFactory getMarkerFactory() {
+            return null;
+        }
+
+        @Override
+        public MDCAdapter getMDCAdapter() {
+            return null;
+        }
+
+        @Override
+        public String getRequesteApiVersion() {
+            return null;
+        }
+
+        @Override
+        public void initialize() {
+
+        }
+    }
+}

--- a/slf4j-site/src/site/pages/faq.html
+++ b/slf4j-site/src/site/pages/faq.html
@@ -427,7 +427,9 @@
         
       </table>
 
-      
+      <p>It is also possible to specify the binding explicitly by the <code>slf4j.binding</code> system property.
+      It probably shortens the initialization phase, so could be valuable for systems which are sensitive to cold-start times like FaaS.
+      </p>
     </dd>
 
     


### PR DESCRIPTION
According to [my micro benchmark](https://gist.github.com/KengoTODA/24298b154c3a1be2e1ce7d256be2b69f), this change shortens SLF4J initialization about 20 [ms]. 

Come to and discuss at [SLF4J-450](https://jira.qos.ch/browse/SLF4J-450) if you have more data or cases in your usage.