### PR TITLE
JDK 18 version sanity check raising AbstractMethodError

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -308,7 +308,7 @@ public final class LoggerFactory {
                                 + Arrays.asList(API_COMPATIBILITY_LIST).toString());
                 Util.report("See " + VERSION_MISMATCH + " for further details.");
             }
-        } catch (java.lang.NoSuchFieldError nsfe) {
+        } catch (java.lang.NoSuchFieldError | java.lang.AbstractMethodError unsupported) {
             // given our large user base and SLF4J's commitment to backward
             // compatibility, we cannot cry here. Only for implementations
             // which willingly declare a REQUESTED_API_VERSION field do we


### PR DESCRIPTION
Account for java.lang.AbstractMethodError in same clause of try-catch construct when performing version sanity check.

I.e.
```
Unexpected problem occured during version sanity check
Reported exception:
java.lang.AbstractMethodError: Receiver class org.apache.logging.slf4j.SLF4JServiceProvider does not define or inherit an implementation of the resolved method 'abstract java.lang.String getRequestedApiVersion()' of interface org.slf4j.spi.SLF4JServiceProvider.
	at org.slf4j.LoggerFactory.versionSanityCheck(LoggerFactory.java:297)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:141)
	at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:421)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:407)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:356)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:382)
	at io.micronaut.runtime.Micronaut.<clinit>(Micronaut.java:50)
```