### PR TITLE
Update maven plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ More information can be found on the [SLF4J website](http://www.slf4j.org).
 
 SLF4J uses Maven as its build tool.
 
-SLF4J version 2.0.x will run under Java 8 but requires Java 9 or later to build.
+SLF4J version 2.0.x will run under Java 8 but requires Java 11 or later to build.
 
 # How to contribute pull requests
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,17 +50,17 @@
     <reload4j.version>1.2.22</reload4j.version>    
     <log4j.version>1.2.17</log4j.version>
     <logback.version>1.2.10</logback.version>
-    <junit.version>4.13.1</junit.version>
-    <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-    <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+    <junit.version>4.13.2</junit.version>
+    <maven-site-plugin.version>3.12.0</maven-site-plugin.version>
+    <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
+    <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
-    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-    <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
-    <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
-            
+    <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
+    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+    <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
+    <maven-jxr-plugin.version>3.2.0</maven-jxr-plugin.version>
+    <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
   </properties>
 
   <developers>
@@ -162,19 +162,6 @@
       <plugins>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.14</version>
-          <configuration>
-            <signature>
-              <groupId>org.codehaus.mojo.signature</groupId>
-              <artifactId>java16</artifactId>
-              <version>1.0</version>
-            </signature>
-          </configuration>
-        </plugin>
-
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>${maven-deploy-plugin.version}</version>
@@ -198,6 +185,7 @@
             <configuration>
               <source>${jdk.version}</source>
               <target>${jdk.version}</target>
+              <release>${jdk.version}</release>
             </configuration>
           </execution> 
 
@@ -215,8 +203,6 @@
               <multiReleaseOutput>true</multiReleaseOutput>
             </configuration>
           </execution>
-
-
 
         </executions>
 
@@ -282,6 +268,30 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-versions</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.5.2,)</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[11,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- as suggested in http://jira.qos.ch/browse/SLF4J-143 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -306,7 +316,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.3.0</version>
       </plugin>
     </plugins>
   
@@ -450,7 +460,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.1</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
Update some maven plugins and also include the maven-enforcer-plugin to require Java 9+ at build time.