### PR TITLE
Add 'Main-Class' header to slf4j-migrator Manifest.MF

### DIFF
--- a/slf4j-migrator/pom.xml
+++ b/slf4j-migrator/pom.xml
@@ -16,4 +16,20 @@
   <name>SLF4J Migrator</name>
   <description>SLF4J Migrator</description>
 
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Main-Class>org.slf4j.migrator.Main</Main-Class>
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
 </project>

--- a/slf4j-migrator/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-migrator/src/main/resources/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-Main-Class: org.slf4j.migrator.Main


### PR DESCRIPTION
Because the Manifest.MF did not have a terminating new-line it was invalid and its content was ignored.

Disable the execution of the 'maven-bundle-plugin' for the migrator module to not have (useless) OSGi-metadata generated into it.