### PR TITLE
Pass key-value properties into events in slf4j-reload4j.

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jul-to-slf4j/pom.xml
+++ b/jul-to-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jul-to-slf4j/pom.xml
+++ b/jul-to-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jul-to-slf4j/pom.xml
+++ b/jul-to-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/jul-to-slf4j/pom.xml
+++ b/jul-to-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/osgi-over-slf4j/pom.xml
+++ b/osgi-over-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/osgi-over-slf4j/pom.xml
+++ b/osgi-over-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/osgi-over-slf4j/pom.xml
+++ b/osgi-over-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/osgi-over-slf4j/pom.xml
+++ b/osgi-over-slf4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -294,7 +294,6 @@
           <additionalOptions>
             <additionalOption>-Xdoclint:none</additionalOption>
           </additionalOptions>
-          <excludePackageNames>org.slf4j.migrator:org.slf4j.migrator.*</excludePackageNames>
           <sourceFileExcludes>
             <sourceFileExclude>**/module-info.java</sourceFileExclude>
           </sourceFileExcludes>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-bom</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
 
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
-    <project.build.outputTimestamp>2023-12-28T23:03:15Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-01-08T17:55:00Z</project.build.outputTimestamp>
     <latest.1.version>1.7.36</latest.1.version>
     <!-- java.util.ServiceLoader requires Java 6 -->
     <jdk.version>8</jdk.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-bom</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
 
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
-    <project.build.outputTimestamp>2023-09-03T16:20:19Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2023-12-28T20:04:00Z</project.build.outputTimestamp>
     <latest.1.version>1.7.36</latest.1.version>
     <!-- java.util.ServiceLoader requires Java 6 -->
     <jdk.version>8</jdk.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-bom</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
 
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
-    <project.build.outputTimestamp>2023-12-28T20:04:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2023-12-28T23:03:15Z</project.build.outputTimestamp>
     <latest.1.version>1.7.36</latest.1.version>
     <!-- java.util.ServiceLoader requires Java 6 -->
     <jdk.version>8</jdk.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-bom</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
 
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
-    <project.build.outputTimestamp>2024-01-08T17:55:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-01-08T19:49:43Z</project.build.outputTimestamp>
     <latest.1.version>1.7.36</latest.1.version>
     <!-- java.util.ServiceLoader requires Java 6 -->
     <jdk.version>8</jdk.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -24,7 +24,6 @@
   <inceptionYear>2005</inceptionYear>
 
 
-
   <properties>
     <!-- yyyy-MM-dd'T'HH:mm:ss'Z' -->
     <project.build.outputTimestamp>2024-01-08T17:55:00Z</project.build.outputTimestamp>
@@ -38,14 +37,14 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- used in integration testing -->
     <cal10n.version>0.8.1</cal10n.version>
-    <reload4j.version>1.2.22</reload4j.version>    
+    <reload4j.version>1.2.22</reload4j.version>
     <logback.version>1.2.10</logback.version>
     <jcl.version>1.2</jcl.version>
     <junit.version>4.13.1</junit.version>
     <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
-    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
@@ -53,7 +52,6 @@
     <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
   </properties>
 
- 
 
   <dependencies>
     <dependency>
