### PR TITLE
Fully automate OSGi metadata creation and restore OSGi-metadata in remaining slf4j modules

### DIFF
--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <module-name>org.apache.commons.logging</module-name>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -39,5 +39,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
 
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <_exportcontents>org.apache.commons.logging*;version=${jcl.version};-noimport:=true</_exportcontents>
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
 </project>

--- a/jcl-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/jcl-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
@@ -1,9 +1,0 @@
-Implementation-Title: jcl-over-slf4j
-Bundle-ManifestVersion: 2
-Bundle-SymbolicName: jcl.over.slf4j
-Bundle-Name: jcl-over-slf4j
-Bundle-Vendor: SLF4J.ORG
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.apache.commons.logging;version=1.2, 
-  org.apache.commons.logging.impl;version=1.2
-Import-Package: org.slf4j;version=${parsedVersion.osgiVersion}, org.slf4j.spi;version=${parsedVersion.osgiVersion}

--- a/jul-to-slf4j/pom.xml
+++ b/jul-to-slf4j/pom.xml
@@ -31,4 +31,20 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Automatic-Module-Name>jul.to.slf4j</Automatic-Module-Name>
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
 </project>

--- a/jul-to-slf4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/jul-to-slf4j/src/main/resources/META-INF/MANIFEST.MF
@@ -1,8 +1,2 @@
 Bundle-ManifestVersion: 2
-Bundle-SymbolicName: jul.to.slf4j
-Bundle-Name: jul-to-slf4j
-Bundle-Vendor: SLF4J.ORG
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.slf4j.bridge;version=${parsedVersion.osgiVersion};uses:="org.slf4j,org.slf4j.spi"
-Import-Package: org.slf4j;version=${parsedVersion.osgiVersion},org.slf4j.spi;version=${parsedVersion.osgiVersion}
 Automatic-Module-Name: jul.to.slf4j

--- a/jul-to-slf4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/jul-to-slf4j/src/main/resources/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Bundle-ManifestVersion: 2
-Automatic-Module-Name: jul.to.slf4j

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -41,4 +41,20 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <_exportcontents>org.apache.log4j*;version=${reload4j.version};-noimport:=true</_exportcontents>
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
 </project>

--- a/log4j-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/log4j-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
@@ -1,5 +1,0 @@
-Bundle-ManifestVersion: 2
-Export-Package: org.apache.log4j;version=${reload4j.version},
- org.apache.log4j.helpers;version=${reload4j.version},
- org.apache.log4j.spi;version=${reload4j.version},
- org.apache.log4j.xml;version=${reload4j.version}

--- a/log4j-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/log4j-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
@@ -1,13 +1,5 @@
-Implementation-Title: log4j-over-slf4j
 Bundle-ManifestVersion: 2
-Bundle-SymbolicName: log4j.over.slf4j
-Bundle-Name: log4j-over-slf4j
-Bundle-Vendor: SLF4J.ORG
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.apache.log4j;version=${reload4j.version},
  org.apache.log4j.helpers;version=${reload4j.version},
  org.apache.log4j.spi;version=${reload4j.version},
  org.apache.log4j.xml;version=${reload4j.version}
-Import-Package: org.slf4j;version=${slf4j.api.minimum.compatible.version},
- org.slf4j.helpers;version=${slf4j.api.minimum.compatible.version},
- org.slf4j.spi;version=${slf4j.api.minimum.compatible.version}

--- a/osgi-over-slf4j/pom.xml
+++ b/osgi-over-slf4j/pom.xml
@@ -37,8 +37,27 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>org.slf4j.osgi-over-slf4j</Bundle-SymbolicName>
+            <Bundle-Activator>org.slf4j.osgi.logservice.impl.Activator</Bundle-Activator>
+            <Bundle-Category>osgi</Bundle-Category>
+            <_exportcontents combine.self="override" />
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
 </project>

