### PR TITLE
Platform Logging bridge should use MessageFormat but it's using String.format

### DIFF
--- a/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/platform/logging/SLF4JPlatformLogger.java
+++ b/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/platform/logging/SLF4JPlatformLogger.java
@@ -26,6 +26,7 @@ package org.slf4j.jdk.platform.logging;
 
 import static java.util.Objects.requireNonNull;
 
+import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
@@ -142,7 +143,7 @@ class SLF4JPlatformLogger implements System.Logger {
                 leb = leb.addArgument(p);
             }
             // The JDK uses a different formatting convention. We must invoke it now.
-            message = String.format(message, params);
+            message = MessageFormat.format(message, params);
         }
         if (leb instanceof CallerBoundaryAware) {
             CallerBoundaryAware cba = (CallerBoundaryAware) leb;

--- a/slf4j-jdk-platform-logging/src/test/java/org/slf4j/jdk/platform/logging/test/SLF4JPlatformLoggingTest.java
+++ b/slf4j-jdk-platform-logging/src/test/java/org/slf4j/jdk/platform/logging/test/SLF4JPlatformLoggingTest.java
@@ -88,7 +88,7 @@ public class SLF4JPlatformLoggingTest {
         assertEquals(EXPECTED_FINDER_CLASS, finder.getClass().getName());
         Logger systemLogger = finder.getLogger("smoke", null);
         systemLogger.log(Level.INFO, "hello");
-        systemLogger.log(Level.INFO, "hello %s", "world");
+        systemLogger.log(Level.INFO, "hello {0}", "world");
         
         List<String> results = SPS.stringList;
         assertEquals(2, results.size());


### PR DESCRIPTION
[java.lang.System.Logger.log](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.Logger.html#log(java.lang.System.Logger.Level,java.lang.String,java.lang.Object...)) is specified to accept the message format of MessageFormat. However, the current SLF4JPlatformLogger implementation uses String.format instead of MessageFormat. As a result, the current implementation cannot format the message correctly.

# Expected  and actual behavior

```java
LoggerFinder finder = System.LoggerFinder.getLoggerFinder();
Logger systemLogger = finder.getLogger("smoke", null);
systemLogger.log(Level.INFO, "hello {0}", "world");
```

Expected output:

```
INFO smoke - hello world
```

Actual output:

```
INFO smoke - hello {0}
```

# What this change does

This change replaces use of String.format by MessageFormat.format to comply the spec of Platform Logging.