@@ -72,7 +70,7 @@
         <artifactId>reload4j</artifactId>
         <version>${reload4j.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>ch.qos.cal10n</groupId>
         <artifactId>cal10n-api</artifactId>
@@ -147,14 +145,14 @@
               <source>${jdk.version}</source>
               <target>${jdk.version}</target>
             </configuration>
-          </execution> 
+          </execution>
 
-          <execution>                      
+          <execution>
             <id>module-compile</id>
             <phase>compile</phase>
             <goals>
               <goal>compile</goal>
-            </goals>          
+            </goals>
             <configuration>
               <release>9</release>
               <compileSourceRoots>
@@ -163,7 +161,6 @@
               <multiReleaseOutput>true</multiReleaseOutput>
             </configuration>
           </execution>
-
 
 
         </executions>
@@ -200,19 +197,19 @@
           <supportIncrementalBuild>true</supportIncrementalBuild>
           <!-- populated by the plugin itself -->
           <instructions>
-			  <Bundle-SymbolicName>${replacestring;${project.artifactId};-;.}</Bundle-SymbolicName>
-			  <Bundle-Vendor>SLF4J.ORG</Bundle-Vendor>
-			  <_snapshot/>
-			  <_exportcontents>!META-INF.versions.9,*;-noimport:=true</_exportcontents>
-			  <Bundle-Description>${project.description}</Bundle-Description>
-			  <Bundle-DocURL>${project.url}</Bundle-DocURL>
-			  <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
-			  <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
-			  <Implementation-Version>${project.version}</Implementation-Version>
-			  <Implementation-Title>${project.artifactId}</Implementation-Title>
-			  <Multi-Release>true</Multi-Release>
-			  <_removeheaders>Private-Package,Bundle-SCM, Bundle-Developers, Include-Resource</_removeheaders>
-		  </instructions>
+            <Bundle-SymbolicName>${replacestring;${project.artifactId};-;.}</Bundle-SymbolicName>
+            <Bundle-Vendor>SLF4J.ORG</Bundle-Vendor>
+            <_snapshot/>
+            <_exportcontents>!META-INF.versions.9,*;-noimport:=true</_exportcontents>
+            <Bundle-Description>${project.description}</Bundle-Description>
+            <Bundle-DocURL>${project.url}</Bundle-DocURL>
+            <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+            <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
+            <Implementation-Version>${project.version}</Implementation-Version>
+            <Implementation-Title>${project.artifactId}</Implementation-Title>
+            <Multi-Release>true</Multi-Release>
+            <_removeheaders>Private-Package,Bundle-SCM, Bundle-Developers, Include-Resource</_removeheaders>
+          </instructions>
         </configuration>
         <executions>
           <execution>
@@ -267,70 +264,8 @@
         <version>3.0.0</version>
       </plugin>
     </plugins>
-  
-  </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jxr-plugin</artifactId>
-        <version>${maven-jxr-plugin.version}</version>
-        <configuration>
-          <aggregate>true</aggregate>
-          <javadocDir>target/site/apidocs/</javadocDir>
-          <linkJavadoc>true</linkJavadoc>
-        </configuration>
-      </plugin>
-      
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven-javadoc-plugin.version}</version>
-        <configuration>
-          <linkJavadoc>true</linkJavadoc>
-          <linksource>true</linksource>
-          <aggregate>true</aggregate>
-          <additionalOptions>
-            <additionalOption>-Xdoclint:none</additionalOption>
-          </additionalOptions>
-          <sourceFileExcludes>
-            <sourceFileExclude>**/module-info.java</sourceFileExclude>
-          </sourceFileExcludes>
-          
-          <groups>
-            <group>
-              <title>SLF4J packages</title>
-              <packages>org.slf4j:org.slf4j.*</packages>
-            </group>
-            
-            <group>
-              <title>SLF4J extensions</title>
-              <packages>
-                org.slf4j.cal10n:org.slf4j.profiler:org.slf4j.ext:org.slf4j.instrumentation:org.slf4j.agent
-              </packages>
-            </group>
-            
-            <group>
-              <title>Jakarta Commons Logging packages</title>
-              <packages>org.apache.commons.*</packages>
-            </group>
-            
-            <group>
-              <title>java.util.logging (JUL) to SLF4J bridge</title>
-              <packages>org.slf4j.bridge</packages>
-            </group>
-            
-            <group>
-              <title>Apache log4j</title>
-              <packages>org.apache.log4j:org.apache.log4j.*</packages>
-            </group>
-          </groups>
-        </configuration>
-      </plugin>
-      
-    </plugins>
-  </reporting>
+  </build>
 
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
              slf4j-jdk-platform-logging,slf4j-migrator,osgi-over-slf4j
           </skippedModules>
           <detectLinks>true</detectLinks>
-          <doctitle>SLF4J project modules 2.1.0-alpha1</doctitle>
+          <doctitle>SLF4J project modules ${project.version}</doctitle>
           <windowtitle>SLF4J javadoc</windowtitle>
           <bottom><![CDATA[Copyright  &copy; 2005-{currentYear} QOS.CH Sarl. All rights reserved]]></bottom>
           <linksource>true</linksource>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.slf4j</groupId>
   <artifactId>slf4j-bom</artifactId>
-  <version>2.0.10</version>
+  <version>2.0.11-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <url>http://www.slf4j.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,6 @@
           <additionalOptions>
             <additionalOption>-Xdoclint:none</additionalOption>
           </additionalOptions>
-          <excludePackageNames>org.slf4j.migrator:org.slf4j.migrator.*</excludePackageNames>
           <sourceFileExcludes>
             <sourceFileExclude>**/module-info.java</sourceFileExclude>
           </sourceFileExcludes>

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
           <additionalOptions>
             <additionalOption>-Xdoclint:none</additionalOption>
           </additionalOptions>
+          <legacyMode>true</legacyMode>
           <sourceFileExcludes>
             <sourceFileExclude>**/module-info.java</sourceFileExclude>
           </sourceFileExcludes>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.slf4j</groupId>
   <artifactId>slf4j-bom</artifactId>
-  <version>2.0.11</version>
+  <version>2.0.12-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <url>http://www.slf4j.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.slf4j</groupId>
   <artifactId>slf4j-bom</artifactId>
-  <version>2.0.11-SNAPSHOT</version>
+  <version>2.0.11</version>
   <packaging>pom</packaging>
 
   <url>http://www.slf4j.org</url>
@@ -152,23 +152,46 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.6.3</version>
         <configuration>
