### PR TITLE
WIP: SLF4J-504 Add functional logging methods

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/Logger.java
+++ b/slf4j-api/src/main/java/org/slf4j/Logger.java
@@ -36,6 +36,8 @@ import org.slf4j.spi.DefaultLoggingEventBuilder;
 import org.slf4j.spi.LoggingEventBuilder;
 import org.slf4j.spi.NOPLoggingEventBuilder;
 
+import java.util.function.Supplier;
+
 /**
  * The org.slf4j.Logger interface is the main user entry point of SLF4J API.
  * It is expected that logging takes place through concrete implementations
@@ -120,6 +122,18 @@ public interface Logger {
     public void trace(String msg);
 
     /**
+     * Log a message from supplier at the TRACE level.
+     *
+     * @param msgSupplier the supplier of a message string to be logged
+     * @since 2.0
+     */
+    default public void trace(Supplier<String> msgSupplier) {
+        if (isTraceEnabled()) {
+            trace(msgSupplier.get());
+        }
+    }
+
+    /**
      * Log a message at the TRACE level according to the specified format
      * and argument.
      * 
@@ -171,6 +185,20 @@ public interface Logger {
      * @since 1.4
      */
     public void trace(String msg, Throwable t);
+
+    /**
+     * Log an exception (throwable) at the TRACE level with an
+     * accompanying message.
+     *
+     * @param t   the exception (throwable) to log
+     * @param msgSupplier the supplier of a message string to be logged
+     * @since 2.0
+     */
+    default public void trace(Throwable t, Supplier<String> msgSupplier) {
+        if (isTraceEnabled()) {
+            trace(msgSupplier.get(), t);
+        }
+    }
 
     /**
      * Similar to {@link #isTraceEnabled()} method except that the

--- a/slf4j-api/src/main/java/org/slf4j/helpers/AbstractLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/AbstractLogger.java
@@ -26,6 +26,7 @@ package org.slf4j.helpers;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +77,13 @@ public abstract class AbstractLogger implements Logger, Serializable {
 		}
 	}
 
+	@Override
+	public void trace(Supplier<String> msgSupplier) {
+		if (isTraceEnabled()) {
+			handle_0ArgsCall(Level.TRACE, null, msgSupplier.get(), null);
+		}
+	}
+
     @Override
 	public void trace(String format, Object arg) {
 		if (isTraceEnabled()) {
@@ -101,6 +109,13 @@ public abstract class AbstractLogger implements Logger, Serializable {
 	public void trace(String msg, Throwable t) {
 		if (isTraceEnabled()) {
 			handle_0ArgsCall(Level.TRACE, null, msg, t);
+		}
+	}
+
+    @Override
+	public void trace(Throwable t, Supplier<String> msgSupplier) {
+		if (isTraceEnabled()) {
+			handle_0ArgsCall(Level.TRACE, null, msgSupplier.get(), t);
 		}
 	}
 

--- a/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
@@ -27,6 +27,7 @@ package org.slf4j.helpers;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.Marker;
@@ -73,6 +74,10 @@ public class SubstituteLogger implements Logger {
         delegate().trace(msg);
     }
 
+    public void trace(Supplier<String> msgSupplier) {
+        delegate().trace(msgSupplier.get());
+    }
+
     public void trace(String format, Object arg) {
         delegate().trace(format, arg);
     }
@@ -87,6 +92,10 @@ public class SubstituteLogger implements Logger {
 
     public void trace(String msg, Throwable t) {
         delegate().trace(msg, t);
+    }
+
+    public void trace(Throwable t, Supplier<String> msgSupplier) {
+        delegate().trace(msgSupplier.get(), t);
     }
 
     public boolean isTraceEnabled(Marker marker) {

--- a/slf4j-ext/src/main/java/org/slf4j/ext/LoggerWrapper.java
+++ b/slf4j-ext/src/main/java/org/slf4j/ext/LoggerWrapper.java
@@ -30,6 +30,8 @@ import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 import org.slf4j.spi.LocationAwareLogger;
 
+import java.util.function.Supplier;
+
 /**
  * A helper class wrapping an {@link org.slf4j.Logger} instance preserving
  * location information if the wrapped instance supports it.
@@ -93,6 +95,20 @@ public class LoggerWrapper implements Logger {
     /**
      * Delegate to the appropriate method of the underlying logger.
      */
+    public void trace(Supplier<String> msgSupplier) {
+        if (!logger.isTraceEnabled())
+            return;
+
+        if (instanceofLAL) {
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, msgSupplier.get(), null, null);
+        } else {
+            logger.trace(msgSupplier.get());
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
     public void trace(String format, Object arg) {
         if (!logger.isTraceEnabled())
             return;
@@ -146,6 +162,20 @@ public class LoggerWrapper implements Logger {
             ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, msg, null, t);
         } else {
             logger.trace(msg, t);
+        }
+    }
+
+    /**
+     * Delegate to the appropriate method of the underlying logger.
+     */
+    public void trace(Throwable t, Supplier<String> msgSupplier) {
+        if (!logger.isTraceEnabled())
+            return;
+
+        if (instanceofLAL) {
+            ((LocationAwareLogger) logger).log(null, fqcn, LocationAwareLogger.TRACE_INT, msgSupplier.get(), null, t);
+        } else {
+            logger.trace(msgSupplier.get(), t);
         }
     }
 


### PR DESCRIPTION
In kotlin we want to use
`logger.trace { "Message with $parameter" } `
instead of
`logger.trace("Message with {}", parameter)`

In this example, I've added `trace` method for this.
If it OK I will add all other methods.
