### PR TITLE
fix(api): initialize provider before getMDCAdapter()

### DIFF
--- a/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
+++ b/slf4j-api/src/main/java/org/slf4j/LoggerFactory.java
@@ -196,9 +196,9 @@ public final class LoggerFactory {
             reportMultipleBindingAmbiguity(providersList);
             if (providersList != null && !providersList.isEmpty()) {
                 PROVIDER = providersList.get(0);
-                earlyBindMDCAdapter();
                 // SLF4JServiceProvider.initialize() is intended to be called here and nowhere else.
                 PROVIDER.initialize();
+                bindMDCAdapter();
                 INITIALIZATION_STATE = SUCCESSFUL_INITIALIZATION;
                 reportActualBinding(providersList);
             } else {
@@ -218,12 +218,10 @@ public final class LoggerFactory {
     }
 
     /**
-     * The value of PROVIDER.getMDCAdapter() can be null while PROVIDER has not yet initialized.
-     *
-     * However, SLF4JServiceProvider implementations are expected to initialize their internal
-     * MDCAdapter field in their constructor or on field declaration.
+     * Bind the provider MDC adapter after {@link SLF4JServiceProvider#initialize()}.
+     * Providers that create their adapter in {@code initialize()} must not be queried beforehand.
      */
-    private static void earlyBindMDCAdapter() {
+    private static void bindMDCAdapter() {
         MDCAdapter mdcAdapter = PROVIDER.getMDCAdapter();
         if(mdcAdapter != null) {
             MDC.setMDCAdapter(mdcAdapter);

--- a/slf4j-api/src/main/java/org/slf4j/spi/SLF4JServiceProvider.java
+++ b/slf4j-api/src/main/java/org/slf4j/spi/SLF4JServiceProvider.java
@@ -53,7 +53,11 @@ public interface SLF4JServiceProvider {
      * Initialize the logging back-end.
      * 
      * <p><b>WARNING:</b> This method is intended to be called once by 
-     * {@link LoggerFactory} class and from nowhere else. 
+     * {@link LoggerFactory} class and from nowhere else.
+     *
+     * <p>{@link LoggerFactory} invokes this method before calling
+     * {@link #getLoggerFactory()}, {@link #getMarkerFactory()} or
+     * {@link #getMDCAdapter()}.
      * 
      */
     public void initialize();

--- a/slf4j-api/src/test/java/org/slf4j/LoggerFactoryTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/LoggerFactoryTest.java
@@ -3,6 +3,9 @@ package org.slf4j;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.helpers.BasicMarkerFactory;
+import org.slf4j.helpers.NOPLoggerFactory;
+import org.slf4j.helpers.NOPMDCAdapter;
 import org.slf4j.spi.MDCAdapter;
 import org.slf4j.spi.SLF4JServiceProvider;
 
@@ -62,6 +65,25 @@ public class LoggerFactoryTest {
         assertTrue(mockedSyserr.toString().contains("Specified SLF4JServiceProvider (java.lang.String) does not implement SLF4JServiceProvider interface"));
     }
 
+    @Test
+    public void initializeIsInvokedBeforeGetMDCAdapter() {
+        DelayedMdcInitProvider.reset();
+        System.setProperty(LoggerFactory.PROVIDER_PROPERTY_KEY, DelayedMdcInitProvider.class.getName());
+        LoggerFactory.reset();
+        MDC.MDC_ADAPTER = null;
+        try {
+            ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+            assertTrue(loggerFactory instanceof NOPLoggerFactory);
+            assertTrue(DelayedMdcInitProvider.initialized);
+            assertFalse(DelayedMdcInitProvider.getMdcAdapterCalledBeforeInitialize);
+            assertSame(DelayedMdcInitProvider.mdcAdapter, MDC.getMDCAdapter());
+        } finally {
+            LoggerFactory.reset();
+            MDC.MDC_ADAPTER = null;
+            DelayedMdcInitProvider.reset();
+        }
+    }
+
     public static class TestingProvider implements SLF4JServiceProvider {
         @Override
         public ILoggerFactory getLoggerFactory() {
@@ -86,6 +108,57 @@ public class LoggerFactoryTest {
         @Override
         public void initialize() {
 
+        }
+    }
+
+    /**
+     * Provider that creates its MDC adapter in {@code initialize()}, matching
+     * implementations that throw if {@code getMDCAdapter()} is called first.
+     */
+    public static class DelayedMdcInitProvider implements SLF4JServiceProvider {
+        static volatile boolean initialized;
+        static volatile boolean getMdcAdapterCalledBeforeInitialize;
+        static volatile MDCAdapter mdcAdapter;
+
+        static void reset() {
+            initialized = false;
+            getMdcAdapterCalledBeforeInitialize = false;
+            mdcAdapter = null;
+        }
+
+        private ILoggerFactory loggerFactory;
+        private IMarkerFactory markerFactory;
+
+        @Override
+        public ILoggerFactory getLoggerFactory() {
+            return loggerFactory;
+        }
+
+        @Override
+        public IMarkerFactory getMarkerFactory() {
+            return markerFactory;
+        }
+
+        @Override
+        public MDCAdapter getMDCAdapter() {
+            if (!initialized) {
+                getMdcAdapterCalledBeforeInitialize = true;
+                throw new IllegalStateException("getMDCAdapter() called before initialize()");
+            }
+            return mdcAdapter;
+        }
+
+        @Override
+        public String getRequestedApiVersion() {
+            return "2.0.99";
+        }
+
+        @Override
+        public void initialize() {
+            loggerFactory = new NOPLoggerFactory();
+            markerFactory = new BasicMarkerFactory();
+            mdcAdapter = new NOPMDCAdapter();
+            initialized = true;
         }
     }
 }

--- a/slf4j-api/src/test/java/org/slf4j/LoggerFactoryTest.java
+++ b/slf4j-api/src/test/java/org/slf4j/LoggerFactoryTest.java
@@ -66,7 +66,7 @@ public class LoggerFactoryTest {
     }
 
     @Test
-    public void initializeIsInvokedBeforeGetMDCAdapter() {
+    public void testInitializeIsInvokedBeforeGetMDCAdapter() {
         DelayedMdcInitProvider.reset();
         System.setProperty(LoggerFactory.PROVIDER_PROPERTY_KEY, DelayedMdcInitProvider.class.getName());
         LoggerFactory.reset();
@@ -76,7 +76,10 @@ public class LoggerFactoryTest {
             assertTrue(loggerFactory instanceof NOPLoggerFactory);
             assertTrue(DelayedMdcInitProvider.initialized);
             assertFalse(DelayedMdcInitProvider.getMdcAdapterCalledBeforeInitialize);
-            assertSame(DelayedMdcInitProvider.mdcAdapter, MDC.getMDCAdapter());
+            assertNotNull(DelayedMdcInitProvider.substituteAdapterSeenDuringInit);
+            MDCAdapter boundAdapter = MDC.getMDCAdapter();
+            assertSame(DelayedMdcInitProvider.mdcAdapter, boundAdapter);
+            assertNotSame(DelayedMdcInitProvider.substituteAdapterSeenDuringInit, boundAdapter);
         } finally {
             LoggerFactory.reset();
             MDC.MDC_ADAPTER = null;
@@ -119,11 +122,13 @@ public class LoggerFactoryTest {
         static volatile boolean initialized;
         static volatile boolean getMdcAdapterCalledBeforeInitialize;
         static volatile MDCAdapter mdcAdapter;
+        static volatile MDCAdapter substituteAdapterSeenDuringInit;
 
         static void reset() {
             initialized = false;
             getMdcAdapterCalledBeforeInitialize = false;
             mdcAdapter = null;
+            substituteAdapterSeenDuringInit = null;
         }
 
         private ILoggerFactory loggerFactory;
@@ -157,6 +162,10 @@ public class LoggerFactoryTest {
         public void initialize() {
             loggerFactory = new NOPLoggerFactory();
             markerFactory = new BasicMarkerFactory();
+            // Mimic real providers that touch MDC during initialize() while LoggerFactory
+            // is still ONGOING_INITIALIZATION — returns SUBST_PROVIDER's BasicMDCAdapter.
+            substituteAdapterSeenDuringInit = MDC.getMDCAdapter();
+            MDC.put("delayed-init-key", "delayed-init-value");
             mdcAdapter = new NOPMDCAdapter();
             initialized = true;
         }


### PR DESCRIPTION
## What

`LoggerFactory.bind()` now calls `SLF4JServiceProvider.initialize()` before `getMDCAdapter()`. The MDC adapter is still bound immediately after `initialize()`, so a substitute adapter installed during backend startup is still replaced.

## Why

Fixes #454. The #450 early-bind path queried `getMDCAdapter()` on a provider that had not been initialized. Implementations that create the adapter in `initialize()` (including Kotlin `lateinit`) then fail.

## How tested

```text
JAVA_HOME=Temurin-21.0.12+8
mvn -pl slf4j-api test -Dtest=LoggerFactoryTest
# Tests run: 5, Failures: 0, Errors: 0
# including testInitializeIsInvokedBeforeGetMDCAdapter (captures substitute during init, asserts post-init replace)

mvn -pl slf4j-simple,slf4j-nop,slf4j-jdk14 -am test
# slf4j-api 56 (1 skipped), slf4j-simple 35, slf4j-nop 7, slf4j-jdk14 23
```

Platform: macOS arm64, Temurin 21.