### PR TITLE
SLF4J-528 Use stackwalker to infer calling class

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -387,6 +387,38 @@ public final class LoggerFactory {
         return logger;
     }
 
+    /**
+     * Return a logger named corresponding to the class passed as parameter,
+     * using the statically bound {@link ILoggerFactory} instance.
+     *
+     * <p>
+     * In case the the <code>clazz</code> parameter differs from the name of the
+     * caller as computed internally by SLF4J, a logger name mismatch warning
+     * will be printed but only if the
+     * <code>slf4j.detectLoggerNameMismatch</code> system property is set to
+     * true. By default, this property is not set and no warnings will be
+     * printed even in case of a logger name mismatch.
+     *
+     *
+     * Using Stackwalker to grab the calling class is a convenient and fast way of getting the class information.
+     * https://ionutbalosin.com/2018/06/an-even-faster-way-than-stackwalker-api-for-asynchronously-processing-the-stack-frames/
+     *
+     * This no longer requires a developer to needlessly paste the current class's name into the factory instance.
+     *
+     * @param clazz
+     *            the returned logger will be named after clazz
+     * @return logger
+     *
+     *
+     * @see <a
+     *      href="http://www.slf4j.org/codes.html#loggerNameMismatch">Detected
+     *      logger name mismatch</a>
+     */
+    public static Logger getLogger() {
+        var callerClass = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE).getCallerClass();
+        return LoggerFactory.getLogger(callerClass);
+    }
+
     private static boolean nonMatchingClasses(Class<?> clazz, Class<?> autoComputedCallingClass) {
         return !autoComputedCallingClass.isAssignableFrom(clazz);
     }


### PR DESCRIPTION
Opening this as a proof of concept as to a way we could grab the caller class from the caller.

This approach is pretty fast compared to the usual approach of generating a throwable, but it's obviously still slower than just explicitly passing in the class

https://ionutbalosin.com/2018/06/an-even-faster-way-than-stackwalker-api-for-asynchronously-processing-the-stack-frames/

It's also a mega-convenient way of accessing the logger. Even if it's slow, the developer convenience seems quite valuable, and developers should be able to use the fast way if the need arises.

A couple open questions:
1. Is this a good idea? 
2. How to integrate this into the actual library? The current jdk version is set to 8 [in here](https://github.com/qos-ch/slf4j/blob/master/pom.xml#L38). I know we require java 11 for slf4j 2.0 and above, but I don't see where that's enforced in the code

Would love some guidance here. 

JIRA ticket here: https://jira.qos.ch/browse/SLF4J-528