### PR TITLE
Fix trace-level logs showing up as DEBUG due to FINER mapping

### DIFF
--- a/jul-to-slf4j/src/main/java/org/slf4j/bridge/SLF4JBridgeHandler.java
+++ b/jul-to-slf4j/src/main/java/org/slf4j/bridge/SLF4JBridgeHandler.java
@@ -47,7 +47,7 @@ import org.slf4j.spi.LocationAwareLogger;
  * 
  * <pre>
  * FINEST  -&gt; TRACE
- * FINER   -&gt; DEBUG
+ * FINER   -&gt; TRACE
  * FINE    -&gt; DEBUG
  * INFO    -&gt; INFO
  * WARNING -&gt; WARN
@@ -111,7 +111,7 @@ public class SLF4JBridgeHandler extends Handler {
     private static final String FQCN = java.util.logging.Logger.class.getName();
     private static final String UNKNOWN_LOGGER_NAME = "unknown.jul.logger";
 
-    private static final int TRACE_LEVEL_THRESHOLD = Level.FINEST.intValue();
+    private static final int TRACE_LEVEL_THRESHOLD = Level.FINER.intValue();
     private static final int DEBUG_LEVEL_THRESHOLD = Level.FINE.intValue();
     private static final int INFO_LEVEL_THRESHOLD = Level.INFO.intValue();
     private static final int WARN_LEVEL_THRESHOLD = Level.WARNING.intValue();

--- a/jul-to-slf4j/src/test/java/org/slf4j/bridge/SLF4JBridgeHandlerTest.java
+++ b/jul-to-slf4j/src/test/java/org/slf4j/bridge/SLF4JBridgeHandlerTest.java
@@ -110,7 +110,7 @@ public class SLF4JBridgeHandlerTest {
         assertEquals(6, listAppender.list.size());
         int i = 0;
         assertLevel(i++, org.apache.log4j.Level.TRACE);
-        assertLevel(i++, org.apache.log4j.Level.DEBUG);
+        assertLevel(i++, org.apache.log4j.Level.TRACE);
         assertLevel(i++, org.apache.log4j.Level.DEBUG);
         assertLevel(i++, org.apache.log4j.Level.INFO);
         assertLevel(i++, org.apache.log4j.Level.WARN);


### PR DESCRIPTION
While lowering the log level to TRACE to monitor more detailed logs, I noticed that some logs that should be TRACE were actually showing up as DEBUG.

I found that jul’s FINER level was being mapped to DEBUG, so I updated the mapping so that FINER is treated as TRACE instead, and also fixed the related tests.
