### PR TITLE
SLF4J-582: add license file to jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,14 @@
         <directory>${project.basedir}/src/main/resources</directory>
         <filtering>true</filtering>
       </resource>
+
+      <resource>
+        <directory>.</directory>
+        <targetPath>META-INF</targetPath>
+        <includes>
+          <include>LICENSE.txt</include>
+        </includes>
+      </resource>
     </resources>
 
     <pluginManagement>


### PR DESCRIPTION
For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the licence information from our dependencies. This scanner can extract all informaton from the Jar file. Therefore it would be great to have the license information included in the Jar file as LICENSE.txt file.