### PR TITLE
SLF4J-514: log4j-over-slf4j: Add missing methods + custructors in ConsoleAppender

### DIFF
--- a/log4j-over-slf4j/src/main/java/org/apache/log4j/ConsoleAppender.java
+++ b/log4j-over-slf4j/src/main/java/org/apache/log4j/ConsoleAppender.java
@@ -16,5 +16,22 @@
 package org.apache.log4j;
 
 public class ConsoleAppender extends WriterAppender {
-
+  public ConsoleAppender() {
+  }
+  public ConsoleAppender(Layout layout) {
+  }
+  public ConsoleAppender(Layout layout, String target) {
+  }
+  public void setTarget(String value) {
+  }
+  public String getTarget() {
+    return null;
+  }
+  public void setFollow(boolean newValue) {
+  }
+  public boolean getFollow() {
+    return false;
+  }
+  public void activateOptions() {
+  }
 }


### PR DESCRIPTION
The mock implementation for ConsoleAppender does not provide any constructors or methods.
To ensure that it's compatible with the real log4j these methods have to be present.
Taken from log4j 1.2.17: https://github.com/apache/log4j/blob/v1_2_17/src/main/java/org/apache/log4j/ConsoleAppender.java

Closes jira issue SLF4J-514 at https://jira.qos.ch/browse/SLF4J-514