--- a/osgi-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/osgi-over-slf4j/src/main/resources/META-INF/MANIFEST.MF
@@ -1,8 +1,0 @@
-Implementation-Title: osgi-over-slf4j
-Bundle-ManifestVersion: 2
-Bundle-SymbolicName: org.slf4j.osgi-over-slf4j
-Bundle-Name: OSGi LogService implemented over SLF4J
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Activator: org.slf4j.osgi.logservice.impl.Activator
-Bundle-Category: osgi
-Import-Package: org.osgi.framework;version="[1.5,2)",org.osgi.service.log;version="[1.3,2)",org.slf4j;version=${parsedVersion.osgiVersion}

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- used in integration testing -->
-    <slf4j.api.minimum.compatible.version>1.6.0</slf4j.api.minimum.compatible.version>
     <cal10n.version>0.8.1</cal10n.version>
     <reload4j.version>1.2.22</reload4j.version>    
     <logback.version>1.2.10</logback.version>
+    <jcl.version>1.2</jcl.version>
     <junit.version>4.13.1</junit.version>
     <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -58,8 +58,6 @@
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
     <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
-    <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
-            
   </properties>
 
   <developers>
@@ -303,21 +301,6 @@
             <phase>package</phase>
             <goals>
               <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- as suggested in http://jira.qos.ch/browse/SLF4J-143 -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>${build-helper-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>parse-version</id>
-            <goals>
-              <goal>parse-version</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,35 @@
       </build>
     </profile>
 
+    <profile>
+      <id>generate-osgi-service-loader-mediator-entries</id>
+      <activation>
+        <file>
+          <exists>src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider</exists>
+        </file>
+      </activation>
+      <build>
+        <!-- Add the OSGi Service Loader Mediator Specification Manifest entries for each module that has a SLF4JServiceProvider Service-Loader file.-->
+        <plugins>
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <configuration>
+              <instructions>
+                <Provide-Capability><![CDATA[
+                  osgi.service;objectClass:List<String>="org.slf4j.spi.SLF4JServiceProvider";type=${slf4j.provider.type};effective:=active,
+                  osgi.serviceloader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="${slf4j.provider.implementation}";type=${slf4j.provider.type}
+                ]]></Provide-Capability>
+                <Require-Capability><![CDATA[
+                  osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))"
+                ]]></Require-Capability>
+              </instructions>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!--
     <profile>
       <id>travis</id>

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,6 @@
           <!-- populated by the plugin itself -->
           <instructions>
 			  <Bundle-SymbolicName>${replacestring;${project.artifactId};-;.}</Bundle-SymbolicName>
-			  <Bundle-Name>${project.artifactId}</Bundle-Name>
 			  <Bundle-Vendor>SLF4J.ORG</Bundle-Vendor>
 			  <_snapshot/>
 			  <_exportcontents>!META-INF.versions.9,*;-noimport:=true</_exportcontents>

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -58,7 +58,7 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <configuration>
           <instructions>
