### PR TITLE
Fix text formatting in slf4j-jdk-platform-logging to use the correct JDK convention

### DIFF
--- a/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/platform/logging/SLF4JPlatformLogger.java
+++ b/slf4j-jdk-platform-logging/src/main/java/org/slf4j/jdk/platform/logging/SLF4JPlatformLogger.java
@@ -28,6 +28,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+import java.text.MessageFormat;
 
 import org.slf4j.Logger;
 import org.slf4j.spi.CallerBoundaryAware;
@@ -142,7 +143,7 @@ class SLF4JPlatformLogger implements System.Logger {
                 leb = leb.addArgument(p);
             }
             // The JDK uses a different formatting convention. We must invoke it now.
-            message = String.format(message, params);
+            message = MessageFormat.format(message, params);
         }
         if (leb instanceof CallerBoundaryAware) {
             CallerBoundaryAware cba = (CallerBoundaryAware) leb;

--- a/slf4j-jdk-platform-logging/src/test/java/org/slf4j/jdk/platform/logging/test/SLF4JPlatformLoggingTest.java
+++ b/slf4j-jdk-platform-logging/src/test/java/org/slf4j/jdk/platform/logging/test/SLF4JPlatformLoggingTest.java
@@ -88,7 +88,7 @@ public class SLF4JPlatformLoggingTest {
         assertEquals(EXPECTED_FINDER_CLASS, finder.getClass().getName());
         Logger systemLogger = finder.getLogger("smoke", null);
         systemLogger.log(Level.INFO, "hello");
-        systemLogger.log(Level.INFO, "hello %s", "world");
+        systemLogger.log(Level.INFO, "hello {0}", "world");
         
         List<String> results = SPS.stringList;
         assertEquals(2, results.size());


### PR DESCRIPTION
While there is a comment here showing that it was understood the JDK has a different convention, the wrong format method was used here. The JDK uses MessageFormat.

I have not tested this PR and cannot assure that I have made the correct change, a reviewer should test this fork and see if invoking the system logger with extra parameters, i.e. `log("Hello, {0}!", "world")` outputs correctly.