### PR TITLE
Reword Marker javadoc slightly

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/Marker.java
+++ b/slf4j-api/src/main/java/org/slf4j/Marker.java
@@ -29,14 +29,13 @@ import java.util.Iterator;
 
 /**
  * Markers are named objects used to enrich log statements. Conforming logging
- * system Implementations of SLF4J determine how information conveyed by markers
- * are used, if at all. In particular, many conforming logging systems ignore
- * marker data.
- * 
- * <p>
- * Markers can contain references to other markers, which in turn may contain 
- * references of their own.
- * 
+ * system implementations of SLF4J should determine how information conveyed by
+ * any markers are used, if at all. Many conforming logging systems ignore marker
+ * data entirely.
+ *
+ * <p>Markers can contain references to other markers, which in turn may
+ * contain references of their own.
+ *
  * @author Ceki G&uuml;lc&uuml;
  */
 public interface Marker extends Serializable {


### PR DESCRIPTION
Updates the Javadoc for Marker.java to make it a little easier to read grammatically