-            <Import-Package>org.slf4j.spi;version="${range;[===,+);${version;===;${maven_version;${project.version}}}}"</Import-Package>
+            <Import-Package>org.slf4j.spi;version="${range;[===,+);${version_cleanup;${project.version}}}"</Import-Package>
             <!-- Export the client/user package of slf4j-api version 1 to make the slf4j-api bundle in version 2 usable for bundles that only import slf4j-1.x -->
             <_exportcontents><![CDATA[
               *,\

--- a/slf4j-ext/pom.xml
+++ b/slf4j-ext/pom.xml
@@ -73,8 +73,19 @@
           </archive>
         </configuration>
       </plugin>
-    </plugins>
 
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Import-Package>ch.qos.cal10n;version="${cal10n.version}";resolution:="optional", org.slf4j, org.slf4j.*</Import-Package>
+            <_exportcontents>org.slf4j.ext, org.slf4j.profiler, org.slf4j.cal10n</_exportcontents>
+          </instructions>
+        </configuration>
+      </plugin>
+
+    </plugins>
   </build>
 
 </project>

--- a/slf4j-ext/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-ext/src/main/resources/META-INF/MANIFEST.MF
@@ -1,8 +1,0 @@
-Implementation-Title: slf4j-ext
-Bundle-ManifestVersion: 2
-Bundle-SymbolicName: slf4j.ext
-Bundle-Name: slf4j-ext
-Bundle-Vendor: SLF4J.ORG
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.slf4j.profiler;version=${parsedVersion.osgiVersion}, org.slf4j.cal10n;version=${parsedVersion.osgiVersion}, org.slf4j.ext;version=${parsedVersion.osgiVersion}
-Import-Package: org.slf4j;version=${parsedVersion.osgiVersion}, org.slf4j.spi;version=${parsedVersion.osgiVersion}, org.slf4j.helpers;version=${parsedVersion.osgiVersion}, ch.qos.cal10n;version=${cal10n.version};resolution:=optional

--- a/slf4j-jdk-platform-logging/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-jdk-platform-logging/src/main/resources/META-INF/MANIFEST.MF
@@ -1,9 +1,0 @@
-Implementation-Title:  slf4j-jdk-platform-logging
-Bundle-ManifestVersion: 2
-Bundle-SymbolicName:  slf4j.jdk.platform.logging
-Bundle-Name: slf4j-jdk-platform-logging
-Bundle-Vendor: SLF4J.ORG
-Require-Bundle: slf4j.api
-Bundle-RequiredExecutionEnvironment: JavaSE-9
-Export-Package: slf4j.jdk.platform.logging;version=${parsedVersion.osgiVersion}
-Import-Package: org.slf4j;version=${parsedVersion.osgiVersion}

--- a/slf4j-jdk14/pom.xml
+++ b/slf4j-jdk14/pom.xml
@@ -18,6 +18,8 @@
 
   <properties>
     <module-name>org.slf4j.jul</module-name>
+    <slf4j.provider.implementation>org.slf4j.jul.JULServiceProvider</slf4j.provider.implementation>
+    <slf4j.provider.type>jul</slf4j.provider.type>
   </properties>
 
   <dependencies>

--- a/slf4j-jdk14/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-jdk14/src/main/resources/META-INF/MANIFEST.MF
@@ -1,14 +1,4 @@
-Implementation-Title: slf4j-jdk14
 Bundle-ManifestVersion: 2
-Bundle-SymbolicName: slf4j.jdk14
-Bundle-Name: slf4j-jdk14
-Bundle-Vendor: SLF4J.ORG
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.slf4j.jul;version=${parsedVersion.osgiVersion}
-Import-Package: org.slf4j;version=${parsedVersion.osgiVersion},
- org.slf4j.spi;version=${parsedVersion.osgiVersion},
- org.slf4j.helpers;version=${parsedVersion.osgiVersion},
- org.slf4j.event;version=${parsedVersion.osgiVersion}
 Provide-Capability: osgi.service;objectClass:List<String>="org.slf4j.s
  pi.SLF4JServiceProvider";type=jul;effective:=active,osgi.serviceloade
  r;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="

--- a/slf4j-jdk14/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-jdk14/src/main/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Bundle-ManifestVersion: 2
-Provide-Capability: osgi.service;objectClass:List<String>="org.slf4j.s
- pi.SLF4JServiceProvider";type=jul;effective:=active,osgi.serviceloade
- r;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="
- org.slf4j.jul.JULServiceProvider";type=jul
-Require-Capability: osgi.extender;filter:="(&(osgi.extender=osgi.servi
- celoader.registrar)(version>=1.0.0)(!(version>=2.0.0)))"

--- a/slf4j-nop/pom.xml
+++ b/slf4j-nop/pom.xml
@@ -19,6 +19,8 @@
 
   <properties>
     <module-name>org.slf4j.nop</module-name>
