### PR TITLE
SLF4J-579 Export both org.slf4j and org.slf4j.helper in version 1.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -28,7 +28,8 @@
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
     <project.build.outputTimestamp>2023-09-03T16:20:19Z</project.build.outputTimestamp>
-    <latest.1.version>1.7.36</latest.1.version>
+    <!-- package version being backwards compatible with SLF4J 1.x OSGi consumers -->
+    <backwards.compatible.version>1.8.0</backwards.compatible.version>
     <!-- java.util.ServiceLoader requires Java 6 -->
     <jdk.version>8</jdk.version>
     <maven.compiler.source>${jdk.version}</maven.compiler.source>
@@ -221,6 +222,15 @@
             <goals>
               <goal>manifest</goal>
             </goals>
+          </execution>
+          <execution>
+            <id>bundle-baseline</id>
+            <goals>
+              <goal>baseline</goal>
+            </goals>
+            <configuration>
+                <comparisonVersion>1.7.36</comparisonVersion>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -60,11 +60,13 @@
         <configuration>
           <instructions>
             <Import-Package>org.slf4j.spi;version="${range;[===,+);${version_cleanup;${project.version}}}"</Import-Package>
-            <!-- Export the client/user package of slf4j-api version 1 to make the slf4j-api bundle in version 2 usable for bundles that only import slf4j-1.x -->
-            <_exportcontents><![CDATA[
+            <!-- Export the client/user packages of slf4j-api in version 1 to make the slf4j-api bundle in version 2 usable for bundles that only import version ranges not including 2.x -->
+            <!-- Uses directive not automatically added: https://github.com/bndtools/bnd/issues/5789 but in this case not necessary either -->
+            <Export-Package><![CDATA[
               *,\
-              org.slf4j;uses:="org.slf4j.event,org.slf4j.helpers,org.slf4j.spi";version="${latest.1.version}"
-            ]]></_exportcontents>
+              org.slf4j;version="${backwards.compatible.version}",\
+              org.slf4j.helper;version="${backwards.compatible.version}"
+            ]]></Export-Package>
             <Require-Capability><![CDATA[
               osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))",
               osgi.serviceloader;filter:="(osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider)";osgi.serviceloader="org.slf4j.spi.SLF4JServiceProvider"


### PR DESCRIPTION
additionally to the default 2.x versions

Enable baselining against latest 1.7.36 version to enforce correct semantic versioning