### PR TITLE
Fix typo: "apllications" --> "applications"

### DIFF
--- a/slf4j-site/src/site/pages/codes.html
+++ b/slf4j-site/src/site/pages/codes.html
@@ -544,7 +544,7 @@ class B extends A {
     post-inititilization. Note that the replayed logging calls are
     subject to filtering by the underlying logging system.</p>
 
-    <p>In principle, replaying only occurs for apllications which are
+    <p>In principle, replaying only occurs for applications which are
     already multi-threaded at the time the first logging call occurs.
     </p>
 


### PR DESCRIPTION
Simple documentation typo fix.