### PR TITLE
Replace license names with SPDX identifiers

### DIFF
--- a/jcl-over-slf4j/pom.xml
+++ b/jcl-over-slf4j/pom.xml
@@ -19,7 +19,7 @@
 
   <licenses>
     <license>
-      <name>Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>

--- a/log4j-over-slf4j/pom.xml
+++ b/log4j-over-slf4j/pom.xml
@@ -21,8 +21,8 @@
 
   <licenses>
     <license>
-      <name>Apache Software Licenses</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 
   <licenses>
     <license>
-      <name>MIT License</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <name>MIT</name>
+      <url>https://opensource.org/license/mit</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
As suggested by [Maven documentation](https://maven.apache.org/pom.html#Licenses) the `/project/licenses/licence/name` element in the POM file should contain a SPDX identifier of the license. The license element is often used by external tools, such as SBOM generators.

This PR:

- Replaces the current content of the `<name>` element with the appropriate SPDX identifier.
- Follows all HTTP 301 redirections of the currently provided license URLs.