### PR TITLE
SLF4J-498: Introduce GitHub Actions to run build in the PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+      - 1.7-maintenance
+  pull_request:
+    branches:
+      - master
+      - 1.7-maintenance
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Build with Maven
+        run: |
+          mvn -V -B install


### PR DESCRIPTION
We use Travis CI to run the build to verify PRs, but it does not report the result to PR page.
For instance, #232 has a checkmark for each pushed commit, but #236 doesn't have it.
So it is possible that we merge PR which breaks the build without being noticed.

I cannot identify the reason of this problem, so suggest using GitHub Actions as a workaround.
It can integrate the build result to each pushed commit without configuration.

close [SLF4J-498](https://jira.qos.ch/browse/SLF4J-498)