### PR TITLE
Add missing javadoc to SLF4JServiceProvider.java

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/spi/SLF4JServiceProvider.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/SLF4JServiceProvider.java
@@ -39,6 +39,14 @@ public interface SLF4JServiceProvider {
      */
     public MDCAdapter getMDCAdapter();
 
+    /**
+     * Return the maximum API version for SLF4J that the logging
+     * implementation supports.
+     *
+     * <p>For example: {@code "2.0.1"}.
+     *
+     * @return the string API version.
+     */
     public String getRequestedApiVersion();
 
     /**


### PR DESCRIPTION
Had to do some digging around the logback-classic alpha release for SLF4J2 API integration to work out the nature of this behaviour. This should prevent confusion for developers of other logging implementations in the future.