### PR TITLE
SLF4J-522 - Adds NDC.contains() Method

### DIFF
--- a/slf4j-ext/src/main/java/org/slf4j/NDC.java
+++ b/slf4j-ext/src/main/java/org/slf4j/NDC.java
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2004-2011 QOS.ch
  * All rights reserved.
- *
+ * <p>
  * Permission is hereby granted, free  of charge, to any person obtaining
  * a  copy  of this  software  and  associated  documentation files  (the
  * "Software"), to  deal in  the Software without  restriction, including
@@ -9,10 +9,10 @@
  * distribute,  sublicense, and/or sell  copies of  the Software,  and to
  * permit persons to whom the Software  is furnished to do so, subject to
  * the following conditions:
- *
+ * <p>
  * The  above  copyright  notice  and  this permission  notice  shall  be
  * included in all copies or substantial portions of the Software.
- *
+ * <p>
  * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
  * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
  * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
@@ -20,7 +20,6 @@
  * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
  * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- *
  */
 package org.slf4j;
 
@@ -29,9 +28,9 @@ public class NDC {
 
     private static int size() {
         int i = 0;
-        while (true) {
+        while(true) {
             String val = MDC.get(PREFIX + i);
-            if (val != null) {
+            if(val != null) {
                 i++;
             } else {
                 break;
@@ -40,14 +39,28 @@ public class NDC {
         return i;
     }
 
+    /**
+     * Adds a new value to the current thread's nested diagnostic context. The
+     * <code>context</code> parameter cannot be <code>null</code>.
+     *
+     * @param val a non-null value to add to the nested diagnostic context
+     * @throws IllegalArgumentException in case the <code>val</code> parameter is null
+     */
     public static void push(String val) {
         int next = size();
         MDC.put(PREFIX + next, val);
     }
 
+    /**
+     * Removes the last added value from the current thread's nested diagnostic context and returns it.
+     * If the nested diagnostic context is empty, an empty String will be returned.
+     *
+     * @return the nested diagnostic context value removed, or an empty String if the nested diagnostic context is
+     * empty.
+     */
     public static String pop() {
         int next = size();
-        if (next == 0) {
+        if(next == 0) {
             return "";
         }
         int last = next - 1;
@@ -55,6 +68,30 @@ public class NDC {
         String val = MDC.get(key);
         MDC.remove(key);
         return val;
+    }
+
+    /**
+     * Returns whether or not the provided context value is already included in the current thread's
+     * nested diagnostic context. A <code>null</code> value will always return <code>false</code>.
+     *
+     * @param context the context to check for in the nested diagnostic context.
+     * @return <code>true</code> if the provided context exists within the nested diagnostic context,
+     * <code>false</code> if it does not exist or the provided context value was <code>null</code>.
+     */
+    public static boolean contains(String context) {
+        if(context == null) {
+            return false;
+        }
+
+        int i = 0;
+        String val;
+        while((val = MDC.get(PREFIX + i)) != null) {
+            if(val.equals(context)) {
+                return true;
+            }
+            i++;
+        }
+        return false;
     }
 
 }

--- a/slf4j-ext/src/test/java/org/slf4j/NDCTest.java
+++ b/slf4j-ext/src/test/java/org/slf4j/NDCTest.java
@@ -24,10 +24,10 @@
  */
 package org.slf4j;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class NDCTest {
 
@@ -56,5 +56,30 @@ public class NDCTest {
         String result0 = NDC.pop();
         assertEquals("b", result1);
         assertEquals("a", result0);
+    }
+
+    @Test
+    public void testContains() {
+        assertFalse("nested context does not contain null value", NDC.contains(null));
+        assertFalse("default nested context does not contain \"a\" value", NDC.contains("a"));
+
+        NDC.push("a");
+
+        assertTrue("nested context contains \"a\" after being pushed", NDC.contains("a"));
+        assertFalse("nested context does not contain \"b\" before being pushed", NDC.contains("b"));
+
+        NDC.push("b");
+
+        assertTrue("nested context still contains \"a\" after \"b\" is pushed", NDC.contains("a"));
+        assertTrue("nested context contains \"b\" after being pushed", NDC.contains("b"));
+
+        NDC.pop();
+
+        assertFalse("nested context no longer contains \"b\" after being popped", NDC.contains("b"));
+        assertTrue("nested context still contains \"a\" after \"b\" is popped", NDC.contains("a"));
+
+        NDC.pop();
+
+        assertFalse("nested context no longer contains \"a\" after being popped", NDC.contains("a"));
     }
 }


### PR DESCRIPTION
Updates the NDC class in slf4j-ext to include a static contains() method
that can check the existing nested diagnostic context for the presence
of a value.

Added unit tests to test the new NDC.contains() method.