### PR TITLE
Update reload4j to 1.2.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <!-- used in integration testing -->
     <slf4j.api.minimum.compatible.version>1.6.0</slf4j.api.minimum.compatible.version>
     <cal10n.version>0.8.1</cal10n.version>
-    <reload4j.version>1.2.19</reload4j.version>    
+    <reload4j.version>1.2.22</reload4j.version>    
     <log4j.version>1.2.17</log4j.version>
     <logback.version>1.2.10</logback.version>
     <junit.version>4.13.1</junit.version>


### PR DESCRIPTION
From https://reload4j.qos.ch/news.html

2022-07-21 - Release of reload4j 1.2.22
• Fixed a newly discovered [XXE vector vulnerability](https://github.com/qos-ch/reload4j/issues/53) reported against Chainsaw. This issue was reported by PJ Fanning.