### PR TITLE
SLF4J-574: Add full OSGi headers, especially "uses" clauses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,14 +228,6 @@
             </goals>
             <configuration>
               <archive>
-                <manifestEntries>
-                  <Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
-                  <Bundle-Description>${project.description}</Bundle-Description>
-                  <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
-                  <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
-                  <Implementation-Version>${project.version}</Implementation-Version>
-                  <Multi-Release>true</Multi-Release>
-                </manifestEntries>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
               </archive>
               <skipIfEmpty>true</skipIfEmpty>
@@ -243,7 +235,32 @@
           </execution>
         </executions>
       </plugin>
- 
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <unpackBundle>true</unpackBundle>
+              <instructions>
+                <Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
+                <Bundle-Description>${project.description}</Bundle-Description>
+                <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+                <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
+                <Implementation-Version>${project.version}</Implementation-Version>
+                <Multi-Release>true</Multi-Release>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -52,6 +52,20 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
   </build>


### PR DESCRIPTION
Fixes: https://jira.qos.ch/browse/SLF4J-574

This uses the BND tool, via org.apache.felix to generate the MANIFEST.MF to be fully compliant with OSGi.
Compared to using just the maven-jar-plugin to create the MANIFEST.MF the uses clauses are added to the
Export-Package