### PR TITLE
[SLF4J-546] Fluent logging API doesn't populate timestamp with Reload4JLogger

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -198,9 +198,13 @@ public final class LoggerFactory {
             } else {
                 paths = loggerFactoryClassLoader.getResources(STATIC_LOGGER_BINDER_PATH);
             }
-            while (paths.hasMoreElements()) {
-                URL path = paths.nextElement();
-                staticLoggerBinderPathSet.add(path);
+            if (null == paths) {
+                Util.report("Getting resources from static logger binder path was empty.");
+            } else {
+                while (paths.hasMoreElements()) {
+                    URL path = paths.nextElement();
+                    staticLoggerBinderPathSet.add(path);
+                }
             }
         } catch (IOException ioe) {
             Util.report("Error getting resources from path", ioe);

--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -198,13 +198,9 @@ public final class LoggerFactory {
             } else {
                 paths = loggerFactoryClassLoader.getResources(STATIC_LOGGER_BINDER_PATH);
             }
-            if (null == paths) {
-                Util.report("Getting resources from static logger binder path was empty.");
-            } else {
-                while (paths.hasMoreElements()) {
-                    URL path = paths.nextElement();
-                    staticLoggerBinderPathSet.add(path);
-                }
+            while (paths.hasMoreElements()) {
+                URL path = paths.nextElement();
+                staticLoggerBinderPathSet.add(path);
             }
         } catch (IOException ioe) {
             Util.report("Error getting resources from path", ioe);

--- a/slf4j-api/src/main/java/org/slf4j/event/DefaultLoggingEvent.java
+++ b/slf4j-api/src/main/java/org/slf4j/event/DefaultLoggingEvent.java
@@ -33,7 +33,6 @@ public class DefaultLoggingEvent implements LoggingEvent {
     public DefaultLoggingEvent(Level level, Logger logger) {
         this.logger = logger;
         this.level = level;
-        this.timeStamp = System.currentTimeMillis();
     }
 
     public void addMarker(Marker marker) {

--- a/slf4j-api/src/main/java/org/slf4j/event/DefaultLoggingEvent.java
+++ b/slf4j-api/src/main/java/org/slf4j/event/DefaultLoggingEvent.java
@@ -33,6 +33,7 @@ public class DefaultLoggingEvent implements LoggingEvent {
     public DefaultLoggingEvent(Level level, Logger logger) {
         this.logger = logger;
         this.level = level;
+        this.timeStamp = System.currentTimeMillis();
     }
 
     public void addMarker(Marker marker) {

--- a/slf4j-reload4j/src/test/java/org/slf4j/reload4j/RecursiveInitializationTest.java
+++ b/slf4j-reload4j/src/test/java/org/slf4j/reload4j/RecursiveInitializationTest.java
@@ -51,4 +51,11 @@ public class RecursiveInitializationTest {
         logger.info("hello");
     }
 
+    @Test
+    public void testFluent() {
+      System.setProperty(CONFIG_FILE_KEY, "recursiveInit.properties");
+      Logger logger = LoggerFactory.getLogger("testFluent");
+      logger.info("A simple message");
+      logger.atInfo().log("Fluent message");
+    }
 }

--- a/slf4j-reload4j/src/test/java/org/slf4j/reload4j/RecursiveInitializationTest.java
+++ b/slf4j-reload4j/src/test/java/org/slf4j/reload4j/RecursiveInitializationTest.java
@@ -51,11 +51,4 @@ public class RecursiveInitializationTest {
         logger.info("hello");
     }
 
-    @Test
-    public void testFluent() {
-      System.setProperty(CONFIG_FILE_KEY, "recursiveInit.properties");
-      Logger logger = LoggerFactory.getLogger("testFluent");
-      logger.info("A simple message");
-      logger.atInfo().log("Fluent message");
-    }
 }

--- a/slf4j-reload4j/src/test/resources/recursiveInit.properties
+++ b/slf4j-reload4j/src/test/resources/recursiveInit.properties
@@ -1,8 +1,9 @@
 log4j.debug=true
-log4j.rootLogger=DEBUG, CONSOLE, RECURSIVE
+log4j.rootLogger=DEBUG, RECURSIVE
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=[%t] %d %c - %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=[%t] %c - %m%n
 
 log4j.appender.RECURSIVE=org.slf4j.reload4j.testHarness.RecursiveAppender
+                        

--- a/slf4j-reload4j/src/test/resources/recursiveInit.properties
+++ b/slf4j-reload4j/src/test/resources/recursiveInit.properties
@@ -1,9 +1,8 @@
 log4j.debug=true
-log4j.rootLogger=DEBUG, RECURSIVE
+log4j.rootLogger=DEBUG, CONSOLE, RECURSIVE
 
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=[%t] %c - %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=[%t] %d %c - %m%n
 
 log4j.appender.RECURSIVE=org.slf4j.reload4j.testHarness.RecursiveAppender
-                        


### PR DESCRIPTION
A new contribution, looking for a simple solution when timestamp in fluent api message is not initialized.

Regards,
Antonio.
