### PR TITLE
SLF4J-186: TimeInstrumentStatus should be public

### DIFF
--- a/slf4j-ext/src/main/java/org/slf4j/profiler/TimeInstrumentStatus.java
+++ b/slf4j-ext/src/main/java/org/slf4j/profiler/TimeInstrumentStatus.java
@@ -35,6 +35,6 @@ package org.slf4j.profiler;
  * @author Ceki G&uuml;lc&uuml;
  *
  */
-enum TimeInstrumentStatus {
+public enum TimeInstrumentStatus {
     STARTED, STOPPED;
 }


### PR DESCRIPTION
The `TimeInstrument` interface is already public, so I assume that the issue is still valid and need to be fixed.

fixes https://jira.qos.ch/projects/SLF4J/issues/SLF4J-186