### PR TITLE
Pin fluent API caller method name in CallerInfoTest

### DIFF
--- a/slf4j-jdk14/src/test/java/org/slf4j/issue/CallerInfoTest.java
+++ b/slf4j-jdk14/src/test/java/org/slf4j/issue/CallerInfoTest.java
@@ -78,6 +78,7 @@ public class CallerInfoTest {
 
         LogRecord logRecod = recordList.get(0);
         assertEquals(this.getClass().getName(), logRecod.getSourceClassName());
+        assertEquals("testCallerInfoWithFluentAPI", logRecod.getSourceMethodName());
     }
 
     @Test


### PR DESCRIPTION
On current master, logger.atDebug().log already reports the test class, not logViaPublicSLF4JLoggerAPI. I added an assert on the method name so %M cannot regress to the internal helper.

See #464