### PR TITLE
message supplier

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/Logger.java
+++ b/slf4j-api/src/main/java/org/slf4j/Logger.java
@@ -36,6 +36,8 @@ import org.slf4j.spi.DefaultLoggingEventBuilder;
 import org.slf4j.spi.LoggingEventBuilder;
 import org.slf4j.spi.NOPLoggingEventBuilder;
 
+import java.util.function.Supplier;
+
 /**
  * The org.slf4j.Logger interface is the main user entry point of SLF4J API.
  * It is expected that logging takes place through concrete implementations
@@ -120,6 +122,14 @@ public interface Logger {
     public void trace(String msg);
 
     /**
+     * Log a message at the TRACE level.
+     *
+     * @param msgSupplier supplier for the message string to be logged
+     * @since 1.4
+     */
+    public void trace(Supplier<String> msgSupplier);
+
+    /**
      * Log a message at the TRACE level according to the specified format
      * and argument.
      * 
@@ -171,6 +181,16 @@ public interface Logger {
      * @since 1.4
      */
     public void trace(String msg, Throwable t);
+
+    /**
+     * Log an exception (throwable) at the TRACE level with an
+     * accompanying message.
+     *
+     * @param msgSupplier supplier for the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     * @since 1.4
+     */
+    public void trace(Supplier<String> msgSupplier, Throwable t);
 
     /**
      * Similar to {@link #isTraceEnabled()} method except that the
@@ -270,6 +290,13 @@ public interface Logger {
     public void debug(String msg);
 
     /**
+     * Log a message at the DEBUG level.
+     *
+     * @param msgSupplier supplier for the message string to be logged
+     */
+    public void debug(Supplier<String> msgSupplier);
+
+    /**
      * Log a message at the DEBUG level according to the specified format
      * and argument.
      * 
@@ -309,6 +336,15 @@ public interface Logger {
      * @param arguments a list of 3 or more arguments
      */
     public void debug(String format, Object... arguments);
