### PR TITLE
[SLF4J-534] Improve error handling for situations where paths is null in findPossibleStaticLoggerBinderPathSet()

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -198,9 +198,13 @@ public final class LoggerFactory {
             } else {
                 paths = loggerFactoryClassLoader.getResources(STATIC_LOGGER_BINDER_PATH);
             }
-            while (paths.hasMoreElements()) {
-                URL path = paths.nextElement();
-                staticLoggerBinderPathSet.add(path);
+            if (null == paths) {
+                Util.report("Getting resources from static logger binder path was empty.");
+            } else {
+                while (paths.hasMoreElements()) {
+                    URL path = paths.nextElement();
+                    staticLoggerBinderPathSet.add(path);
+                }
             }
         } catch (IOException ioe) {
             Util.report("Error getting resources from path", ioe);


### PR DESCRIPTION
My first contribution, a very simple commit, avoiding NPE in system resources resolution. I wish it wouldn't be the last one.

Regards,
Antonio.