### PR TITLE
fix(build): ship correct LICENSE.txt in jcl-over-slf4j / Apache module JARs

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,8 +95,10 @@
         <filtering>true</filtering>
       </resource>
 
+      <!-- Use each module's own LICENSE.txt (e.g. Apache-2.0 for jcl-over-slf4j
+           and log4j-over-slf4j) rather than the repo-root MIT LICENSE. -->
       <resource>
-        <directory>..</directory>
+        <directory>${project.basedir}</directory>
         <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE.txt</include>


### PR DESCRIPTION
## Summary

Fixes #465.

`jcl-over-slf4j` (and `log4j-over-slf4j`) are Apache-2.0 in the POM and have the correct Apache License text at the module root (`jcl-over-slf4j/LICENSE.txt`). However, the parent POM resource configuration always packaged the **repo-root MIT** `LICENSE.txt` into `META-INF/LICENSE.txt` of every module JAR:

```xml
<directory>..</directory>  <!-- always repo root MIT -->
```

License scanners that prefer the JAR license file over the POM (e.g. Mojohaus license-maven-plugin) therefore report MIT for `org.slf4j:jcl-over-slf4j`.

## Change

In `parent/pom.xml`, package `${project.basedir}/LICENSE.txt` instead of `../LICENSE.txt`. Each module already maintains the correct license file:

| Module | Module `LICENSE.txt` | After fix in JAR |
|--------|----------------------|------------------|
| `jcl-over-slf4j` | Apache-2.0 | Apache-2.0 |
| `log4j-over-slf4j` | Apache-2.0 | Apache-2.0 |
| other modules | MIT | MIT (unchanged) |

## Verification

Built with Temurin 21 / Maven 3.9:

```bash
mvn -pl jcl-over-slf4j,log4j-over-slf4j,slf4j-api -am package
```

- `jcl-over-slf4j` JAR `META-INF/LICENSE.txt` → Apache License Version 2.0 (matches module file)
- `log4j-over-slf4j` JAR → same
- `slf4j-api` JAR → MIT (unchanged)
- `mvn -pl jcl-over-slf4j,log4j-over-slf4j -am test` → BUILD SUCCESS

## Notes

No source/runtime behavior change; packaging-only fix.