### PR TITLE
implement putAll and putAllCloseable

### DIFF
--- a/slf4j-nop/src/test/java/org/slf4j/nop/InvocationTest.java
+++ b/slf4j-nop/src/test/java/org/slf4j/nop/InvocationTest.java
@@ -33,6 +33,9 @@ import org.slf4j.MDC;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Test whether invoking the SLF4J API causes problems or not.
  * 
@@ -116,11 +119,40 @@ public class InvocationTest {
     }
 
     @Test
+    public void testMDCPutAll() {
+        Map<String, String> values = new HashMap<>();
+        values.put("key1", "value1");
+        values.put("key2", "value2");
+        MDC.putAll(values);
+        assertNull(MDC.get("key1"));
+        assertNull(MDC.get("key2"));
+        MDC.remove("key1");
+        MDC.remove("key2");
+        assertNull(MDC.get("key1"));
+        assertNull(MDC.get("key2"));
+        MDC.clear();
+    }
+
+    @Test
     public void testMDCCloseable() {
         MDC.MDCCloseable closeable = MDC.putCloseable("k", "v");
         assertNull(MDC.get("k"));
         closeable.close();
         assertNull(MDC.get("k"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCCloseablePutAll() {
+        Map<String, String> values = new HashMap<>();
+        values.put("key1", "value1");
+        values.put("key2", "value2");
+        MDC.MDCCloseable closeable = MDC.putAllCloseable(values);
+        assertNull(MDC.get("key1"));
+        assertNull(MDC.get("key2"));
+        closeable.close();
+        assertNull(MDC.get("key1"));
+        assertNull(MDC.get("key2"));
         MDC.clear();
     }
 }

--- a/slf4j-reload4j/src/test/java/org/slf4j/reload4j/InvocationTest.java
+++ b/slf4j-reload4j/src/test/java/org/slf4j/reload4j/InvocationTest.java
@@ -189,6 +189,112 @@ public class InvocationTest {
     }
 
     @Test
+    public void testMDCPutAll() {
+        Map<String, String> values = new HashMap<>();
+        values.put("k1", "v1");
+        values.put("k2", "v2");
+
+        MDC.put("k", "v");
+        MDC.putAll(values);
+
+        assertNotNull(MDC.get("k"));
+        assertNotNull(MDC.get("k1"));
+        assertNotNull(MDC.get("k2"));
+        MDC.remove("k1");
+        MDC.remove("k2");
+        assertNotNull(MDC.get("k"));
+        assertNull(MDC.get("k1"));
+        assertNull(MDC.get("k2"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCCloseable() {
+        MDC.put("pre", "v");
+        try(MDC.MDCCloseable mdcCloseable = MDC.putCloseable("try-with", "v")) {
+            assertNotNull(MDC.get("pre"));
+            assertNotNull(MDC.get("try-with"));
+            assertNull(MDC.get("post"));
+        }
+        MDC.put("post", "v");
+        assertNotNull(MDC.get("pre"));
+        assertNull(MDC.get("try-with"));
+        assertNotNull(MDC.get("post"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCCloseableOverwrites() {
+        MDC.put("pre", "v");
+        try(MDC.MDCCloseable mdcCloseable = MDC.putCloseable("pre", "v2")) {
+            assertNotNull(MDC.get("pre"));
+            assertEquals("v2", MDC.get("pre"));
+            assertNull(MDC.get("post"));
+        }
+        MDC.put("post", "v");
+        assertNull(MDC.get("pre"));
+        assertNotNull(MDC.get("post"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCCloseablePutAllImmutable() {
+        Map<String, String> values = new HashMap<>();
+        values.put("try-with", "v");
+
+        MDC.put("pre", "v");
+        try(MDC.MDCCloseable mdcCloseable = MDC.putAllCloseable(values)) {
+            values.remove("try-with");
+            assertNotNull(MDC.get("pre"));
+            assertNotNull(MDC.get("try-with"));
+            assertNull(MDC.get("post"));
+        }
+        MDC.put("post", "v");
+        assertNotNull(MDC.get("pre"));
+        assertNull(MDC.get("try-with"));
+        assertNotNull(MDC.get("post"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCCloseablePutAll() {
+        Map<String, String> values = new HashMap<>();
+        values.put("try-with", "v");
+
+        MDC.put("pre", "v");
+        try(MDC.MDCCloseable mdcCloseable = MDC.putAllCloseable(values)) {
+            assertNotNull(MDC.get("pre"));
+            assertNotNull(MDC.get("try-with"));
+            assertNull(MDC.get("post"));
+        }
+        MDC.put("post", "v");
+        assertNotNull(MDC.get("pre"));
+        assertNull(MDC.get("try-with"));
+        assertNotNull(MDC.get("post"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCCloseablePutAllOverwrites() {
+        Map<String, String> values = new HashMap<>();
+        values.put("pre", "v2");
+        values.put("try-with", "v");
+
+        MDC.put("pre", "v");
+        try(MDC.MDCCloseable mdcCloseable = MDC.putAllCloseable(values)) {
+            assertNotNull(MDC.get("pre"));
+            assertEquals("v2", MDC.get("pre"));
+            assertNotNull(MDC.get("try-with"));
+            assertNull(MDC.get("post"));
+        }
+        MDC.put("post", "v");
+        assertNull(MDC.get("pre"));
+        assertNull(MDC.get("try-with"));
+        assertNotNull(MDC.get("post"));
+        MDC.clear();
+    }
+
+    @Test
     public void testCallerInfo() {
         Logger logger = LoggerFactory.getLogger("testMarker");
         listAppender.extractLocationInfo = true;

--- a/slf4j-simple/src/test/java/org/slf4j/simple/InvocationTest.java
+++ b/slf4j-simple/src/test/java/org/slf4j/simple/InvocationTest.java
@@ -27,6 +27,8 @@ package org.slf4j.simple;
 import static org.junit.Assert.assertNull;
 
 import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -138,6 +140,44 @@ public class InvocationTest {
         assertNull(MDC.get("k"));
         MDC.remove("k");
         assertNull(MDC.get("k"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCPutAll() {
+        Map<String, String> values = new HashMap<>();
+        values.put("key1", "value1");
+        values.put("key2", "value2");
+        MDC.putAll(values);
+        assertNull(MDC.get("key1"));
+        assertNull(MDC.get("key2"));
+        MDC.remove("key1");
+        MDC.remove("key2");
+        assertNull(MDC.get("key1"));
+        assertNull(MDC.get("key2"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCCloseable() {
+        MDC.MDCCloseable closeable = MDC.putCloseable("k", "v");
+        assertNull(MDC.get("k"));
+        closeable.close();
+        assertNull(MDC.get("k"));
+        MDC.clear();
+    }
+
+    @Test
+    public void testMDCCloseablePutAll() {
+        Map<String, String> values = new HashMap<>();
+        values.put("key1", "value1");
+        values.put("key2", "value2");
+        MDC.MDCCloseable closeable = MDC.putAllCloseable(values);
+        assertNull(MDC.get("key1"));
+        assertNull(MDC.get("key2"));
+        closeable.close();
+        assertNull(MDC.get("key1"));
+        assertNull(MDC.get("key2"));
         MDC.clear();
     }
 }


### PR DESCRIPTION
Implements putAll and putAllCloseable described in [SLF4J-387](https://jira.qos.ch/browse/SLF4J-387) – I ran into the same problem a short while ago that I needed a closeable MDC that discards multiple entries after the try-with resource is closed.

If more tests or other changes are required I'll happily take another look at this.