-          <linkJavadoc>true</linkJavadoc>
+          <verbose>true</verbose>
+          <skippedModules>
+             slf4j-jdk-platform-logging,slf4j-migrator,osgi-over-slf4j
+          </skippedModules>
+          <detectLinks>true</detectLinks>
+          <doctitle>SLF4J project modules 2.1.0-alpha1</doctitle>
+          <windowtitle>SLF4J javadoc</windowtitle>
+          <bottom><![CDATA[Copyright  &copy; 2005-{currentYear} QOS.CH Sarl. All rights reserved]]></bottom>
           <linksource>true</linksource>
           <additionalOptions>
             <additionalOption>-Xdoclint:none</additionalOption>
           </additionalOptions>
-          <legacyMode>true</legacyMode>
-          <sourceFileExcludes>
-            <sourceFileExclude>**/module-info.java</sourceFileExclude>
-          </sourceFileExcludes>
-          <skippedModules>
-            slf4j-jdk-platform-logging
-          </skippedModules>
           <groups>
             <group>
-              <title>SLF4J packages</title>
-              <packages>org.slf4j:org.slf4j.*</packages>
+              <title>SLF4J API packages</title>
+              <packages>org.slf4j:org.slf4j.spi:org.slf4j.event:org.slf4j.helpers</packages>
             </group>
+
+            <group>
+              <title>slf4j-simple package</title>
+              <packages>org.slf4j.simple</packages>
+            </group>
+
+            <group>
+              <title>slf4j-nop package</title>
+              <packages>org.slf4j.nop</packages>
+            </group>
+
+
+            <group>
+              <title>slf4j-jdk14 package</title>
+              <packages>org.slf4j.jul</packages>
+            </group>
+
+
+            <group>
+              <title>slf4j-reload4j package</title>
+              <packages>org.slf4j.reload4j</packages>
+            </group>
+
 
             <group>
               <title>SLF4J extensions</title>
@@ -188,10 +211,11 @@
             </group>
 
             <group>
-              <title>Apache log4j</title>
+              <title>log4j-over-slf4j redirection</title>
               <packages>org.apache.log4j:org.apache.log4j.*</packages>
             </group>
           </groups>
+
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
   <groupId>org.slf4j</groupId>
   <artifactId>slf4j-bom</artifactId>
-  <version>2.0.10-SNAPSHOT</version>
+  <version>2.0.10</version>
   <packaging>pom</packaging>
 
   <url>http://www.slf4j.org</url>
-  
+
   <name>SLF4J BOM</name>
   <description>SLF4J project BOM</description>
 
@@ -25,9 +25,9 @@
   <scm>
     <url>https://github.com/qos-ch/slf4j</url>
     <connection>scm:git:https://github.com/qos-ch/slf4j.git</connection>
-  </scm>  
+  </scm>
 
-  
+
   <!-- Inspired by Improving the Maven Bill of Materials (BOM) Pattern  -->
   <!-- https://www.garretwilson.com/blog/2023/06/14/improve-maven-bom-pattern -->
   <modules>
@@ -38,7 +38,7 @@
     <module>slf4j-jdk14</module>
     <module>slf4j-jdk-platform-logging</module>
     <module>slf4j-log4j12</module>
-    <module>slf4j-reload4j</module>    
+    <module>slf4j-reload4j</module>
     <module>slf4j-ext</module>
     <module>jcl-over-slf4j</module>
     <module>log4j-over-slf4j</module>
@@ -68,7 +68,7 @@
         <artifactId>slf4j-nop</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-jdk14</artifactId>
@@ -81,49 +81,49 @@
         <artifactId>slf4j-jdk-platform-logging</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-reload4j</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-ext</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>osgi-over-slf4j</artifactId>
         <version>${project.version}</version>
       </dependency>
-      
+
 
     </dependencies>
   </dependencyManagement>
@@ -145,8 +145,60 @@
     </developer>
   </developers>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.6.3</version>
+        <configuration>
+          <linkJavadoc>true</linkJavadoc>
+          <linksource>true</linksource>
+          <additionalOptions>
+            <additionalOption>-Xdoclint:none</additionalOption>
+          </additionalOptions>
+          <excludePackageNames>org.slf4j.migrator:org.slf4j.migrator.*</excludePackageNames>
+          <sourceFileExcludes>
+            <sourceFileExclude>**/module-info.java</sourceFileExclude>
+          </sourceFileExcludes>
+          <skippedModules>
+            slf4j-jdk-platform-logging
+          </skippedModules>
+          <groups>
+            <group>
+              <title>SLF4J packages</title>
+              <packages>org.slf4j:org.slf4j.*</packages>
+            </group>
+
+            <group>
+              <title>SLF4J extensions</title>
+              <packages>
+                org.slf4j.cal10n:org.slf4j.profiler:org.slf4j.ext:org.slf4j.instrumentation:org.slf4j.agent
+              </packages>
+            </group>
+
+            <group>
+              <title>Jakarta Commons Logging packages</title>
+              <packages>org.apache.commons.*</packages>
+            </group>
+
+            <group>
+              <title>java.util.logging (JUL) to SLF4J bridge</title>
+              <packages>org.slf4j.bridge</packages>
+            </group>
+
+            <group>
+              <title>Apache log4j</title>
+              <packages>org.apache.log4j:org.apache.log4j.*</packages>
+            </group>
+          </groups>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
-    
+
     <profile>
       <id>sign-artifacts</id>
       <build>