+
+    /**
+     * Log an exception (throwable) at the DEBUG level with an
+     * accompanying message.
+     *
+     * @param msgSupplier supplier for the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    public void debug(Supplier<String> msgSupplier, Throwable t);
 
     /**
      * Log an exception (throwable) at the DEBUG level with an

--- a/slf4j-api/src/main/java/org/slf4j/helpers/AbstractLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/AbstractLogger.java
@@ -26,6 +26,7 @@ package org.slf4j.helpers;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +77,14 @@ public abstract class AbstractLogger implements Logger, Serializable {
 		}
 	}
 
-    @Override
+	@Override
+	public void trace(Supplier<String> msgSupplier) {
+		if (isTraceEnabled()) {
+			handle_0ArgsCall(Level.TRACE, null, msgSupplier.get(), null);
+		}
+	}
+
+	@Override
 	public void trace(String format, Object arg) {
 		if (isTraceEnabled()) {
 			handle_1ArgsCall(Level.TRACE, null, format, arg);
@@ -104,7 +112,14 @@ public abstract class AbstractLogger implements Logger, Serializable {
 		}
 	}
 
-    @Override
+	@Override
+	public void trace(Supplier<String> msgSupplier, Throwable t) {
+		if (isTraceEnabled()) {
+			handle_0ArgsCall(Level.TRACE, null, msgSupplier.get(), t);
+		}
+	}
+
+	@Override
 	public void trace(Marker marker, String msg) {
 		if (isTraceEnabled(marker)) {
 			handle_0ArgsCall(Level.TRACE, marker, msg, null);
@@ -144,6 +159,13 @@ public abstract class AbstractLogger implements Logger, Serializable {
 		}
 	}
 
+	@Override
+	public void debug(Supplier<String> msgSupplier) {
+		if (isDebugEnabled()) {
+			handle_0ArgsCall(Level.DEBUG, null, msgSupplier.get(), null);
+		}
+	}
+
 	public void debug(String format, Object arg) {
 		if (isDebugEnabled()) {
 			handle_1ArgsCall(Level.DEBUG, null, format, arg);
@@ -165,6 +187,13 @@ public abstract class AbstractLogger implements Logger, Serializable {
 	public void debug(String msg, Throwable t) {
 		if (isDebugEnabled()) {
 			handle_0ArgsCall(Level.DEBUG, null, msg, t);
+		}
+	}
+
+	@Override
+	public void debug(Supplier<String> msgSupplier, Throwable t) {
+		if (isDebugEnabled()) {
+			handle_0ArgsCall(Level.DEBUG, null, msgSupplier.get(), t);
 		}
 	}
 

--- a/slf4j-api/src/main/java/org/slf4j/helpers/NOPLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/NOPLogger.java
@@ -25,7 +25,8 @@
 package org.slf4j.helpers;
 
 import org.slf4j.Logger;
-import org.slf4j.helpers.MarkerIgnoringBase;
+
+import java.util.function.Supplier;
 
 /**
  * A direct NOP (no operation) implementation of {@link Logger}.
@@ -68,6 +69,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    /** A NOP implementation. */
+    public void trace(Supplier<String> msgSupplier) {
+        // NOP
+    }
+
     /** A NOP implementation.  */
     final public void trace(String format, Object arg) {
         // NOP
@@ -88,6 +94,11 @@ public class NOPLogger extends MarkerIgnoringBase {
         // NOP
     }
 
+    /** A NOP implementation. */
+    public void trace(Supplier<String> msgSupplier, Throwable t) {
+        // NOP
+    }
+
     /**
      * Always returns false.
      * @return always false
@@ -98,6 +109,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void debug(String msg) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    final public void debug(Supplier<String> msgSupplier) {
         // NOP
     }
 
@@ -118,6 +134,11 @@ public class NOPLogger extends MarkerIgnoringBase {
 
     /** A NOP implementation. */
     final public void debug(String msg, Throwable t) {
+        // NOP
+    }
+
+    /** A NOP implementation. */
+    public void debug(Supplier<String> msgSupplier, Throwable t) {
         // NOP
     }
 

--- a/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
@@ -27,6 +27,7 @@ package org.slf4j.helpers;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.Marker;
@@ -73,6 +74,11 @@ public class SubstituteLogger implements Logger {
         delegate().trace(msg);
     }
 
+    @Override
+    public void trace(Supplier<String> msgSupplier) {
+        delegate().trace(msgSupplier);
+    }
+
     public void trace(String format, Object arg) {
         delegate().trace(format, arg);
     }
@@ -87,6 +93,11 @@ public class SubstituteLogger implements Logger {
 
     public void trace(String msg, Throwable t) {
         delegate().trace(msg, t);
+    }
+
+    @Override
+    public void trace(Supplier<String> msgSupplier, Throwable t) {
+        delegate().trace(msgSupplier, t);
     }
 
     public boolean isTraceEnabled(Marker marker) {
@@ -121,6 +132,11 @@ public class SubstituteLogger implements Logger {
         delegate().debug(msg);
     }
 
+    @Override
+    public void debug(Supplier<String> msgSupplier) {
+        delegate().debug(msgSupplier);
+    }
+
     public void debug(String format, Object arg) {
         delegate().debug(format, arg);
     }
@@ -135,6 +151,11 @@ public class SubstituteLogger implements Logger {
 
     public void debug(String msg, Throwable t) {
         delegate().debug(msg, t);
+    }
+
+    @Override
+    public void debug(Supplier<String> msgSupplier, Throwable t) {
+        delegate().debug(msgSupplier, t);
     }
 
     public boolean isDebugEnabled(Marker marker) {


### PR DESCRIPTION
When we run code with 
**logger.debug("heavy message generator")** 
or 
**logger.trace("heavy message generator")**
and debug or trace is not enabled, program have to calculate method argument to throw it away in next step.
Message supplier will speed up code execution ))