+    <slf4j.provider.implementation>org.slf4j.nop.NOPServiceProvider</slf4j.provider.implementation>
+    <slf4j.provider.type>nop</slf4j.provider.type>
   </properties>
 
   <dependencies>

--- a/slf4j-nop/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-nop/src/main/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Bundle-ManifestVersion: 2
-Provide-Capability: osgi.service;objectClass:List<String>="org.slf4j.s
- pi.SLF4JServiceProvider";type=nop;effective:=active,osgi.serviceloade
- r;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="
- org.slf4j.nop.NOPServiceProvider";type=nop
-Require-Capability: osgi.extender;filter:="(&(osgi.extender=osgi.servi
- celoader.registrar)(version>=1.0.0)(!(version>=2.0.0)))"

--- a/slf4j-nop/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-nop/src/main/resources/META-INF/MANIFEST.MF
@@ -1,14 +1,4 @@
-Implementation-Title: slf4j-nop
 Bundle-ManifestVersion: 2
-Bundle-SymbolicName: slf4j.nop
-Bundle-Name: slf4j-nop
-Bundle-Vendor: SLF4J.ORG
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.slf4j.nop;version=${parsedVersion.osgiVersion}
-Import-Package: org.slf4j;version=${parsedVersion.osgiVersion},
- org.slf4j.spi;version=${parsedVersion.osgiVersion},
- org.slf4j.helpers;version=${parsedVersion.osgiVersion},
- org.slf4j.event;version=${parsedVersion.osgiVersion}
 Provide-Capability: osgi.service;objectClass:List<String>="org.slf4j.s
  pi.SLF4JServiceProvider";type=nop;effective:=active,osgi.serviceloade
  r;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register:="

--- a/slf4j-reload4j/pom.xml
+++ b/slf4j-reload4j/pom.xml
@@ -18,6 +18,10 @@
   <description>SLF4J Reload4j Provider</description>
   <url>http://reload4j.qos.ch</url>
 
+  <properties>
+    <slf4j.provider.implementation>org.slf4j.reload4j.Reload4jServiceProvider</slf4j.provider.implementation>
+    <slf4j.provider.type>reload4j</slf4j.provider.type>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/slf4j-reload4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-reload4j/src/main/resources/META-INF/MANIFEST.MF
@@ -1,15 +1,4 @@
-Implementation-Title: slf4j-reload4j
 Bundle-ManifestVersion: 2
-Bundle-SymbolicName: slf4j.reload4j
-Bundle-Name: slf4j-reload4j
-Bundle-Vendor: SLF4J.ORG
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.slf4j.reload4j;version=${parsedVersion.osgiVersion}
-Import-Package: org.slf4j;version=${parsedVersion.osgiVersion},
- org.slf4j.spi;version=${parsedVersion.osgiVersion},
- org.slf4j.helpers;version=${parsedVersion.osgiVersion},
- org.slf4j.event;version=${parsedVersion.osgiVersion},
- org.apache.log4j
 Provide-Capability: osgi.service;objectClass:List<String>="org.slf4j.s
  pi.SLF4JServiceProvider";type=reload4j;effective:=active,osgi.service
  loader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";regist

--- a/slf4j-reload4j/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-reload4j/src/main/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Bundle-ManifestVersion: 2
-Provide-Capability: osgi.service;objectClass:List<String>="org.slf4j.s
- pi.SLF4JServiceProvider";type=reload4j;effective:=active,osgi.service
- loader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";regist
- er:="org.slf4j.reload4j.Reload4jServiceProvider";type=reload4j
-Require-Capability: osgi.extender;filter:="(&(osgi.extender=osgi.servi
- celoader.registrar)(version>=1.0.0)(!(version>=2.0.0)))"

--- a/slf4j-simple/pom.xml
+++ b/slf4j-simple/pom.xml
@@ -18,6 +18,8 @@
 
   <properties>
     <module-name>org.slf4j.simple</module-name>
