### PR TITLE
SLF4J-256: Allow use of lambda to construct build event

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/Logger.java
+++ b/slf4j-api/src/main/java/org/slf4j/Logger.java
@@ -38,8 +38,11 @@ import static org.slf4j.event.Level.WARN;
 
 import org.slf4j.event.Level;
 import org.slf4j.spi.DefaultLoggingEventBuilder;
+import org.slf4j.spi.FluentLogApiStub;
 import org.slf4j.spi.LoggingEventBuilder;
-import org.slf4j.spi.NOPLoggingEventBuilder;
+import org.slf4j.spi.NopFluentApiStub;
+
+import java.util.function.Consumer;
 
 /**
  * The org.slf4j.Logger interface is the main user entry point of SLF4J API.
@@ -96,30 +99,43 @@ public interface Logger {
     public String getName();
 
     /**
-     * Make a new {@link LoggingEventBuilder} instance as appropriate for this logger and the 
+     * Make a new {@link FluentLogApiStub} instance as appropriate for this logger and the
      * desired {@link Level} passed as parameter. If this Logger is disabled for the given Level, then 
-     * a {@link  NOPLoggingEventBuilder} is returned.
+     * a {@link  NopFluentApiStub} is returned.
      * 
      * 
      * @param level desired level for the event builder
      * @return a new {@link LoggingEventBuilder} instance as appropriate for this logger
      * @since 2.0
      */
