### PR TITLE
SLF4J-414: suggest to add a method returning Optional value

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/MDC.java
+++ b/slf4j-api/src/main/java/org/slf4j/MDC.java
@@ -228,7 +228,7 @@ public class MDC {
      * parameter must only contain keys and values of type String.
      * 
      * @param contextMap
-     *          must contain only keys and values of type String
+     *          must contain only keys and values of type String. Should be non-null.
      * @since 1.5.1
      */
     public static void setContextMap(Map<String, String> contextMap) {

--- a/slf4j-api/src/main/java/org/slf4j/helpers/BasicMDCAdapter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/BasicMDCAdapter.java
@@ -140,6 +140,11 @@ public class BasicMDCAdapter implements MDCAdapter {
         }
     }
 
+    @Override
+    public Optional<Map<String, String>> getCopiedContextMap() {
+        return Optional.ofNullable(getCopyOfContextMap());
+    }
+
     public void setContextMap(Map<String, String> contextMap) {
         inheritableThreadLocal.set(new HashMap<String, String>(contextMap));
     }

--- a/slf4j-api/src/main/java/org/slf4j/helpers/NOPMDCAdapter.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/NOPMDCAdapter.java
@@ -25,6 +25,7 @@
 package org.slf4j.helpers;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.slf4j.spi.MDCAdapter;
 
@@ -54,6 +55,11 @@ public class NOPMDCAdapter implements MDCAdapter {
 
     public Map<String, String> getCopyOfContextMap() {
         return null;
+    }
+
+    @Override
+    public Optional<Map<String, String>> getCopiedContextMap() {
+        return Optional.empty();
     }
 
     public void setContextMap(Map<String, String> contextMap) {

--- a/slf4j-api/src/main/java/org/slf4j/spi/MDCAdapter.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/MDCAdapter.java
@@ -25,6 +25,7 @@
 package org.slf4j.spi;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This interface abstracts the service offered by various MDC
@@ -75,8 +76,21 @@ public interface MDCAdapter {
      * 
      * @return A copy of the current thread's context map. May be null.
      * @since 1.5.1
+     * @deprecated use {@link #getCopiedContextMap()} instead.
      */
+    @Deprecated
     public Map<String, String> getCopyOfContextMap();
+
+    /**
+     * Return a copy of the current thread's context map, with keys and
+     * values of type String. Returned {@link Optional} value may be empty.
+     *
+     * @return A copy of the current thread's context map. May be empty.
+     * @since 2.0.0
+     */
+    default Optional<Map<String, String>> getCopiedContextMap() {
+        return Optional.ofNullable(getCopyOfContextMap());
+    }
 
     /**
      * Set the current thread's context map by first clearing any existing 

--- a/slf4j-log4j12/src/main/java/org/slf4j/log4j12/Log4jMDCAdapter.java
+++ b/slf4j-log4j12/src/main/java/org/slf4j/log4j12/Log4jMDCAdapter.java
@@ -27,6 +27,7 @@ package org.slf4j.log4j12;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.log4j.MDCFriend;
 import org.slf4j.spi.MDCAdapter;
@@ -79,6 +80,11 @@ public class Log4jMDCAdapter implements MDCAdapter {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public Optional<Map<String, String>> getCopiedContextMap() {
+        return Optional.ofNullable(getCopyOfContextMap());
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/slf4j-nop/src/main/java/org/slf4j/nop/NOPMDCAdapter.java
+++ b/slf4j-nop/src/main/java/org/slf4j/nop/NOPMDCAdapter.java
@@ -25,6 +25,7 @@
 package org.slf4j.nop;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.slf4j.spi.MDCAdapter;
 
@@ -54,6 +55,11 @@ public class NOPMDCAdapter implements MDCAdapter {
 
     public Map<String, String> getCopyOfContextMap() {
         return null;
+    }
+
+    @Override
+    public Optional<Map<String, String>> getCopiedContextMap() {
+        return Optional.empty();
     }
 
     public void setContextMap(Map<String, String> contextMap) {


### PR DESCRIPTION
Unlike #223, this PR suggests adding a method which returns `Optional` value to solve the [SLF4J-414](https://jira.qos.ch/browse/SLF4J-414).

This suggestion keeps existing documented behavior.
It is also good to return `Optional` value instead of asking users to care for the nullness of the returned value.

After the change, usage of these APIs will be like below:

```java
final Map<String, String> context = MDC.getCopiedContextMap().orElse(HashMap::new);
executor.submit(() -> {
    MDC.setContextMap(context);
});
```