### PR TITLE
[SLF4J-497] Avoid creating a String of message Object when log level is disabled

### DIFF
--- a/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/SLF4JLocationAwareLog.java
+++ b/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/SLF4JLocationAwareLog.java
@@ -104,7 +104,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the message to log. Converted to {@link String}
      */
     public void trace(Object message) {
-        logger.log(null, FQCN, LocationAwareLogger.TRACE_INT, String.valueOf(message), null, null);
+        if (isTraceEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.TRACE_INT, String.valueOf(message), null, null);
+        }
     }
 
     /**
@@ -117,7 +119,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the exception to log
      */
     public void trace(Object message, Throwable t) {
-        logger.log(null, FQCN, LocationAwareLogger.TRACE_INT, String.valueOf(message), null, t);
+        if (isTraceEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.TRACE_INT, String.valueOf(message), null, t);
+        }
     }
 
     /**
@@ -128,7 +132,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the message to log. Converted to {@link String}
      */
     public void debug(Object message) {
-        logger.log(null, FQCN, LocationAwareLogger.DEBUG_INT, String.valueOf(message), null, null);
+        if (isDebugEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.DEBUG_INT, String.valueOf(message), null, null);
+        }
     }
 
     /**
@@ -141,7 +147,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the exception to log
      */
     public void debug(Object message, Throwable t) {
-        logger.log(null, FQCN, LocationAwareLogger.DEBUG_INT, String.valueOf(message), null, t);
+        if (isDebugEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.DEBUG_INT, String.valueOf(message), null, t);
+        }
     }
 
     /**
@@ -152,7 +160,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the message to log. Converted to {@link String}
      */
     public void info(Object message) {
-        logger.log(null, FQCN, LocationAwareLogger.INFO_INT, String.valueOf(message), null, null);
+        if (isInfoEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.INFO_INT, String.valueOf(message), null, null);
+        }
     }
 
     /**
@@ -165,7 +175,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the exception to log
      */
     public void info(Object message, Throwable t) {
-        logger.log(null, FQCN, LocationAwareLogger.INFO_INT, String.valueOf(message), null, t);
+        if (isInfoEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.INFO_INT, String.valueOf(message), null, t);
+        }
     }
 
     /**
@@ -176,7 +188,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the message to log. Converted to {@link String}
      */
     public void warn(Object message) {
-        logger.log(null, FQCN, LocationAwareLogger.WARN_INT, String.valueOf(message), null, null);
+        if (isWarnEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.WARN_INT, String.valueOf(message), null, null);
+        }
     }
 
     /**
@@ -189,7 +203,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the exception to log
      */
     public void warn(Object message, Throwable t) {
-        logger.log(null, FQCN, LocationAwareLogger.WARN_INT, String.valueOf(message), null, t);
+        if (isWarnEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.WARN_INT, String.valueOf(message), null, t);
+        }
     }
 
     /**
@@ -200,7 +216,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the message to log. Converted to {@link String}
      */
     public void error(Object message) {
-        logger.log(null, FQCN, LocationAwareLogger.ERROR_INT, String.valueOf(message), null, null);
+        if (isErrorEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.ERROR_INT, String.valueOf(message), null, null);
+        }
     }
 
     /**
@@ -213,7 +231,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the exception to log
      */
     public void error(Object message, Throwable t) {
-        logger.log(null, FQCN, LocationAwareLogger.ERROR_INT, String.valueOf(message), null, t);
+        if (isErrorEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.ERROR_INT, String.valueOf(message), null, t);
+        }
     }
 
     /**
@@ -224,7 +244,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the message to log. Converted to {@link String}
      */
     public void fatal(Object message) {
-        logger.log(null, FQCN, LocationAwareLogger.ERROR_INT, String.valueOf(message), null, null);
+        if (isErrorEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.ERROR_INT, String.valueOf(message), null, null);
+        }
     }
 
     /**
@@ -237,7 +259,9 @@ public class SLF4JLocationAwareLog implements Log, Serializable {
      *          the exception to log
      */
     public void fatal(Object message, Throwable t) {
-        logger.log(null, FQCN, LocationAwareLogger.ERROR_INT, String.valueOf(message), null, t);
+        if (isErrorEnabled()) {
+            logger.log(null, FQCN, LocationAwareLogger.ERROR_INT, String.valueOf(message), null, t);
+        }
     }
 
     /**

--- a/jcl-over-slf4j/src/test/java/org/apache/commons/logging/test/InvokeJCLTest.java
+++ b/jcl-over-slf4j/src/test/java/org/apache/commons/logging/test/InvokeJCLTest.java
@@ -27,6 +27,7 @@ package org.apache.commons.logging.test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -88,4 +89,56 @@ public class InvokeJCLTest {
         log.fatal(null, e);
         log.fatal("fatal message", e);
     }
+
+    @Test
+    public void testAvoidConvertingObjectToString() {
+        Log log = LogFactory.getLog(InvokeJCLTest.class);
+        Exception e = new Exception("just testing");
+
+        TestMessage fatalMsg = new TestMessage("fatal msg");
+        TestMessage errorMsg = new TestMessage("error msg");
+        TestMessage warnMsg = new TestMessage("warn msg");
+        TestMessage infoMsg = new TestMessage("info msg");
+        TestMessage debugMsg = new TestMessage("debug msg");
+        TestMessage traceMsg = new TestMessage("trace msg");
+
+        log.fatal(fatalMsg);
+        log.fatal(fatalMsg, e);
+        assertEquals(2, fatalMsg.invokedCount);
+
+        log.error(errorMsg);
+        log.error(errorMsg, e);
+        assertEquals(2, errorMsg.invokedCount);
+
+        log.warn(warnMsg);
+        log.warn(warnMsg, e);
+        assertEquals(2, warnMsg.invokedCount);
+
+        log.info(infoMsg);
+        log.info(infoMsg, e);
+        assertEquals(2, infoMsg.invokedCount);
+
+        log.debug(debugMsg);
+        log.debug(debugMsg, e);
+        assertEquals(0, debugMsg.invokedCount);
+
+        log.trace(traceMsg);
+        log.trace(traceMsg, e);
+        assertEquals(0, traceMsg.invokedCount);
+    }
+
+    static class TestMessage {
+
+        private final String msg;
+        int invokedCount = 0;
+
+        TestMessage(String msg) {this.msg = msg;}
+
+        @Override
+        public String toString() {
+            invokedCount++;
+            return msg;
+        }
+    }
+
 }


### PR DESCRIPTION
As described in issue [SLF4J-497](https://jira.qos.ch/browse/SLF4J-497), rendering of message object can have significant performance impact on application with high workload with some log levels disabled.