### PR TITLE
Pull-up plugin-management of maven-deploy-plugin to the BOM

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,6 @@
     <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
     <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
     <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
@@ -118,12 +117,6 @@
               <version>1.0</version>
             </signature>
           </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>${maven-deploy-plugin.version}</version>
         </plugin>
 
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,9 @@
     <connection>scm:git:https://github.com/qos-ch/slf4j.git</connection>
   </scm>
 
+  <properties>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+  </properties>
 
   <!-- Inspired by Improving the Maven Bill of Materials (BOM) Pattern  -->
   <!-- https://www.garretwilson.com/blog/2023/06/14/improve-maven-bom-pattern -->
@@ -146,6 +149,18 @@
   </developers>
 
   <build>
+    <pluginManagement>
+
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${maven-deploy-plugin.version}</version>
+        </plugin>
+      </plugins>
+
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Pull-up plugin-management of `maven-deploy-plugin` to the BOM so that the version of the plugin used to deploy the BOM is the same as that used to deploy the remainder of the project.

why: currently the version of the deploy plugin used to deploy the BOM not controlled by the build.  So it will be under the influence of the local Maven environment.  This could effect build repeatability.