-    default public LoggingEventBuilder makeLoggingEventBuilder(Level level) {
+    default public FluentLogApiStub makeLoggingEventBuilder(Level level) {
         if (isEnabledForLevel(level)) {
             return new DefaultLoggingEventBuilder(this, level);          
         } else {
-            return NOPLoggingEventBuilder.singleton();
+            return NopFluentApiStub.singleton();
         }
     }
 
+    default public FluentLogApiStub atLevel(Level level) {
+        return makeLoggingEventBuilder(level);
+    }
+
+
     /**
-     * A convenient alias for {@link #makeLoggingEventBuilder}. 
-     * 
+     * Use provided LoggingEventBuilder consumer to construct the logging event, and log at provided level.
+     *
+     * <code>
+     *     logger.atDebug(log->log.message("Temperature rise from {} to {}")
+     * </code>
+     *
      * @since 2.0
      */
-    default public LoggingEventBuilder atLevel(Level level) {
-        return makeLoggingEventBuilder(level);
+    default public void atLevel(Level level, Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        if (isEnabledForLevel(level)) {
+            DefaultLoggingEventBuilder eventBuilder= new DefaultLoggingEventBuilder(this, level);
+            eventBuilderConsumer.accept(eventBuilder);
+            eventBuilder.log();
+        }
     }
 
     
@@ -233,15 +249,18 @@ public interface Logger {
     /**
      * Entry point for fluent-logging for {@link org.slf4j.event.Level#TRACE} level. 
      *  
-     * @return LoggingEventBuilder instance as appropriate for level TRACE
+     * @return FluentLogApiStub instance as appropriate for level TRACE
      * @since 2.0
      */
-    default public LoggingEventBuilder atTrace() {
+    default public FluentLogApiStub atTrace() {
         if (isTraceEnabled()) {
             return makeLoggingEventBuilder(TRACE);
         } else {
-            return NOPLoggingEventBuilder.singleton();
+            return NopFluentApiStub.singleton();
         }
+    }
+    default public void atTrace(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        this.atLevel(TRACE, eventBuilderConsumer);
     }
 
     /**
@@ -429,15 +448,19 @@ public interface Logger {
     /**
      * Entry point for fluent-logging for {@link org.slf4j.event.Level#DEBUG} level. 
      *  
-     * @return LoggingEventBuilder instance as appropriate for level DEBUG
+     * @return FluentLogApiStub instance as appropriate for level DEBUG
      * @since 2.0
      */
-    default public LoggingEventBuilder atDebug() {
+    default public FluentLogApiStub atDebug() {
         if (isDebugEnabled()) {
             return makeLoggingEventBuilder(DEBUG);
         } else {
-            return NOPLoggingEventBuilder.singleton();
+            return NopFluentApiStub.singleton();
         }
+    }
+
+    default public void atDebug(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        this.atLevel(DEBUG, eventBuilderConsumer);
     }
 
     /**
@@ -568,15 +591,18 @@ public interface Logger {
     /**
      * Entry point for fluent-logging for {@link org.slf4j.event.Level#INFO} level. 
      *  
-     * @return LoggingEventBuilder instance as appropriate for level INFO
+     * @return FluentLogApiStub instance as appropriate for level INFO
      * @since 2.0
      */
-    default public LoggingEventBuilder atInfo() {
+    default public FluentLogApiStub atInfo() {
         if (isInfoEnabled()) {
             return makeLoggingEventBuilder(INFO);
         } else {
-            return NOPLoggingEventBuilder.singleton();
+            return NopFluentApiStub.singleton();
         }
+    }
+    default public void atInfo(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        this.atLevel(INFO, eventBuilderConsumer);
     }
 
     /**
@@ -708,15 +734,18 @@ public interface Logger {
     /**
      * Entry point for fluent-logging for {@link org.slf4j.event.Level#WARN} level. 
      *  
-     * @return LoggingEventBuilder instance as appropriate for level WARN
+     * @return FluentLogApiStub instance as appropriate for level WARN
      * @since 2.0
      */
-    default public LoggingEventBuilder atWarn() {
+    default public FluentLogApiStub atWarn() {
         if (isWarnEnabled()) {
             return makeLoggingEventBuilder(WARN);
         } else {
-            return NOPLoggingEventBuilder.singleton();
+            return NopFluentApiStub.singleton();
         }
+    }
+    default public void atWarn(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        this.atLevel(WARN, eventBuilderConsumer);
     }
 
     /**
@@ -849,15 +878,21 @@ public interface Logger {
     /**
      * Entry point for fluent-logging for {@link org.slf4j.event.Level#ERROR} level. 
      *  
-     * @return LoggingEventBuilder instance as appropriate for level ERROR
+     * @return FluentLogApiStub instance as appropriate for level ERROR
      * @since 2.0
      */
-    default public LoggingEventBuilder atError() {
+    default public FluentLogApiStub atError() {
         if (isErrorEnabled()) {
             return makeLoggingEventBuilder(ERROR);
         } else {
-            return NOPLoggingEventBuilder.singleton();
+            return NopFluentApiStub.singleton();
         }
     }
+
+    default public void atError(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        this.atLevel(ERROR, eventBuilderConsumer);
+    }
+
+
 
 }

--- a/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
+++ b/slf4j-api/src/main/java/org/slf4j/helpers/SubstituteLogger.java
@@ -27,6 +27,7 @@ package org.slf4j.helpers;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Queue;
+import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.Marker;
@@ -34,6 +35,7 @@ import org.slf4j.event.EventRecodingLogger;
 import org.slf4j.event.Level;
 import org.slf4j.event.LoggingEvent;
 import org.slf4j.event.SubstituteLoggingEvent;
+import org.slf4j.spi.FluentLogApiStub;
 import org.slf4j.spi.LoggingEventBuilder;
 
 /**
@@ -69,15 +71,21 @@ public class SubstituteLogger implements Logger {
     }
     
     @Override
-    public LoggingEventBuilder makeLoggingEventBuilder(Level level) {
+    public FluentLogApiStub makeLoggingEventBuilder(Level level) {
         return delegate().makeLoggingEventBuilder(level);
     }
 
     @Override
-    public LoggingEventBuilder atLevel(Level level) {
+    public FluentLogApiStub atLevel(Level level) {
         return delegate().atLevel(level); 
     }
-    
+
+    @Override
+    public void atLevel(Level level, Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        delegate().atLevel(level, eventBuilderConsumer);
+    }
+
+
     @Override
     public boolean isEnabledForLevel(Level level) {
         return delegate().isEnabledForLevel(level);
@@ -142,10 +150,15 @@ public class SubstituteLogger implements Logger {
     }
     
     @Override
-    public LoggingEventBuilder atTrace() {
+    public FluentLogApiStub atTrace() {
         return delegate().atTrace();
     }
-    
+
+    @Override
+    public void atTrace(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        delegate().atTrace(eventBuilderConsumer);
+    }
+
     @Override
     public boolean isDebugEnabled() {
         return delegate().isDebugEnabled();
@@ -207,10 +220,15 @@ public class SubstituteLogger implements Logger {
     }
     
     @Override
-    public LoggingEventBuilder atDebug() {
+    public FluentLogApiStub atDebug() {
         return delegate().atDebug();
     }
-    
+
+    @Override
+    public void atDebug(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        delegate().atDebug(eventBuilderConsumer);
+    }
+
     @Override
     public boolean isInfoEnabled() {
         return delegate().isInfoEnabled();
@@ -273,11 +291,15 @@ public class SubstituteLogger implements Logger {
     }
     
     @Override
-    public LoggingEventBuilder atInfo() {
+    public FluentLogApiStub atInfo() {
         return delegate().atInfo();
     }
 
-    
+    @Override
+    public void atInfo(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        delegate().atInfo(eventBuilderConsumer);
+    }
+
     @Override
     public boolean isWarnEnabled() {
         return delegate().isWarnEnabled();
@@ -338,11 +360,15 @@ public class SubstituteLogger implements Logger {
     }
     
     @Override
-    public LoggingEventBuilder atWarn() {
+    public FluentLogApiStub atWarn() {
         return delegate().atWarn();
     }
 
-    
+    @Override
+    public void atWarn(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        delegate().atWarn(eventBuilderConsumer);
+    }
+
     
     @Override
     public boolean isErrorEnabled() {
@@ -405,10 +431,15 @@ public class SubstituteLogger implements Logger {
     }
 
     @Override
-    public LoggingEventBuilder atError() {
+    public FluentLogApiStub atError() {
         return delegate().atError();
     }
-    
+
+    @Override
+    public void atError(Consumer<LoggingEventBuilder> eventBuilderConsumer) {
+        delegate().atError(eventBuilderConsumer);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)

--- a/slf4j-api/src/main/java/org/slf4j/spi/DefaultLoggingEventBuilder.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/DefaultLoggingEventBuilder.java
@@ -9,7 +9,7 @@ import org.slf4j.event.KeyValuePair;
 import org.slf4j.event.Level;
 import org.slf4j.event.LoggingEvent;
 
-public class DefaultLoggingEventBuilder implements LoggingEventBuilder, CallerBoundaryAware {
+public class DefaultLoggingEventBuilder implements FluentLogApiStub, LoggingEventBuilder, CallerBoundaryAware {
 
     protected DefaultLoggingEvent loggingEvent;
     protected Logger logger;
@@ -17,6 +17,12 @@ public class DefaultLoggingEventBuilder implements LoggingEventBuilder, CallerBo
     public DefaultLoggingEventBuilder(Logger logger, Level level) {
         this.logger = logger;
         loggingEvent = new DefaultLoggingEvent(level, logger);
+    }
+
+    @Override
+    public DefaultLoggingEventBuilder setMessage(String message) {
+        loggingEvent.setMessage(message);
+        return this;
     }
 
     /**
@@ -27,27 +33,32 @@ public class DefaultLoggingEventBuilder implements LoggingEventBuilder, CallerBo
      * @param marker the marker to add
      */
     @Override
-    public LoggingEventBuilder addMarker(Marker marker) {
+    public DefaultLoggingEventBuilder addMarker(Marker marker) {
         loggingEvent.addMarker(marker);
         return this;
     }
 
     @Override
-    public LoggingEventBuilder setCause(Throwable t) {
+    public DefaultLoggingEventBuilder setCause(Throwable t) {
         loggingEvent.setThrowable(t);
         return this;
     }
 
     @Override
-    public LoggingEventBuilder addArgument(Object p) {
+    public DefaultLoggingEventBuilder addArgument(Object p) {
         loggingEvent.addArgument(p);
         return this;
     }
 
     @Override
-    public LoggingEventBuilder addArgument(Supplier<?> objectSupplier) {
+    public DefaultLoggingEventBuilder addArgument(Supplier<?> objectSupplier) {
         loggingEvent.addArgument(objectSupplier.get());
         return this;
+    }
+
+    @Override
+    public LoggingEvent build() {
+        return this.loggingEvent;
     }
 
     @Override
@@ -92,7 +103,11 @@ public class DefaultLoggingEventBuilder implements LoggingEventBuilder, CallerBo
             log(messageSupplier.get());
         }
     }
-    
+
+    public void log() {
+        log(loggingEvent);
+    }
+
     protected void log(LoggingEvent aLoggingEvent) {
         if (logger instanceof LoggingEventAware) {
             ((LoggingEventAware) logger).log(aLoggingEvent);
@@ -183,13 +198,13 @@ public class DefaultLoggingEventBuilder implements LoggingEventBuilder, CallerBo
 
 
     @Override
-    public LoggingEventBuilder addKeyValue(String key, Object value) {
+    public DefaultLoggingEventBuilder addKeyValue(String key, Object value) {
         loggingEvent.addKeyValue(key, value);
         return this;
     }
 
     @Override
-    public LoggingEventBuilder addKeyValue(String key, Supplier<Object> value) {
+    public DefaultLoggingEventBuilder addKeyValue(String key, Supplier<Object> value) {
         loggingEvent.addKeyValue(key, value.get());
         return this;
     }

--- a/slf4j-api/src/main/java/org/slf4j/spi/FluentLogApiStub.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/FluentLogApiStub.java
@@ -24,10 +24,9 @@
  */
 package org.slf4j.spi;
 
-import java.util.function.Supplier;
-
 import org.slf4j.Marker;
-import org.slf4j.event.LoggingEvent;
+
+import java.util.function.Supplier;
 
 /**
  * This is main interface in slf4j's fluent API for creating logging events.
@@ -36,38 +35,28 @@ import org.slf4j.event.LoggingEvent;
  * @since 2.0.0
  *
  */
-public interface LoggingEventBuilder {
+public interface FluentLogApiStub {
 
-    LoggingEventBuilder setMessage(String message);
+    FluentLogApiStub setCause(Throwable cause);
 
-    default public LoggingEventBuilder message(String message) {
-        return this.setMessage(message);
-    }
+    FluentLogApiStub addMarker(Marker marker);
 
-    LoggingEventBuilder setCause(Throwable cause);
+    FluentLogApiStub addArgument(Object p);
 
-    default public LoggingEventBuilder cause(Throwable cause) {
-        return this.setCause(cause);
-    }
+    FluentLogApiStub addArgument(Supplier<?> objectSupplier);
 
-    LoggingEventBuilder addMarker(Marker marker);
+    FluentLogApiStub addKeyValue(String key, Object value);
 
-    LoggingEventBuilder addArgument(Object p);
+    FluentLogApiStub addKeyValue(String key, Supplier<Object> value);
 
-    default public LoggingEventBuilder arg(Object p) {
-        return this.addArgument(p);
-    }
+    void log(String message);
 
-    LoggingEventBuilder addArgument(Supplier<?> objectSupplier);
+    void log(String message, Object arg);
 
-    default public LoggingEventBuilder arg(Supplier<?> argSupplier) {
-        return this.addArgument(argSupplier);
-    }
+    void log(String message, Object arg0, Object arg1);
 
-    LoggingEventBuilder addKeyValue(String key, Object value);
+    void log(String message, Object... args);
 
-    LoggingEventBuilder addKeyValue(String key, Supplier<Object> value);
-
-    LoggingEvent build();
+    void log(Supplier<String> messageSupplier);
 
 }

--- a/slf4j-api/src/main/java/org/slf4j/spi/NopFluentApiStub.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/NopFluentApiStub.java
@@ -5,7 +5,7 @@ import java.util.function.Supplier;
 import org.slf4j.Marker;
 
 /**
- * A no-operation implementation of {@link LoggingEventBuilder}. 
+ * A no-operation implementation of {@link FluentLogApiStub}.
  * As the name indicates, this implementation does nothing or alternatively returns
  * a singleton, i.e. the unique instance of this class.
  * 
@@ -13,45 +13,45 @@ import org.slf4j.Marker;
  * @since 2.0.0
  *
  */
-public class NOPLoggingEventBuilder implements LoggingEventBuilder {
+public class NopFluentApiStub implements FluentLogApiStub {
 
-    static final NOPLoggingEventBuilder SINGLETON = new NOPLoggingEventBuilder();
+    static final NopFluentApiStub SINGLETON = new NopFluentApiStub();
 
     
-    private NOPLoggingEventBuilder() {
+    private NopFluentApiStub() {
     }
     
-    public static LoggingEventBuilder singleton() {
+    public static NopFluentApiStub singleton() {
         return SINGLETON;
     }
 
     @Override
-    public LoggingEventBuilder addMarker(Marker marker) {
+    public NopFluentApiStub addMarker(Marker marker) {
         return singleton();
     }
 
     @Override
-    public LoggingEventBuilder addArgument(Object p) {
+    public NopFluentApiStub addArgument(Object p) {
         return singleton();
     }
 
     @Override
-    public LoggingEventBuilder addArgument(Supplier<?> objectSupplier) {
+    public NopFluentApiStub addArgument(Supplier<?> objectSupplier) {
         return singleton();
     }
 
     @Override
-    public LoggingEventBuilder addKeyValue(String key, Object value) {
+    public NopFluentApiStub addKeyValue(String key, Object value) {
         return singleton();
     }
 
     @Override
-    public LoggingEventBuilder addKeyValue(String key, Supplier<Object> value) {
+    public NopFluentApiStub addKeyValue(String key, Supplier<Object> value) {
         return singleton();
     }
 
     @Override
-    public LoggingEventBuilder setCause(Throwable cause) {
+    public NopFluentApiStub setCause(Throwable cause) {
         return singleton();
     }
 

--- a/slf4j-api/src/test/java/org/slf4j/basicTests/FluentAPIUsage.java
+++ b/slf4j-api/src/test/java/org/slf4j/basicTests/FluentAPIUsage.java
@@ -24,4 +24,13 @@ public class FluentAPIUsage {
         assertFalse(logger.isEnabledForLevel(Level.DEBUG));
     }
 
+    @Test
+    public void fluentApiWithLambda() {
+        Logger logger = LoggerFactory.getLogger("fluentApiWithLambda");
+        logger.atDebug(l-> l.setMessage("Hello {}")
+                            .addArgument("world")
+                            .setCause(new Throwable()));
+
+    }
+
 }

--- a/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/platform/logging/SLF4JPlatformLogger.java
+++ b/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/platform/logging/SLF4JPlatformLogger.java
@@ -31,7 +31,7 @@ import java.util.ResourceBundle;
 
 import org.slf4j.Logger;
 import org.slf4j.spi.CallerBoundaryAware;
-import org.slf4j.spi.LoggingEventBuilder;
+import org.slf4j.spi.FluentLogApiStub;
 
 /**
  * Adapts {@link Logger} to {@link System.Logger}.
@@ -132,7 +132,7 @@ class SLF4JPlatformLogger implements System.Logger {
 
     private void performLog(org.slf4j.event.Level slf4jLevel, ResourceBundle bundle, String msg, Throwable thrown, Object... params) {
         String message = getResourceStringOrMessage(bundle, msg);
-        LoggingEventBuilder leb = slf4jLogger.makeLoggingEventBuilder(slf4jLevel);
+        FluentLogApiStub leb = slf4jLogger.atLevel(slf4jLevel);
         if (thrown != null) {
             leb = leb.setCause(thrown);
         }


### PR DESCRIPTION
- Rename current LoggingEventBuilder to FluentApiStub to better describe its responsibility
- New interface of LoggingEventBuilder to act only as Fluent Builder of LoggingEvent, which is
  used by the lambda