+    <slf4j.provider.implementation>org.slf4j.simple.SimpleServiceProvider</slf4j.provider.implementation>
+    <slf4j.provider.type>simple</slf4j.provider.type>
   </properties>
 
   <dependencies>

--- a/slf4j-simple/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-simple/src/main/resources/META-INF/MANIFEST.MF
@@ -1,15 +1,4 @@
-Implementation-Title: slf4j-simple
 Bundle-ManifestVersion: 2
-Bundle-SymbolicName: slf4j.simple
-Bundle-Name: slf4j-simple
-Bundle-Vendor: SLF4J.ORG
-Require-Bundle: slf4j.api
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.slf4j.simple;version=${parsedVersion.osgiVersion}
-Import-Package: org.slf4j;version=${parsedVersion.osgiVersion},
- org.slf4j.spi;version=${parsedVersion.osgiVersion},
- org.slf4j.helpers;version=${parsedVersion.osgiVersion},
- org.slf4j.event;version=${parsedVersion.osgiVersion}
 Provide-Capability: osgi.service;objectClass:List<String>="org.slf4j.s
  pi.SLF4JServiceProvider";type=simple;effective:=active,osgi.servicelo
  ader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register

--- a/slf4j-simple/src/main/resources/META-INF/MANIFEST.MF
+++ b/slf4j-simple/src/main/resources/META-INF/MANIFEST.MF
@@ -1,7 +1,0 @@
-Bundle-ManifestVersion: 2
-Provide-Capability: osgi.service;objectClass:List<String>="org.slf4j.s
- pi.SLF4JServiceProvider";type=simple;effective:=active,osgi.servicelo
- ader;osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider";register
- :="org.slf4j.simple.SimpleServiceProvider";type=simple 
-Require-Capability: osgi.extender;filter:="(&(osgi.extender=osgi.servi
- celoader.registrar)(version>=1.0.0)(!(version>=2.0.0)))"


### PR DESCRIPTION
This is a follow-up of https://github.com/qos-ch/slf4j/pull/324 and the reduced version of https://github.com/qos-ch/slf4j/pull/327, that has not been covered in https://github.com/qos-ch/slf4j/pull/330.

With this change the OSGi metadata of all remaining slf4j modules are generated using the maven-bundle-plugin.
This makes all remaining MANIFEST.MF files obsolete and they are therefore removed. Then sfl4j only has one source for OSGi metadata: the configuration of the maven-bundle-plugin. This simplifies the understanding how the metadata are crafted and maintenance on the long run, as requested in https://github.com/qos-ch/slf4j/pull/331#issuecomment-1472395543 and noted in [SLF4J-583](https://jira.qos.ch/browse/SLF4J-583).

This also re-adds metadata that where accidentally removed in 2.0.6 and thus fixes [SLF4J-578](https://jira.qos.ch/browse/SLF4J-578).
Additionally it improves the metadata by adding more use-clauses to more Export-Package entries.

@ceki can you please review this or let me know if you want to have this split up? I know you prefer smaller steps, but I didn't wanted to create one PR for each slf4j module and therefore made a bigger change. Nevertheless the single changes are now simpler compared to other PRs.
The PR is build in two steps. The first commit is dedicated to restore missing metadata and to remove entries from the manifest that are already generated by the m-bundle-plugin and are therefore duplicates. This already allowed to remove some Manifests entirely.
The second commit then replaces all remaining manifests by a corresponding configuration of the maven-bundle-plugin, so that no OSGi metadata are crafted from that. In order to simplify the generation of the OSGi Service Loader Mediator headers I created a profile that is activated by the existence of the file `src/main/resources/META-INF/services/org.slf4j.spi.SLF4JServiceProvider` and adds the corresponding manifest headers. The properties in the header are filled with values from the corresponding project.

Please let me know if you want a change or something is not clear.