### PR TITLE
Format pom.xml files and remove trailing whitespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <scm>
     <url>https://github.com/qos-ch/slf4j</url>
     <connection>scm:git:https://github.com/qos-ch/slf4j.git</connection>
-  </scm>  
+  </scm>
 
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
@@ -46,7 +46,7 @@
     <!-- used in integration testing -->
     <slf4j.api.minimum.compatible.version>1.6.0</slf4j.api.minimum.compatible.version>
     <cal10n.version>0.8.1</cal10n.version>
-    <reload4j.version>1.2.22</reload4j.version>    
+    <reload4j.version>1.2.22</reload4j.version>
     <logback.version>1.2.10</logback.version>
     <junit.version>4.13.1</junit.version>
     <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
@@ -59,7 +59,6 @@
     <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
     <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
-            
   </properties>
 
   <developers>
@@ -77,7 +76,7 @@
     <module>slf4j-jdk14</module>
     <module>slf4j-jdk-platform-logging</module>
     <module>slf4j-log4j12</module>
-    <module>slf4j-reload4j</module>    
+    <module>slf4j-reload4j</module>
     <module>slf4j-ext</module>
     <module>jcl-over-slf4j</module>
     <module>log4j-over-slf4j</module>
@@ -112,7 +111,6 @@
         <version>${project.version}</version>
       </dependency>
 
-      
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
@@ -124,7 +122,7 @@
         <artifactId>reload4j</artifactId>
         <version>${reload4j.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>ch.qos.cal10n</groupId>
         <artifactId>cal10n-api</artifactId>
@@ -199,14 +197,14 @@
               <source>${jdk.version}</source>
               <target>${jdk.version}</target>
             </configuration>
-          </execution> 
+          </execution>
 
-          <execution>                      
+          <execution>
             <id>module-compile</id>
             <phase>compile</phase>
             <goals>
               <goal>compile</goal>
-            </goals>          
+            </goals>
             <configuration>
               <release>9</release>
               <compileSourceRoots>
@@ -215,8 +213,6 @@
               <multiReleaseOutput>true</multiReleaseOutput>
             </configuration>
           </execution>
-
-
 
         </executions>
 
@@ -334,8 +330,8 @@
         <artifactId>maven-project-info-reports-plugin</artifactId>
         <version>3.0.0</version>
       </plugin>
+
     </plugins>
-  
   </build>
 
   <reporting>
@@ -350,7 +346,7 @@
           <linkJavadoc>true</linkJavadoc>
         </configuration>
       </plugin>
-      
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -366,30 +362,30 @@
           <sourceFileExcludes>
             <sourceFileExclude>**/module-info.java</sourceFileExclude>
           </sourceFileExcludes>
-          
+
           <groups>
             <group>
               <title>SLF4J packages</title>
               <packages>org.slf4j:org.slf4j.*</packages>
             </group>
-            
+
             <group>
               <title>SLF4J extensions</title>
               <packages>
                 org.slf4j.cal10n:org.slf4j.profiler:org.slf4j.ext:org.slf4j.instrumentation:org.slf4j.agent
               </packages>
             </group>
-            
+
             <group>
               <title>Jakarta Commons Logging packages</title>
               <packages>org.apache.commons.*</packages>
             </group>
-            
+
             <group>
               <title>java.util.logging (JUL) to SLF4J bridge</title>
               <packages>org.slf4j.bridge</packages>
             </group>
-            
+
             <group>
               <title>Apache log4j</title>
               <packages>org.apache.log4j:org.apache.log4j.*</packages>
@@ -397,7 +393,7 @@
           </groups>
         </configuration>
       </plugin>
-      
+
     </plugins>
   </reporting>
 
@@ -465,8 +461,7 @@
         </plugins>
       </build>
 
-      <pluginRepositories>
-      </pluginRepositories>
+      <pluginRepositories />
     </profile>
 
     <profile>
@@ -521,16 +516,15 @@
 
   <pluginRepositories>
     <pluginRepository>
-         <id>apache-snapshot-repo</id>
-         <name>apache-snapshot-repo</name>
-         <url>https://repository.apache.org/content/groups/snapshots/</url>
-         <releases>
-           <enabled>false</enabled>
-         </releases>
-         <snapshots>
-           <enabled>true</enabled>
-         </snapshots>
-
+      <id>apache-snapshot-repo</id>
+      <name>apache-snapshot-repo</name>
+      <url>https://repository.apache.org/content/groups/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </pluginRepository>
   </pluginRepositories>
 

--- a/slf4j-jdk-platform-logging/pom.xml
+++ b/slf4j-jdk-platform-logging/pom.xml
@@ -49,20 +49,20 @@
               <source>9</source>
               <target>9</target>
               <release>9</release>
-            </configuration>            
+            </configuration>
           </execution>
           <execution>
             <id>default-testCompile</id>
             <goals>
-              <goal>testCompile</goal> 
+              <goal>testCompile</goal>
             </goals>
             <configuration>
               <source>9</source>
               <target>9</target>
               <release>9</release>
-            </configuration>            
-          </execution> 
-        </executions>        
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -76,7 +76,6 @@
           <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
-
 
     </plugins>
   </build>

--- a/slf4j-reload4j/pom.xml
+++ b/slf4j-reload4j/pom.xml
@@ -12,13 +12,11 @@
 
   <artifactId>slf4j-reload4j</artifactId>
 
-
   <packaging>jar</packaging>
- <name>SLF4J Reload4j Binding</name>
+  <name>SLF4J Reload4j Binding</name>
   <description>SLF4J Reload4j Binding</description>
   <url>http://reload4j.qos.ch</url>
-  
-  
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -29,7 +27,7 @@
       <groupId>ch.qos.reload4j</groupId>
       <artifactId>reload4j</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -39,10 +37,9 @@
     </dependency>
   </dependencies>
 
-
   <build>
     <plugins>
-        
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -59,9 +56,8 @@
           <argLine>-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8001</argLine>
           <!--<argLine>XXadd-opens log4j/org.apache.log4j=org.slf4j.log4j12</argLine>-->
         </configuration>
-      </plugin>     
-        
- 
+      </plugin>
+
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This is the part of https://github.com/qos-ch/slf4j/pull/327 that only applies some white-space clean ups and does one re-ordering of elements. Just in case it should be reviewed separately.