@@ -169,5 +221,5 @@
       </build>
     </profile>
   </profiles>
-  
+
 </project>

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-api/pom.xml
+++ b/slf4j-api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-api/src/main/java/org/slf4j/MDC.java
+++ b/slf4j-api/src/main/java/org/slf4j/MDC.java
@@ -91,6 +91,9 @@ public class MDC {
     static {
         SLF4JServiceProvider provider = LoggerFactory.getProvider();
         if (provider != null) {
+            // obtain and attach the MDCAdapter from the provider
+            // If you wish to change the adapter, Setting the MDC.mdcAdapter variable might not be enough as
+            // the provider might perform additional assignments that you would need to replicate/adapt.
             mdcAdapter = provider.getMDCAdapter();
         } else {
             Reporter.error("Failed to find provider.");

--- a/slf4j-ext/pom.xml
+++ b/slf4j-ext/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-ext/pom.xml
+++ b/slf4j-ext/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-ext/pom.xml
+++ b/slf4j-ext/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-ext/pom.xml
+++ b/slf4j-ext/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-jdk-platform-logging/pom.xml
+++ b/slf4j-jdk-platform-logging/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <artifactId>slf4j-parent</artifactId>
     <groupId>org.slf4j</groupId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-jdk-platform-logging/pom.xml
+++ b/slf4j-jdk-platform-logging/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <artifactId>slf4j-parent</artifactId>
     <groupId>org.slf4j</groupId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-jdk-platform-logging/pom.xml
+++ b/slf4j-jdk-platform-logging/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <artifactId>slf4j-parent</artifactId>
     <groupId>org.slf4j</groupId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-jdk-platform-logging/pom.xml
+++ b/slf4j-jdk-platform-logging/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <artifactId>slf4j-parent</artifactId>
     <groupId>org.slf4j</groupId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-jdk14/pom.xml
+++ b/slf4j-jdk14/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-jdk14/pom.xml
+++ b/slf4j-jdk14/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-jdk14/pom.xml
+++ b/slf4j-jdk14/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-jdk14/pom.xml
+++ b/slf4j-jdk14/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-log4j12/pom.xml
+++ b/slf4j-log4j12/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   
@@ -24,7 +24,7 @@
     <relocation>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
-      <version>2.0.9</version>      
+      <version>2.0.10</version>      
     </relocation>
   </distributionManagement>
 

--- a/slf4j-log4j12/pom.xml
+++ b/slf4j-log4j12/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   
@@ -24,7 +24,7 @@
     <relocation>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
-      <version>2.0.10</version>      
+      <version>2.0.11</version>      
     </relocation>
   </distributionManagement>
 

--- a/slf4j-log4j12/pom.xml
+++ b/slf4j-log4j12/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   

--- a/slf4j-log4j12/pom.xml
+++ b/slf4j-log4j12/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   

--- a/slf4j-migrator/pom.xml
+++ b/slf4j-migrator/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-migrator/pom.xml
+++ b/slf4j-migrator/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-migrator/pom.xml
+++ b/slf4j-migrator/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-migrator/pom.xml
+++ b/slf4j-migrator/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-nop/pom.xml
+++ b/slf4j-nop/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-nop/pom.xml
+++ b/slf4j-nop/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-nop/pom.xml
+++ b/slf4j-nop/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-nop/pom.xml
+++ b/slf4j-nop/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-reload4j/pom.xml
+++ b/slf4j-reload4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-reload4j/pom.xml
+++ b/slf4j-reload4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-reload4j/pom.xml
+++ b/slf4j-reload4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-reload4j/pom.xml
+++ b/slf4j-reload4j/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-reload4j/src/test/java/org/slf4j/reload4j/Reload4jLoggerAdapterTest.java
+++ b/slf4j-reload4j/src/test/java/org/slf4j/reload4j/Reload4jLoggerAdapterTest.java
@@ -1,0 +1,107 @@
+package org.slf4j.reload4j;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Logger;
+import org.apache.log4j.MDC;
+import org.junit.Test;
+import org.slf4j.event.DefaultLoggingEvent;
+import org.slf4j.event.Level;
+import org.slf4j.event.LoggingEvent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
+public class Reload4jLoggerAdapterTest {
+    static Map<String, Object> propertiesFromConvertedEvent(LoggingEvent event) {
+        List<org.apache.log4j.spi.LoggingEvent> capturedEvents = new ArrayList<>();
+
+        Logger logger = Logger.getRootLogger();
+        logger.removeAllAppenders();
+        logger.addAppender(new AppenderSkeleton() {
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean requiresLayout() {
+                return false;
+            }
+
+            @Override
+            protected void append(org.apache.log4j.spi.LoggingEvent loggingEvent) {
+                capturedEvents.add(loggingEvent);
+            }
+        });
+        Reload4jLoggerAdapter adapter = new Reload4jLoggerAdapter(logger);
+
+        adapter.log(event);
+
+        if (capturedEvents.size() != 1) {
+            throw new IllegalStateException();
+        }
+        return capturedEvents.get(0).getProperties();
+    }
+
+    @Test
+    public void propertiesAreEmptyWhenNotProvided() {
+        LoggingEvent event = new DefaultLoggingEvent(Level.INFO, null);
+
+        assertEquals(emptyMap(), propertiesFromConvertedEvent(event));
+    }
+
+    @Test
+    public void mdcContentsArePresentInEventProperties() {
+        try {
+            MDC.put("mdc-key", "value");
+            LoggingEvent event = new DefaultLoggingEvent(Level.INFO, null);
+            assertEquals(singletonMap("mdc-key", "value"), propertiesFromConvertedEvent(event));
+        } finally {
+            MDC.remove("mdc-key");
+        }
+    }
+
+    @Test
+    public void keyValuesArePlacedInEventProperties() {
+        DefaultLoggingEvent event = new DefaultLoggingEvent(Level.INFO, null);
+        event.addKeyValue("kv-key", "value");
+
+        assertEquals(singletonMap("kv-key", "value"), propertiesFromConvertedEvent(event));
+    }
+
+    @Test
+    public void mdcAndKeyValuesAreMergedInEventProperties() {
+        try {
+            MDC.put("mdc-key", "value");
+            DefaultLoggingEvent event = new DefaultLoggingEvent(Level.INFO, null);
+            event.addKeyValue("kv-key", "value");
+            Map<String, String> expectedProperties = new HashMap<>();
+            expectedProperties.put("mdc-key", "value");
+            expectedProperties.put("kv-key", "value");
+
+            assertEquals(expectedProperties,
+                    propertiesFromConvertedEvent(event));
+        } finally {
+            MDC.remove("mdc-key");
+        }
+    }
+
+    @Test
+    public void keyValuePropertiesOverrideMdc() {
+        try {
+            MDC.put("clashing-key", "mdc-value");
+            DefaultLoggingEvent event = new DefaultLoggingEvent(Level.INFO, null);
+            event.addKeyValue("clashing-key", "kv-value");
+            assertEquals(
+                    singletonMap("clashing-key", "kv-value"),
+                    propertiesFromConvertedEvent(event));
+        } finally {
+            MDC.remove("clashing-key");
+        }
+    }
+}

--- a/slf4j-simple/pom.xml
+++ b/slf4j-simple/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-simple/pom.xml
+++ b/slf4j-simple/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-simple/pom.xml
+++ b/slf4j-simple/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-simple/pom.xml
+++ b/slf4j-simple/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
@@ -224,7 +224,7 @@ public class SimpleLogger extends LegacyAbstractLogger {
      * Package access allows only {@link SimpleLoggerFactory} to instantiate
      * SimpleLogger instances.
      */
-    SimpleLogger(String name) {
+    protected SimpleLogger(String name) {
         this.name = name;
 
         String levelString = recursivelyComputeLevelString();
@@ -439,8 +439,8 @@ public class SimpleLogger extends LegacyAbstractLogger {
         write(buf, t);
     }
 
-    protected String renderLevel(int level) {
-        switch (level) {
+    protected String renderLevel(int levelInt) {
+        switch (levelInt) {
             case LOG_LEVEL_TRACE:
                 return "TRACE";
             case LOG_LEVEL_DEBUG:
@@ -452,7 +452,7 @@ public class SimpleLogger extends LegacyAbstractLogger {
             case LOG_LEVEL_ERROR:
                 return "ERROR";
         }
-        throw new IllegalStateException("Unrecognized level ["+level+"]");
+        throw new IllegalStateException("Unrecognized level ["+levelInt+"]");
     }
 
     public void log(LoggingEvent event) {

--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
@@ -409,7 +409,7 @@ public class SimpleLogger extends LegacyAbstractLogger {
             buf.append('[');
 
         // Append a readable representation of the log level
-        String levelStr = level.name();
+        String levelStr = renderLevel(level.toInt());
         buf.append(levelStr);
         if (CONFIG_PARAMS.levelInBrackets)
             buf.append(']');
@@ -437,6 +437,22 @@ public class SimpleLogger extends LegacyAbstractLogger {
         buf.append(formattedMessage);
 
         write(buf, t);
+    }
+
+    protected String renderLevel(int level) {
+        switch (level) {
+            case LOG_LEVEL_TRACE:
+                return "TRACE";
+            case LOG_LEVEL_DEBUG:
+                return("DEBUG");
+            case LOG_LEVEL_INFO:
+                return "INFO";
+            case LOG_LEVEL_WARN:
+                return "WARN";
+            case LOG_LEVEL_ERROR:
+                return "ERROR";
+        }
+        throw new IllegalStateException("Unrecognized level ["+level+"]");
     }
 
     public void log(LoggingEvent event) {

--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLogger.java
@@ -221,7 +221,7 @@ public class SimpleLogger extends LegacyAbstractLogger {
     public static final String DEFAULT_LOG_LEVEL_KEY = SimpleLogger.SYSTEM_PREFIX + "defaultLogLevel";
 
     /**
-     * Package access allows only {@link SimpleLoggerFactory} to instantiate
+     * Protected access allows only {@link SimpleLoggerFactory} and also derived classes to instantiate
      * SimpleLogger instances.
      */
     protected SimpleLogger(String name) {

--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLoggerFactory.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLoggerFactory.java
@@ -49,26 +49,23 @@ public class SimpleLoggerFactory implements ILoggerFactory {
      * Return an appropriate {@link SimpleLogger} instance by name.
      */
     public Logger getLogger(String name) {
-        Logger simpleLogger = loggerMap.get(name);
-        if (simpleLogger != null) {
-            return simpleLogger;
-        } else {
-            Logger newInstance = new SimpleLogger(name);
-            Logger oldInstance = loggerMap.putIfAbsent(name, newInstance);
-            return oldInstance == null ? newInstance : oldInstance;
-        }
+        return loggerMap.computeIfAbsent(name, this::createLogger);
+    }
+
+    protected Logger createLogger(String name) {
+        return new SimpleLogger(name);
     }
 
     /**
      * Clear the internal logger cache.
      *
-     * This method is intended to be called by classes (in the same package) for
-     * testing purposes. This method is internal. It can be modified, renamed or
-     * removed at any time without notice.
+     * This method is intended to be called by classes (in the same package or
+     * subclasses) for testing purposes. This method is internal. It can be
+     * modified, renamed or removed at any time without notice.
      *
      * You are strongly discouraged from calling this method in production code.
      */
-    void reset() {
+    protected void reset() {
         loggerMap.clear();
     }
 }

--- a/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLoggerFactory.java
+++ b/slf4j-simple/src/main/java/org/slf4j/simple/SimpleLoggerFactory.java
@@ -47,11 +47,17 @@ public class SimpleLoggerFactory implements ILoggerFactory {
 
     /**
      * Return an appropriate {@link SimpleLogger} instance by name.
+     *
+     * This method will call {@link #createLogger(String)} if the logger
+     * has not been created yet.
      */
     public Logger getLogger(String name) {
         return loggerMap.computeIfAbsent(name, this::createLogger);
     }
 
+    /**
+     * Actually creates the logger for the given name.
+     */
     protected Logger createLogger(String name) {
         return new SimpleLogger(name);
     }

--- a/slf4j-simple/src/test/java/org/slf4j/simple/AcceptanceTest.java
+++ b/slf4j-simple/src/test/java/org/slf4j/simple/AcceptanceTest.java
@@ -1,0 +1,50 @@
+package org.slf4j.simple;
+
+import org.junit.Ignore;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import java.io.PrintStream;
+
+@Ignore
+public class AcceptanceTest extends LoggerTestSuite {
+
+    @Override
+    public Logger createLogger(ListAppendingOutputStream outputStream, Level level) {
+        SimpleLogger.CONFIG_PARAMS.outputChoice = new OutputChoice(new PrintStream(outputStream));
+
+        SimpleLogger logger = new SimpleLogger("TestSuiteLogger");
+        logger.currentLogLevel = SimpleLoggerConfiguration.stringToLevel(level.toString());
+        return logger;
+    }
+
+    @Override
+    public String extractMessage(String message) {
+        return message
+                .split("\n")[0]
+                .split("- ")[1];
+    }
+
+    @Override
+    public String extractExceptionMessage(String message) {
+        String[] logLines = message.split("\n");
+
+        if (logLines.length < 2) {
+            return null;
+        }
+        String exceptionLine = logLines[1];
+        return exceptionLine.split(": ")[1];
+    }
+
+    @Override
+    public String extractExceptionType(String message) {
+        String[] logLines = message.split("\n");
+
+        if (logLines.length < 2) {
+            return null;
+        }
+        String exceptionLine = logLines[1];
+        return exceptionLine.split(": ")[0];
+    }
+
+}

--- a/slf4j-simple/src/test/java/org/slf4j/simple/LoggerTestSuite.java
+++ b/slf4j-simple/src/test/java/org/slf4j/simple/LoggerTestSuite.java
@@ -1,0 +1,274 @@
+package org.slf4j.simple;
+
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public abstract class LoggerTestSuite {
+
+    public static class ListAppendingOutputStream extends OutputStream {
+        private final StringBuilder word = new StringBuilder();
+        private int index = 0;
+        private final List<String> list;
+
+        private ListAppendingOutputStream(List<String> list) {this.list = list;}
+
+
+        @Override
+        public void write(int b) throws IOException {
+            word.append((char) b);
+        }
+
+        @Override
+        public void flush() {
+            list.add(word.toString());
+            word.delete(0, word.length());
+            index++;
+        }
+    }
+
+    private ListAppendingOutputStream prepareSink(List<String> source) {
+        return new ListAppendingOutputStream(source);
+
+    }
+
+    @Test
+    public void testTrace() {
+        ArrayList<String> loggingEvents = new ArrayList<>();
+        Logger configuredLogger = createLogger(prepareSink(loggingEvents), Level.TRACE);
+
+        assertTrue("Trace level should be enabled for this test", configuredLogger.isTraceEnabled());
+        configuredLogger.trace("Simple trace message");
+
+        assertEquals("Trace message should've been captured", 1, loggingEvents.size());
+        assertTrue("Message should be logged in trace level", isTraceMessage(loggingEvents.get(0)));
+        assertEquals("Supplied trace message wasn't found in the log",
+                     "Simple trace message",
+                     extractMessage(loggingEvents.get(0)));
+
+        loggingEvents.clear();
+
+        configuredLogger.debug("Simple debug message");
+        configuredLogger.info("Simple info message");
+        configuredLogger.warn("Simple warn message");
+        configuredLogger.error("Simple error message");
+        assertEquals("The other levels should have been captured", 4, loggingEvents.size());
+
+    }
+
+    @Test
+    public void testDebug() {
+        ArrayList<String> loggingEvents = new ArrayList<>();
+        Logger configuredLogger = createLogger(prepareSink(loggingEvents), Level.DEBUG);
+
+        configuredLogger.trace("Simple trace message");
+        assertEquals("Lower levels should have been ignored", 0, loggingEvents.size());
+
+        assertTrue("Debug level should be enabled for this test", configuredLogger.isDebugEnabled());
+        configuredLogger.debug("Simple debug message");
+
+        assertEquals("Debug message should've been captured", 1, loggingEvents.size());
+        assertTrue("Message should be logged in debug level", isDebugMessage(loggingEvents.get(0)));
+        assertEquals("Supplied debug message wasn't found in the log",
+                     "Simple debug message",
+                     extractMessage(loggingEvents.get(0)));
+
+        loggingEvents.clear();
+
+        configuredLogger.info("Simple info message");
+        configuredLogger.warn("Simple warn message");
+        configuredLogger.error("Simple error message");
+        assertEquals("The other levels should have been captured", 3, loggingEvents.size());
+    }
+
+
+    @Test
+    public void testInfo() {
+        ArrayList<String> loggingEvents = new ArrayList<>();
+        Logger configuredLogger = createLogger(prepareSink(loggingEvents), Level.INFO);
+
+        configuredLogger.trace("Simple trace message");
+        configuredLogger.debug("Simple debug message");
+        assertEquals("Lower levels should have been ignored", 0, loggingEvents.size());
+
+        assertTrue("Info level should be enabled for this test", configuredLogger.isInfoEnabled());
+        configuredLogger.info("Simple info message");
+
+        assertEquals("Info message should've been captured", 1, loggingEvents.size());
+        assertTrue("Message should be logged in debug level", isInfoMessage(loggingEvents.get(0)));
+        assertEquals("Supplied info message wasn't found in the log",
+                     "Simple info message",
+                     extractMessage(loggingEvents.get(0)));
+
+        loggingEvents.clear();
+
+        configuredLogger.warn("Simple warn message");
+        configuredLogger.error("Simple error message");
+        assertEquals("The other levels should have been captured", 2, loggingEvents.size());
+    }
+
+    @Test
+    public void testWarn() {
+        ArrayList<String> loggingEvents = new ArrayList<>();
+        Logger configuredLogger = createLogger(prepareSink(loggingEvents), Level.WARN);
+
+        configuredLogger.trace("Simple trace message");
+        configuredLogger.debug("Simple debug message");
+        configuredLogger.info("Simple info message");
+        assertEquals("Lower levels should have been ignored", 0, loggingEvents.size());
+
+        assertTrue("Warn level should be enabled for this test", configuredLogger.isWarnEnabled());
+        configuredLogger.warn("Simple warn message");
+
+        assertEquals("Warn message should've been captured", 1, loggingEvents.size());
+        assertTrue("Message should be logged in warn level", isWarnMessage(loggingEvents.get(0)));
+        assertEquals("Supplied warn message wasn't found in the log",
+                     "Simple warn message",
+                     extractMessage(loggingEvents.get(0)));
+
+        loggingEvents.clear();
+
+        configuredLogger.error("Simple error message");
+        assertEquals("The other levels should have been captured", 1, loggingEvents.size());
+    }
+
+    @Test
+    public void testError() {
+        ArrayList<String> loggingEvents = new ArrayList<>();
+        Logger configuredLogger = createLogger(prepareSink(loggingEvents), Level.ERROR);
+
+        configuredLogger.trace("Simple trace message");
+        configuredLogger.debug("Simple debug message");
+        configuredLogger.info("Simple info message");
+        configuredLogger.warn("Simple warn message");
+        assertEquals("Lower levels should have been ignored", 0, loggingEvents.size());
+
+        assertTrue("Error level should be enabled for this test", configuredLogger.isErrorEnabled());
+        configuredLogger.error("Simple error message");
+
+        assertEquals("Error message should've been captured", 1, loggingEvents.size());
+        assertTrue("Message should be logged in error level", isErrorMessage(loggingEvents.get(0)));
+        assertEquals("Supplied error message wasn't found in the log",
+                     "Simple error message",
+                     extractMessage(loggingEvents.get(0)));
+    }
+
+    @Test
+    public void testFormatting() {
+        ArrayList<String> loggingEvents = new ArrayList<>();
+        Logger configuredLogger = createLogger(prepareSink(loggingEvents), Level.INFO);
+
+        configuredLogger.info("Some {} string", "formatted");
+        assertEquals("The formatted message should've been captured", 1, loggingEvents.size());
+        assertEquals("Message should've been formatted", "Some formatted string", extractMessage(loggingEvents.get(0)));
+    }
+
+    @Test
+    public void testException() {
+        ArrayList<String> loggingEvents = new ArrayList<>();
+        Logger configuredLogger = createLogger(prepareSink(loggingEvents), Level.INFO);
+
+        Exception exception = new RuntimeException("My error");
+
+        configuredLogger.info("Logging with an exception", exception);
+        assertEquals("The formatted message should've been captured", 1, loggingEvents.size());
+        assertEquals("Message should've been formatted",
+                     "My error",
+                     extractExceptionMessage(loggingEvents.get(0)));
+
+        assertEquals("Message should've been formatted",
+                     "java.lang.RuntimeException",
+                     extractExceptionType(loggingEvents.get(0)));
+    }
+
+
+    /**
+     * Allows tests to check whether the log message contains a trace message.
+     * Override if needed.
+     * @param message String containing the full log message
+     * @return whether it is a trace message or not
+     */
+    protected boolean isTraceMessage(String message) {
+        return message.toLowerCase().contains("trace");
+    }
+
+    /**
+     * Allows tests to check whether the log message contains a debug message.
+     * Override if needed.
+     * @param message String containing the full log message
+     * @return whether it is a debug message or not
+     */
+    protected boolean isDebugMessage(String message) {
+        return message.toLowerCase().contains("debug");
+    }
+
+    /**
+     * Allows tests to check whether the log message contains an info message.
+     * Override if needed.
+     * @param message String containing the full log message
+     * @return whether it is an info message or not
+     */
+    protected boolean isInfoMessage(String message) {
+        return message.toLowerCase().contains("info");
+    }
+
+    /**
+     * Allows tests to check whether the log message contains a warn message.
+     * Override if needed.
+     * @param message String containing the full log message
+     * @return whether it is a warn message or not
+     */
+    protected boolean isWarnMessage(String message) {
+        return message.toLowerCase().contains("warn");
+    }
+
+    /**
+     * Allows tests to check whether the log message contains an error message.
+     * Override if needed.
+     * @param message String containing the full log message
+     * @return whether it is an error message or not
+     */
+    protected boolean isErrorMessage(String message) {
+        return message.toLowerCase().contains("error");
+    }
+
+    /**
+     * Extracts only the part of the log string that should represent the `message` string.
+     * @param message the full log message
+     * @return only the supplied message
+     */
+    public abstract String extractMessage(String message);
+
+    /**
+     * Extracts only the part of the log string that should represent the supplied exception message, if any.
+     * @param message the full log message
+     * @return only the supplied exception message
+     */
+    public abstract String extractExceptionMessage(String message);
+
+    /**
+     * Extracts only the part of the log string that should represent the supplied exception type.
+     * @param message the full log message
+     * @return only the supplied exception type name
+     */
+    public abstract String extractExceptionType(String message);
+
+    /**
+     * Configures the logger for running the tests.
+     * @param outputStream The output stream for logs to be written to
+     * @param level The expected level the tests will run for this logger
+     * @return a configured logger able to run the tests
+     */
+    public abstract Logger createLogger(ListAppendingOutputStream outputStream, Level level);
+
+}


### PR DESCRIPTION
I'm aiming to migrate an existing codebase off Log4j as a logging framework. Logging is through SLF4J, but there's also extensive direct use of Log4j's `org.apache.log4j.MDC` to pass values (other than `String`s) through to a `Layout` that produces structured logging output.

An incremental migration would be significantly easier if I were able to adopt SLF4J's new fluent API without having to simultaneously change the backend logging framework.

This PR makes exactly that change: the key-value properties from the fluent API are merged into the snapshot of the MDC, leaving the existing logging backend with exactly the same data, while the logging calls lose their direct dependency on Log4j.

It's not clear to me whether this approach was considered and rejected, because it conflates the two different types of property, or whether it's suitable as a general purpose change.