### PR TITLE
SLF4J-508: Control log level output in the simple logger pattern layout

### DIFF
--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
@@ -197,6 +197,8 @@ public class SimpleLogger extends LegacyAbstractLogger {
 
 	public static final String WARN_LEVEL_STRING_KEY = SimpleLogger.SYSTEM_PREFIX + "warnLevelString";
 
+	public static final String SHOW_LOG_LEVEL_KEY = SimpleLogger.SYSTEM_PREFIX + "showLogLevel";
+
 	public static final String LEVEL_IN_BRACKETS_KEY = SimpleLogger.SYSTEM_PREFIX + "levelInBrackets";
 
 	public static final String LOG_FILE_KEY = SimpleLogger.SYSTEM_PREFIX + "logFile";
@@ -382,15 +384,17 @@ public class SimpleLogger extends LegacyAbstractLogger {
 			buf.append("] ");
 		}
 
-		if (CONFIG_PARAMS.levelInBrackets)
-			buf.append('[');
+		// Append a readable representation of the log level if so configured
+		if (CONFIG_PARAMS.showLogLevel) {
+			if (CONFIG_PARAMS.levelInBrackets)
+				buf.append('[');
 
-		// Append a readable representation of the log level
-		String levelStr = level.name();
-		buf.append(levelStr);
-		if (CONFIG_PARAMS.levelInBrackets)
-			buf.append(']');
-		buf.append(' ');
+			String levelStr = level.name();
+			buf.append(levelStr);
+			if (CONFIG_PARAMS.levelInBrackets)
+				buf.append(']');
+			buf.append(' ');
+		}
 
 		// Append the name of the log instance if so configured
 		if (CONFIG_PARAMS.showShortLogName) {

--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
@@ -81,13 +81,17 @@ import org.slf4j.spi.LocationAwareLogger;
  * <code>SimpleDateFormat</code></a>. If the format is not specified or is
  * invalid, the number of milliseconds since start up will be output.</li>
  *
- * <li><code>org.slf4j.simpleLogger.showThreadName</code> -Set to
+ * <li><code>org.slf4j.simpleLogger.showThreadName</code> - Set to
  * <code>true</code> if you want to output the current thread name. Defaults to
  * <code>true</code>.</li>
  *
  * <li><code>org.slf4j.simpleLogger.showLogName</code> - Set to
  * <code>true</code> if you want the Logger instance name to be included in
  * output messages. Defaults to <code>true</code>.</li>
+ *
+ * <li><code>org.slf4j.simpleLogger.showLogLevel</code> - Set to
+ * <code>true</code> if you want the log level to be included in output messages.
+ * Defaults to <code>true</code>.</li>
  *
  * <li><code>org.slf4j.simpleLogger.showShortLogName</code> - Set to
  * <code>true</code> if you want the last component of the name to be included
@@ -197,8 +201,6 @@ public class SimpleLogger extends LegacyAbstractLogger {
 
 	public static final String WARN_LEVEL_STRING_KEY = SimpleLogger.SYSTEM_PREFIX + "warnLevelString";
 
-	public static final String SHOW_LOG_LEVEL_KEY = SimpleLogger.SYSTEM_PREFIX + "showLogLevel";
-
 	public static final String LEVEL_IN_BRACKETS_KEY = SimpleLogger.SYSTEM_PREFIX + "levelInBrackets";
 
 	public static final String LOG_FILE_KEY = SimpleLogger.SYSTEM_PREFIX + "logFile";
@@ -206,6 +208,8 @@ public class SimpleLogger extends LegacyAbstractLogger {
 	public static final String SHOW_SHORT_LOG_NAME_KEY = SimpleLogger.SYSTEM_PREFIX + "showShortLogName";
 
 	public static final String SHOW_LOG_NAME_KEY = SimpleLogger.SYSTEM_PREFIX + "showLogName";
+
+	public static final String SHOW_LOG_LEVEL_KEY = SimpleLogger.SYSTEM_PREFIX + "showLogLevel";
 
 	public static final String SHOW_THREAD_NAME_KEY = SimpleLogger.SYSTEM_PREFIX + "showThreadName";
 

--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLoggerConfiguration.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLoggerConfiguration.java
@@ -51,6 +51,9 @@ public class SimpleLoggerConfiguration {
     private static final boolean SHOW_SHORT_LOG_NAME_DEFAULT = false;
     boolean showShortLogName = SHOW_SHORT_LOG_NAME_DEFAULT;
 
+    private static final boolean SHOW_LOG_LEVEL_DEFAULT = true;
+    boolean showLogLevel = SHOW_LOG_LEVEL_DEFAULT;
+
     private static final boolean LEVEL_IN_BRACKETS_DEFAULT = false;
     boolean levelInBrackets = LEVEL_IN_BRACKETS_DEFAULT;
 
@@ -78,6 +81,7 @@ public class SimpleLoggerConfiguration {
         showDateTime = getBooleanProperty(SimpleLogger.SHOW_DATE_TIME_KEY, SHOW_DATE_TIME_DEFAULT);
         showThreadName = getBooleanProperty(SimpleLogger.SHOW_THREAD_NAME_KEY, SHOW_THREAD_NAME_DEFAULT);
         dateTimeFormatStr = getStringProperty(SimpleLogger.DATE_TIME_FORMAT_KEY, DATE_TIME_FORMAT_STR_DEFAULT);
+        showLogLevel = getBooleanProperty(SimpleLogger.SHOW_LOG_LEVEL_KEY, SHOW_LOG_LEVEL_DEFAULT);
         levelInBrackets = getBooleanProperty(SimpleLogger.LEVEL_IN_BRACKETS_KEY, LEVEL_IN_BRACKETS_DEFAULT);
         warnLevelString = getStringProperty(SimpleLogger.WARN_LEVEL_STRING_KEY, WARN_LEVELS_STRING_DEFAULT);
 

--- a/slf4j-simple/src/test/java/org/slf4j/simple/SimpleLoggerTest.java
+++ b/slf4j-simple/src/test/java/org/slf4j/simple/SimpleLoggerTest.java
@@ -51,6 +51,10 @@ public class SimpleLoggerTest {
     public void after() {
         System.clearProperty(A_KEY);
         System.clearProperty(SimpleLogger.CACHE_OUTPUT_STREAM_STRING_KEY);
+        System.clearProperty(SimpleLogger.SHOW_DATE_TIME_KEY);
+        System.clearProperty(SimpleLogger.SHOW_LOG_NAME_KEY);
+        System.clearProperty(SimpleLogger.SHOW_THREAD_NAME_KEY);
+        System.clearProperty(SimpleLogger.SHOW_LOG_LEVEL_KEY);
         System.setErr(original);
     }
 
@@ -118,5 +122,20 @@ public class SimpleLoggerTest {
         simpleLogger.info("hello");
         replacement.flush();
         assertTrue(bout.toString().contains("INFO "+this.getClass().getName()+" - hello"));
+    }
+
+    @Test
+    public void checkUseOfMessageOnlyPatternLayout() {
+        System.setProperty(SimpleLogger.SHOW_DATE_TIME_KEY, "false");
+        System.setProperty(SimpleLogger.SHOW_LOG_NAME_KEY, "false");
+        System.setProperty(SimpleLogger.SHOW_THREAD_NAME_KEY, "false");
+        System.setProperty(SimpleLogger.SHOW_LOG_LEVEL_KEY, "false");
+        SimpleLogger.init();
+        SimpleLogger simpleLogger = new SimpleLogger(this.getClass().getName());
+
+        System.setErr(replacement);
+        simpleLogger.info("hello");
+        replacement.flush();
+        assertEquals("hello" + System.lineSeparator(), bout.toString());
     }
 }

--- a/slf4j-simple/src/test/resources/simplelogger.properties
+++ b/slf4j-simple/src/test/resources/simplelogger.properties
@@ -32,3 +32,7 @@
 # Set to true if you want the last component of the name to be included in output messages.
 # Defaults to false.
 #org.slf4j.simpleLogger.showShortLogName=false
+
+# Set to true if you want the log level to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogLevel=true


### PR DESCRIPTION
Set to true if you want the log level to be included in output messages. Defaults to true.
`org.slf4j.simpleLogger.showLogLevel=true`

https://jira.qos.ch/browse/SLF4J-508