### PR TITLE
Binders are deprecated in SLF4J 2

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/spi/LoggerFactoryBinder.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/LoggerFactoryBinder.java
@@ -27,30 +27,31 @@ package org.slf4j.spi;
 import org.slf4j.ILoggerFactory;
 
 /**
- * An internal interface which helps the static {@link org.slf4j.LoggerFactory} 
- * class bind with the appropriate {@link ILoggerFactory} instance. 
- * 
+ * An internal interface which helps the static {@link org.slf4j.LoggerFactory}
+ * class bind with the appropriate {@link ILoggerFactory} instance.
+ *
  * @author Ceki G&uuml;lc&uuml;
+ * @deprecated
  */
 public interface LoggerFactoryBinder {
 
     /**
-     * Return the instance of {@link ILoggerFactory} that 
+     * Return the instance of {@link ILoggerFactory} that
      * {@link org.slf4j.LoggerFactory} class should bind to.
-     * 
-     * @return the instance of {@link ILoggerFactory} that 
+     *
+     * @return the instance of {@link ILoggerFactory} that
      * {@link org.slf4j.LoggerFactory} class should bind to.
      */
     public ILoggerFactory getLoggerFactory();
 
     /**
-     * The String form of the {@link ILoggerFactory} object that this 
-     * <code>LoggerFactoryBinder</code> instance is <em>intended</em> to return. 
-     * 
+     * The String form of the {@link ILoggerFactory} object that this
+     * <code>LoggerFactoryBinder</code> instance is <em>intended</em> to return.
+     *
      * <p>This method allows the developer to interrogate this binder's intention
-     * which may be different from the {@link ILoggerFactory} instance it is able to 
+     * which may be different from the {@link ILoggerFactory} instance it is able to
      * yield in practice. The discrepancy should only occur in case of errors.
-     * 
+     *
      * @return the class name of the intended {@link ILoggerFactory} instance
      */
     public String getLoggerFactoryClassStr();

--- a/slf4j-api/src/main/java/org/slf4j/spi/MarkerFactoryBinder.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/MarkerFactoryBinder.java
@@ -27,30 +27,31 @@ package org.slf4j.spi;
 import org.slf4j.IMarkerFactory;
 
 /**
- * An internal interface which helps the static {@link org.slf4j.MarkerFactory} 
- * class bind with the appropriate {@link IMarkerFactory} instance. 
- * 
+ * An internal interface which helps the static {@link org.slf4j.MarkerFactory}
+ * class bind with the appropriate {@link IMarkerFactory} instance.
+ *
  * @author Ceki G&uuml;lc&uuml;
+ * @deprecated
  */
 public interface MarkerFactoryBinder {
 
     /**
-     * Return the instance of {@link IMarkerFactory} that 
+     * Return the instance of {@link IMarkerFactory} that
      * {@link org.slf4j.MarkerFactory} class should bind to.
-     * 
-     * @return the instance of {@link IMarkerFactory} that 
+     *
+     * @return the instance of {@link IMarkerFactory} that
      * {@link org.slf4j.MarkerFactory} class should bind to.
      */
     public IMarkerFactory getMarkerFactory();
 
     /**
-     * The String form of the {@link IMarkerFactory} object that this 
-     * <code>MarkerFactoryBinder</code> instance is <em>intended</em> to return. 
-     * 
+     * The String form of the {@link IMarkerFactory} object that this
+     * <code>MarkerFactoryBinder</code> instance is <em>intended</em> to return.
+     *
      * <p>This method allows the developer to interrogate this binder's intention
-     * which may be different from the {@link IMarkerFactory} instance it is able to 
+     * which may be different from the {@link IMarkerFactory} instance it is able to
      * return. Such a discrepancy should only occur in case of errors.
-     * 
+     *
      * @return the class name of the intended {@link IMarkerFactory} instance
      */
     public String getMarkerFactoryClassStr();


### PR DESCRIPTION
Signed-off-by: Witalij Berdinskich <radio_rogal@keemail.me>

FAQ says, see [What has changed in SLF4J version 2.0.0?](https://www.slf4j.org/faq.html#changesInVersion200):

> SLF4J 1.7.x and earlier versions relied on the static binder mechanism which is no loger honored by slf4j-api version 2.0.x.

The static binder classes were removed in 6ac20c6a0ae96ea6609f24d92eb235d87d8a0f8b.