### PR TITLE
fix(api): guard addKeyValue value toString from fatal errors

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/spi/DefaultLoggingEventBuilder.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/DefaultLoggingEventBuilder.java
@@ -32,6 +32,7 @@ import org.slf4j.event.DefaultLoggingEvent;
 import org.slf4j.event.KeyValuePair;
 import org.slf4j.event.Level;
 import org.slf4j.event.LoggingEvent;
+import org.slf4j.helpers.Reporter;
 
 /**
  * Default implementation of {@link LoggingEventBuilder}
@@ -254,10 +255,31 @@ public class DefaultLoggingEventBuilder implements LoggingEventBuilder, CallerBo
         for(KeyValuePair kvp : keyValuePairList) {
             sb.append(kvp.key);
             sb.append('=');
-            sb.append(kvp.value);
+            // Same protection as MessageFormatter.safeObjectAppend: a failing
+            // toString() (including StackOverflowError) must not abort logging.
+            // See https://github.com/qos-ch/slf4j/issues/448
+            safeObjectAppend(sb, kvp.value);
             sb.append(' ');
         }
         return sb;
+    }
+
+    /**
+     * Append {@code o} to {@code sb}, catching any {@link Throwable} thrown by
+     * {@link Object#toString()} and substituting {@code [FAILED toString()]}.
+     * Mirrors {@code MessageFormatter.safeObjectAppend}.
+     */
+    private static void safeObjectAppend(StringBuilder sb, Object o) {
+        if (o == null) {
+            sb.append("null");
+            return;
+        }
+        try {
+            sb.append(o.toString());
+        } catch (Throwable t) {
+            Reporter.error("Failed toString() invocation on an object of type [" + o.getClass().getName() + "]", t);
+            sb.append("[FAILED toString()]");
+        }
     }
 
     private String mergeMessage(String msg, StringBuilder sb) {

--- a/slf4j-jdk14/src/test/java/org/slf4j/jul/FluentApiInvocationTest.java
+++ b/slf4j-jdk14/src/test/java/org/slf4j/jul/FluentApiInvocationTest.java
@@ -130,6 +130,35 @@ public class FluentApiInvocationTest {
 
     }
 
+    /**
+     * Regression for https://github.com/qos-ch/slf4j/issues/448:
+     * a toString() that throws (including StackOverflowError) on an
+     * addKeyValue value must not abort logging; same as message args.
+     */
+    @Test
+    public void keyValuePairWithFailingToString() {
+        Object bad = new Object() {
+            @Override
+            public String toString() {
+                throw new IllegalStateException("boom");
+            }
+        };
+        logger.atDebug().addKeyValue("key", bad).log("msg with key/value");
+        assertLogMessage("key=[FAILED toString()] msg with key/value", 0);
+    }
+
+    @Test
+    public void keyValuePairWithStackOverflowInToString() {
+        Object overflow = new Object() {
+            @Override
+            public String toString() {
+                return super.toString() + this.toString();
+            }
+        };
+        logger.atDebug().addKeyValue("key", overflow).log("msg with key/value");
+        assertLogMessage("key=[FAILED toString()] msg with key/value", 0);
+    }
+
     private void assertLogMessage(String expected, int index) {
         LogRecord logRecord = listHandler.recordList.get(index);
         Assert.assertNotNull(logRecord);


### PR DESCRIPTION
## What

`DefaultLoggingEventBuilder.mergeKeyValuePairs` now safely converts key-value values to strings, matching `MessageFormatter.safeObjectAppend`. If `toString()` throws any `Throwable` (including `StackOverflowError`), the pair is rendered as `[FAILED toString()]` and logging continues.

## Why

Fixes #448. Message arguments already survive failing `toString()` via `MessageFormatter`, but fluent `addKeyValue(...)` used bare `StringBuilder.append(Object)`, so the same failure was fatal.

## How tested

```text
JAVA_HOME=Temurin-21.0.12+8
mvn -pl slf4j-api -am install -DskipTests
mvn -pl slf4j-jdk14 test -Dtest=FluentApiInvocationTest
# Tests run: 9, Failures: 0, Errors: 0
# including keyValuePairWithFailingToString and keyValuePairWithStackOverflowInToString
```

Platform: macOS arm64, Temurin 21.