### PR TITLE
Adapt project names from 'Binding' to 'Provider'

### DIFF
--- a/slf4j-jdk14/pom.xml
+++ b/slf4j-jdk14/pom.xml
@@ -12,8 +12,8 @@
 
   <artifactId>slf4j-jdk14</artifactId>
   <packaging>jar</packaging>
-  <name>SLF4J JDK14 Binding</name>
-  <description>SLF4J JDK14 Binding</description>
+  <name>SLF4J JDK14 Provider</name>
+  <description>SLF4J JDK14 Provider</description>
   <url>http://www.slf4j.org</url>
 
   <properties>

--- a/slf4j-nop/pom.xml
+++ b/slf4j-nop/pom.xml
@@ -13,8 +13,8 @@
   <artifactId>slf4j-nop</artifactId>
 
   <packaging>jar</packaging>
-  <name>SLF4J NOP Binding</name>
-  <description>SLF4J NOP Binding</description>
+  <name>SLF4J NOP Provider</name>
+  <description>SLF4J NOP Provider</description>
   <url>http://www.slf4j.org</url>
 
   <properties>

--- a/slf4j-reload4j/pom.xml
+++ b/slf4j-reload4j/pom.xml
@@ -14,11 +14,11 @@
 
 
   <packaging>jar</packaging>
- <name>SLF4J Reload4j Binding</name>
-  <description>SLF4J Reload4j Binding</description>
+  <name>SLF4J Reload4j Provider</name>
+  <description>SLF4J Reload4j Provider</description>
   <url>http://reload4j.qos.ch</url>
-  
-  
+
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -29,7 +29,7 @@
       <groupId>ch.qos.reload4j</groupId>
       <artifactId>reload4j</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -42,7 +42,7 @@
 
   <build>
     <plugins>
-        
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -59,9 +59,8 @@
           <argLine>-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8001</argLine>
           <!--<argLine>XXadd-opens log4j/org.apache.log4j=org.slf4j.log4j12</argLine>-->
         </configuration>
-      </plugin>     
-        
- 
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/slf4j-simple/pom.xml
+++ b/slf4j-simple/pom.xml
@@ -12,8 +12,8 @@
 
   <artifactId>slf4j-simple</artifactId>
   <packaging>jar</packaging>
-  <name>SLF4J Simple Binding</name>
-  <description>SLF4J Simple binding</description>
+  <name>SLF4J Simple Provider</name>
+  <description>SLF4J Simple Provider</description>
   <url>http://www.slf4j.org</url>
 
   <properties>
@@ -25,7 +25,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
Since slf4j 2 Bindings are now called Providers. The corresponding Maven project names and descriptions should be adapted accordingly.

@ceki what do you think about this?

Btw. the FAQ entry for that topic is missing, although it is listed in the table of content:
https://www.slf4j.org/faq.html#bindingProviderDifference